### PR TITLE
PF-339 Add describe, list, start, and stop initial notebooks commands.

### DIFF
--- a/src/main/java/bio/terra/cli/command/Notebooks.java
+++ b/src/main/java/bio/terra/cli/command/Notebooks.java
@@ -2,14 +2,18 @@ package bio.terra.cli.command;
 
 import bio.terra.cli.command.notebooks.Create;
 import bio.terra.cli.command.notebooks.Delete;
+import bio.terra.cli.command.notebooks.Describe;
+import bio.terra.cli.command.notebooks.List;
+import bio.terra.cli.command.notebooks.Start;
+import bio.terra.cli.command.notebooks.Stop;
 import picocli.CommandLine;
 
 /**
- * This class corresponds to the second-level "terra notebooks" command. This command is not valid by
- * itself; it is just a grouping keyword for it sub-commands.
+ * This class corresponds to the second-level "terra notebooks" command. This command is not valid
+ * by itself; it is just a grouping keyword for it sub-commands.
  */
 @CommandLine.Command(
     name = "notebooks",
     description = "Commands related to AI Notebooks in the Terra workspace context.",
-    subcommands = {Create.class, Delete.class})
+    subcommands = {Create.class, Delete.class, Describe.class, List.class, Start.class, Stop.class})
 public class Notebooks {}

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -29,7 +29,7 @@ public class Create implements Callable<Integer> {
       names = "location",
       defaultValue = "us-central1-a",
       description =
-          "The Google Cloud location to create the instance within, by default '${DEFAULT-VALUE}'.")
+          "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -28,7 +28,8 @@ public class Create implements Callable<Integer> {
   @CommandLine.Option(
       names = "location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location to create the instance within, e.g. us-central1-a")
+      description =
+          "The Google Cloud location to create the instance within, by default '${DEFAULT-VALUE}'.")
   private String location;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/notebooks/Describe.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Describe.java
@@ -9,11 +9,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
-/** This class corresponds to the third-level "terra notebooks delete" command. */
+/** This class corresponds to the third-level "terra notebooks describe" command. */
 @CommandLine.Command(
-    name = "delete",
-    description = "Delete an AI Notebook instance within your workspace.")
-public class Delete implements Callable<Integer> {
+    name = "describe",
+    description = "Describe an AI Notebook instance within your workspace.")
+public class Describe implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -34,11 +34,12 @@ public class Delete implements Callable<Integer> {
         new AuthenticationManager(globalContext, workspaceContext);
     authenticationManager.loginTerraUser();
 
-    String command = "gcloud notebooks instances delete $INSTANCE_NAME --location=$LOCATION";
+    String command = "gcloud notebooks instances describe $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
 
+    // TODO(wchamber): Consider reformatting the ouptut or otherwise highlighting the proxy uri.
     String logs =
         new DockerToolsManager(globalContext, workspaceContext)
             .runToolCommand(

--- a/src/main/java/bio/terra/cli/command/notebooks/List.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/List.java
@@ -9,15 +9,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
-/** This class corresponds to the third-level "terra notebooks delete" command. */
+/** This class corresponds to the third-level "terra notebooks describe" command. */
 @CommandLine.Command(
-    name = "delete",
-    description = "Delete an AI Notebook instance within your workspace.")
-public class Delete implements Callable<Integer> {
-
-  @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
-  private String instanceName;
-
+    name = "list",
+    description = "List the AI Notebook instance within your workspace for the specified location.")
+public class List implements Callable<Integer> {
   @CommandLine.Option(
       names = "location",
       defaultValue = "us-central1-a",
@@ -34,11 +30,11 @@ public class Delete implements Callable<Integer> {
         new AuthenticationManager(globalContext, workspaceContext);
     authenticationManager.loginTerraUser();
 
-    String command = "gcloud notebooks instances delete $INSTANCE_NAME --location=$LOCATION";
+    String command = "gcloud notebooks instances list --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
-    envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
 
+    // TODO(wchamber): Output more relevant information, like the proxy uri.
     String logs =
         new DockerToolsManager(globalContext, workspaceContext)
             .runToolCommand(

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -9,11 +9,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
-/** This class corresponds to the third-level "terra notebooks delete" command. */
+/** This class corresponds to the third-level "terra notebooks start" command. */
 @CommandLine.Command(
-    name = "delete",
-    description = "Delete an AI Notebook instance within your workspace.")
-public class Delete implements Callable<Integer> {
+    name = "start",
+    description = "Start a stopped AI Notebook instance within your workspace.")
+public class Start implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -34,7 +34,7 @@ public class Delete implements Callable<Integer> {
         new AuthenticationManager(globalContext, workspaceContext);
     authenticationManager.loginTerraUser();
 
-    String command = "gcloud notebooks instances delete $INSTANCE_NAME --location=$LOCATION";
+    String command = "gcloud notebooks instances start $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -9,11 +9,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
-/** This class corresponds to the third-level "terra notebooks delete" command. */
+/** This class corresponds to the third-level "terra notebooks stop" command. */
 @CommandLine.Command(
-    name = "delete",
-    description = "Delete an AI Notebook instance within your workspace.")
-public class Delete implements Callable<Integer> {
+    name = "stop",
+    description = "Stop a running AI Notebook instance within your workspace.")
+public class Stop implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -34,7 +34,7 @@ public class Delete implements Callable<Integer> {
         new AuthenticationManager(globalContext, workspaceContext);
     authenticationManager.loginTerraUser();
 
-    String command = "gcloud notebooks instances delete $INSTANCE_NAME --location=$LOCATION";
+    String command = "gcloud notebooks instances stop $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);


### PR DESCRIPTION
Longer term, I expect the describe and list commands to talk to the Notebooks Service. As-is, no formatting is undertaken, but I'd like to get these commands in for an initial semi-usable milestone to pass off to Solutions folks.

Also tweak location description in other commands.