### PR TITLE
PF-439: Update create workspace to use latest WSM client library.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
         // terra libraries
         samClient = "0.1-9435410-SNAP"
-        workspaceManagerClient = "0.9.0-SNAPSHOT"
+        workspaceManagerClient = "0.10.0-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/command/Notebooks.java
+++ b/src/main/java/bio/terra/cli/command/Notebooks.java
@@ -5,8 +5,8 @@ import bio.terra.cli.command.notebooks.Delete;
 import picocli.CommandLine;
 
 /**
- * This class corresponds to the second-level "terra notebooks" command. This command is not valid by
- * itself; it is just a grouping keyword for it sub-commands.
+ * This class corresponds to the second-level "terra notebooks" command. This command is not valid
+ * by itself; it is just a grouping keyword for it sub-commands.
  */
 @CommandLine.Command(
     name = "notebooks",

--- a/src/main/java/bio/terra/cli/utils/WorkspaceManagerUtils.java
+++ b/src/main/java/bio/terra/cli/utils/WorkspaceManagerUtils.java
@@ -2,7 +2,6 @@ package bio.terra.cli.utils;
 
 import bio.terra.cli.model.ServerSpecification;
 import bio.terra.cli.model.TerraUser;
-import bio.terra.workspace.api.JobsApi;
 import bio.terra.workspace.api.UnauthenticatedApi;
 import bio.terra.workspace.api.WorkspaceApi;
 import bio.terra.workspace.client.ApiClient;
@@ -91,7 +90,6 @@ public class WorkspaceManagerUtils {
    */
   public static WorkspaceDescription createWorkspace(ApiClient apiClient) {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    JobsApi jobsApi = new JobsApi(apiClient);
     WorkspaceDescription workspaceWithContext = null;
     try {
       // create the Terra workspace object


### PR DESCRIPTION
Updated the "terra workspace create" command to call the new WSM endpoints for creating a cloud context and polling for job completion.

Note: This change is required for the "terra workspace create" command to work again. WSM has already updated their (dev) server, so the CLI is broken until this fix goes in.