### PR TITLE
PF-340 Resource commands. Pass in resolved references to Docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ one of those as a temporary workaround. If you do have access to the Broad VPN, 
 `terra server set terra-dev` to change it back to official Terra dev environment.
 
 #### External data 
-To allow supported tools (i.e. the ones shown by `terra app list`) to read or write data external
-to the Terra workspace, you need to give the user's pet service account the appropriate access.
-To get the email of the user's pet service account, run `terra gcloud config get-value account`.
+To allow supported applications (i.e. the ones shown by `terra app list`) to read or write data
+external to the Terra workspace, you need to give the user's pet service account the appropriate
+access. To get the email of the user's pet service account, run `terra gcloud config get-value account`.
 
 ### Example usage
 The commands below walk through a brief demo of the existing commands.
@@ -99,11 +99,12 @@ Usage: terra [COMMAND]
 Terra CLI
 Commands:
   status     Print details about the current workspace.
-  auth       Commands related to the retrieval and management of user
-               credentials.
-  server     Commands related to the Terra server.
-  workspace  Commands related to the Terra workspace.
-  app        Commands related to applications in the Terra workspace context.
+  auth       Retrieve and manage user credentials.
+  server     Connect to a Terra server.
+  workspace  Setup a Terra workspace.
+  resources  Manage controlled resources in the workspace.
+  app        Run applications in the workspace.
+  notebooks  Use AI Notebooks in the workspace.
 ```
 
 The `status` command prints details about the current workspace and server.
@@ -112,7 +113,8 @@ Each sub-group of commands is described in a sub-section below:
 - Authentication
 - Server
 - Workspace
-- App
+- Resources
+- Applications
 
 #### Authentication
 ```
@@ -158,13 +160,27 @@ Commands:
   remove-user  Remove a user from the workspace.
 ```
 
-A Terra Workspace is backed by a Google project. Creating a new workspace also creates a new backing Google project.
-The same applies to deleting.
+A Terra workspace is backed by a Google project. Creating a new workspace also creates a new backing Google 
+project. The same applies to deleting.
 
 The workspace context is tied to the directory on your local machine, similar to how `git` works.
 So if you change directories, you lose the workspace context.
 
-#### Supported tools
+#### Resources
+```
+Usage: terra resources [COMMAND]
+Manage controlled resources in the workspace.
+Commands:
+  create    Create a new controlled resource.
+  delete    Delete an existing controlled resource.
+  describe  Describe an existing controlled resource.
+  list      List all controlled resources.
+```
+
+A controlled resource is a cloud resource managed by the Terra workspace on behalf of the user.
+Currently, the only supported controlled resource is a bucket.
+
+#### Applications
 ```
 Usage: terra app [COMMAND]
 Commands related to applications in the Terra workspace context.

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
         googleOauth2 = '0.22.0'
         googleClient = '1.31.1'
         bigQuery = '1.116.6'
+        cloudStorage = '1.113.2'
 
         // Docker
         docker = '3.2.7'
@@ -82,6 +83,7 @@ dependencies {
     implementation "com.google.oauth-client:google-oauth-client-java6:${googleClient}"
     implementation "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
     implementation "com.google.cloud:google-cloud-bigquery:${bigQuery}"
+    implementation "com.google.cloud:google-cloud-storage:${cloudStorage}"
 
     implementation "com.github.docker-java:docker-java-core:${docker}"
     implementation "com.github.docker-java:docker-java-transport-httpclient5:${docker}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 
 # install Nextflow
 ENV NXF_VER 20.10.0
+ENV NXF_MODE google
 RUN curl -s https://get.nextflow.io | bash \
     && mv nextflow /usr/local/bin
 

--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -2,8 +2,8 @@
 
 echo "Setting up Terra app environment..."
 
-gcloud auth activate-service-account --key-file=${PET_KEY_FILE}
-gcloud config set project ${GOOGLE_PROJECT_ID}
+gcloud auth activate-service-account --key-file=${TERRA_PET_KEY_FILE}
+gcloud config set project ${TERRA_GOOGLE_PROJECT_ID}
 
 echo "Done setting up Terra app environment..."
 echo

--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -2,7 +2,7 @@
 
 echo "Setting up Terra app environment..."
 
-gcloud auth activate-service-account --key-file=${TERRA_PET_KEY_FILE}
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud config set project ${TERRA_GOOGLE_PROJECT_ID}
 
 echo "Done setting up Terra app environment..."

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -81,6 +81,9 @@ public class DockerAppsRunner {
   /**
    * Run a command inside the Docker container for external tools.
    *
+   * <p>This method substitutes any Terra references in the command and also adds the Terra
+   * references as environment variables in the container.
+   *
    * @param command the full string command to execute in a bash shell (bash -c ..cmd..)
    */
   public void runToolCommand(String command) {
@@ -91,6 +94,9 @@ public class DockerAppsRunner {
    * Run a command inside the Docker container for external tools. Allows adding environment
    * variables and bind mounts beyond what the terra_init script requires. The environment variables
    * and bind mounts expected by the terra_init script will be added to those passed in.
+   *
+   * <p>This method substitutes any Terra references in the command and also adds the Terra
+   * references as environment variables in the container.
    *
    * @param command the full string command to execute in a bash shell (bash -c ..cmd..)
    * @param workingDir the directory where the commmand will be executed
@@ -361,7 +367,7 @@ public class DockerAppsRunner {
    *
    * <p>e.g. TERRA_MY_BUCKET -> gs://terra-wsm-test-9b7511ab-my-bucket
    *
-   * @return
+   * @return a map of Terra references (name -> cloud id)
    */
   private Map<String, String> buildMapOfTerraReferences() {
     // build a map of reference string -> resolved value

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -172,7 +172,7 @@ public class DockerAppsRunner {
     Map<String, String> terraInitEnvVars = new HashMap<>();
     String googleProjectId = workspaceContext.getGoogleProject();
     terraInitEnvVars.put(
-        "TERRA_PET_KEY_FILE",
+        "GOOGLE_APPLICATION_CREDENTIALS",
         PET_KEYS_MOUNT_POINT + "/" + currentUser.getPetKeyFile(googleProjectId).getName());
     terraInitEnvVars.put("TERRA_GOOGLE_PROJECT_ID", googleProjectId);
     for (Map.Entry<String, String> terraInitEnvVar : terraInitEnvVars.entrySet()) {

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -107,6 +107,12 @@ public class DockerAppsRunner {
     // check that the current workspace is defined
     workspaceContext.requireCurrentWorkspace();
 
+    // substitute any Terra references in the command
+    // also add the Terra references as environment variables in the container
+    Map<String, String> terraReferences = buildMapOfTerraReferences();
+    command = replaceTerraReferences(terraReferences, command);
+    envVars.putAll(terraReferences);
+
     buildDockerClient();
 
     // create and start the docker container. run the terra_init script first, then the given
@@ -166,9 +172,9 @@ public class DockerAppsRunner {
     Map<String, String> terraInitEnvVars = new HashMap<>();
     String googleProjectId = workspaceContext.getGoogleProject();
     terraInitEnvVars.put(
-        "PET_KEY_FILE",
+        "TERRA_PET_KEY_FILE",
         PET_KEYS_MOUNT_POINT + "/" + currentUser.getPetKeyFile(googleProjectId).getName());
-    terraInitEnvVars.put("GOOGLE_PROJECT_ID", googleProjectId);
+    terraInitEnvVars.put("TERRA_GOOGLE_PROJECT_ID", googleProjectId);
     for (Map.Entry<String, String> terraInitEnvVar : terraInitEnvVars.entrySet()) {
       if (envVars.get(terraInitEnvVar.getKey()) != null) {
         throw new RuntimeException(
@@ -331,7 +337,12 @@ public class DockerAppsRunner {
     }
   }
 
-  /** Utility method for concatenating a command and its arguments. */
+  /**
+   * Utility method for concatenating a command and its arguments.
+   *
+   * @param cmd command name (e.g. gsutil)
+   * @param cmdArgs command arguments (e.g. ls, gs://my-bucket)
+   */
   public static String buildFullCommand(String cmd, List<String> cmdArgs) {
     String fullCommand = cmd;
     if (cmdArgs != null && cmdArgs.size() > 0) {
@@ -339,5 +350,48 @@ public class DockerAppsRunner {
       fullCommand += argSeparator + String.join(argSeparator, cmdArgs);
     }
     return fullCommand;
+  }
+
+  /**
+   * Build a map of Terra references to use in parsing the CLI command string, and in setting
+   * environment variables in the Docker container.
+   *
+   * <p>The list of references are TERRA_[...] where [...] is the name of a cloud resource. The
+   * cloud resource can be controlled or external.
+   *
+   * <p>e.g. TERRA_MY_BUCKET -> gs://terra-wsm-test-9b7511ab-my-bucket
+   *
+   * @return
+   */
+  private Map<String, String> buildMapOfTerraReferences() {
+    // build a map of reference string -> resolved value
+    Map<String, String> terraReferences = new HashMap<>();
+    workspaceContext
+        .listCloudResources()
+        .forEach(
+            cloudResource ->
+                terraReferences.put(
+                    "TERRA_" + cloudResource.name.toUpperCase(), cloudResource.cloudId));
+
+    return terraReferences;
+  }
+
+  /**
+   * Replace any Terra references in the command string with the resolved values. The references are
+   * case insensitive.
+   *
+   * @param cmd the original command string
+   * @return the modified command string
+   */
+  private String replaceTerraReferences(Map<String, String> terraReferences, String cmd) {
+    // loop through the map entries
+    String modifiedCmd = cmd;
+    for (Map.Entry<String, String> terraReference : terraReferences.entrySet()) {
+      // loop through the map entries, replacing each one in the command string (case insensitive)
+      modifiedCmd =
+          modifiedCmd.replaceAll(
+              "(?i)\\{" + terraReference.getKey() + "}", terraReference.getValue());
+    }
+    return modifiedCmd;
   }
 }

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -317,7 +317,7 @@ public class DockerAppsRunner {
       // from the command classes only.
       // Revisit this once we have better model for centralizing output across all commands/rest of
       // the codebase.
-      System.out.println(logStr); // write to stdout
+      System.out.print(logStr); // write to stdout
 
       if (buildSingleStringOutput) {
         log.append(logStr);

--- a/src/main/java/bio/terra/cli/apps/Nextflow.java
+++ b/src/main/java/bio/terra/cli/apps/Nextflow.java
@@ -43,9 +43,12 @@ public class Nextflow {
     Map<String, File> bindMounts = new HashMap<>();
     bindMounts.put(NEXTFLOW_MOUNT_POINT, DEFAULT_NEXTFLOW_DIR.toFile());
 
+    Map<String, String> envVars = new HashMap<>();
+    envVars.put("NXF_MODE", "google");
+
     String fullCommand = DockerAppsRunner.buildFullCommand("nextflow", cmdArgs);
     new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(fullCommand, NEXTFLOW_MOUNT_POINT, new HashMap<>(), bindMounts);
+        .runToolCommand(fullCommand, NEXTFLOW_MOUNT_POINT, envVars, bindMounts);
   }
 
   /** Create the nextflow sub-directory on the host machine if it does not already exist. */

--- a/src/main/java/bio/terra/cli/command/App.java
+++ b/src/main/java/bio/terra/cli/command/App.java
@@ -12,6 +12,6 @@ import picocli.CommandLine.Command;
  */
 @Command(
     name = "app",
-    description = "Commands related to applications in the Terra workspace context.",
+    description = "Run applications in the workspace.",
     subcommands = {List.class, GetImage.class, SetImage.class, Execute.class})
 public class App {}

--- a/src/main/java/bio/terra/cli/command/Auth.java
+++ b/src/main/java/bio/terra/cli/command/Auth.java
@@ -11,6 +11,6 @@ import picocli.CommandLine.Command;
  */
 @Command(
     name = "auth",
-    description = "Commands related to the retrieval and management of user credentials.",
+    description = "Retrieve and manage user credentials.",
     subcommands = {Status.class, Login.class, Revoke.class})
 public class Auth {}

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -19,6 +19,7 @@ import picocli.CommandLine.ParseResult;
       Auth.class,
       Server.class,
       Workspace.class,
+      Resources.class,
       App.class,
       Gcloud.class,
       Gsutil.class,

--- a/src/main/java/bio/terra/cli/command/Notebooks.java
+++ b/src/main/java/bio/terra/cli/command/Notebooks.java
@@ -14,6 +14,6 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
     name = "notebooks",
-    description = "Commands related to AI Notebooks in the Terra workspace context.",
+    description = "Use AI Notebooks in the workspace.",
     subcommands = {Create.class, Delete.class, Describe.class, List.class, Start.class, Stop.class})
 public class Notebooks {}

--- a/src/main/java/bio/terra/cli/command/Resources.java
+++ b/src/main/java/bio/terra/cli/command/Resources.java
@@ -1,0 +1,17 @@
+package bio.terra.cli.command;
+
+import bio.terra.cli.command.resources.Create;
+import bio.terra.cli.command.resources.Delete;
+import bio.terra.cli.command.resources.Describe;
+import bio.terra.cli.command.resources.List;
+import picocli.CommandLine;
+
+/**
+ * This class corresponds to the second-level "terra resources" command. This command is not valid
+ * by itself; it is just a grouping keyword for it sub-commands.
+ */
+@CommandLine.Command(
+    name = "resources",
+    description = "Manage controlled resources in the workspace.",
+    subcommands = {Create.class, Delete.class, Describe.class, List.class})
+public class Resources {}

--- a/src/main/java/bio/terra/cli/command/Server.java
+++ b/src/main/java/bio/terra/cli/command/Server.java
@@ -11,6 +11,6 @@ import picocli.CommandLine.Command;
  */
 @Command(
     name = "server",
-    description = "Commands related to the Terra server.",
+    description = "Connect to a Terra server.",
     subcommands = {Status.class, List.class, Set.class})
 public class Server {}

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -14,7 +14,7 @@ import picocli.CommandLine.Command;
  */
 @Command(
     name = "workspace",
-    description = "Commands related to the Terra workspace.",
+    description = "Setup a Terra workspace.",
     subcommands = {
       Create.class,
       Mount.class,

--- a/src/main/java/bio/terra/cli/command/resources/Create.java
+++ b/src/main/java/bio/terra/cli/command/resources/Create.java
@@ -22,7 +22,8 @@ public class Create implements Callable<Integer> {
   @CommandLine.Option(
       names = "--name",
       required = true,
-      description = "The name of the resource, scoped to the workspace.")
+      description =
+          "The name of the resource, scoped to the workspace. Only alphanumeric and underscore characters are permitted.")
   private String name;
 
   @Override

--- a/src/main/java/bio/terra/cli/command/resources/Create.java
+++ b/src/main/java/bio/terra/cli/command/resources/Create.java
@@ -1,0 +1,42 @@
+package bio.terra.cli.command.resources;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra resources create" command. */
+@Command(name = "create", description = "Create a new controlled resource.")
+public class Create implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--type",
+      required = true,
+      description = "The type of resource to create: ${COMPLETION-CANDIDATES}")
+  private CloudResource.Type type;
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the resource, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource resource =
+        new WorkspaceManager(globalContext, workspaceContext).createControlledResource(type, name);
+
+    System.out.println(resource.type + " successfully created: " + resource.cloudId);
+    System.out.println("Workspace resource successfully added: " + resource.name);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -1,0 +1,36 @@
+package bio.terra.cli.command.resources;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra resources delete" command. */
+@Command(name = "delete", description = "Delete an existing controlled resource.")
+public class Delete implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the resource, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource resource =
+        new WorkspaceManager(globalContext, workspaceContext).deleteControlledResource(name);
+
+    System.out.println(resource.type + " successfully deleted: " + resource.cloudId);
+    System.out.println("Workspace resource successfully removed: " + resource.name);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/resources/Describe.java
+++ b/src/main/java/bio/terra/cli/command/resources/Describe.java
@@ -1,0 +1,37 @@
+package bio.terra.cli.command.resources;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra resources describe" command. */
+@Command(name = "describe", description = "Describe an existing controlled resource.")
+public class Describe implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the resource, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource resource =
+        new WorkspaceManager(globalContext, workspaceContext).getControlledResource(name);
+
+    System.out.println("Name: " + resource.name);
+    System.out.println("Type: " + resource.type);
+    System.out.println("Cloud Id: " + resource.cloudId);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/resources/List.java
+++ b/src/main/java/bio/terra/cli/command/resources/List.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.command.resources;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra resources list" command. */
+@Command(name = "list", description = "List all controlled resources.")
+public class List implements Callable<Integer> {
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    java.util.List<CloudResource> resources =
+        new WorkspaceManager(globalContext, workspaceContext).listResources();
+
+    for (CloudResource resource : resources) {
+      System.out.println(resource.name + " (" + resource.type + "): " + resource.cloudId);
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/CloudResource.java
+++ b/src/main/java/bio/terra/cli/context/CloudResource.java
@@ -1,0 +1,38 @@
+package bio.terra.cli.context;
+
+/** This POJO class represents a Terra workspace cloud resource (controlled or external). */
+public class CloudResource {
+  // name of the cloud resource. names are unique within a workspace
+  public String name;
+
+  // cloud identifier for the resource (e.g. bucket uri, bq dataset id)
+  public String cloudId;
+
+  // type of resource (e.g. bucket, bq dataset, vm)
+  public Type type;
+
+  // true = this cloud resource maps to a controlled resource within the workspace
+  // false = this cloud resource maps to an external resource within the workspace
+  public boolean isControlled;
+
+  public CloudResource() {}
+
+  public CloudResource(String name, String cloudId, Type type, boolean isControlled) {
+    this.name = name;
+    this.cloudId = cloudId;
+    this.type = type;
+    this.isControlled = isControlled;
+  }
+
+  /** Type of cloud resource. */
+  public enum Type {
+    bucket(true);
+
+    // true = this cloud resource is also a data reference
+    public final boolean isDataReference;
+
+    Type(boolean isDataReference) {
+      this.isDataReference = isDataReference;
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/context/CloudResource.java
+++ b/src/main/java/bio/terra/cli/context/CloudResource.java
@@ -26,13 +26,6 @@ public class CloudResource {
 
   /** Type of cloud resource. */
   public enum Type {
-    bucket(true);
-
-    // true = this cloud resource is also a data reference
-    public final boolean isDataReference;
-
-    Type(boolean isDataReference) {
-      this.isDataReference = isDataReference;
-    }
+    bucket;
   }
 }

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -6,7 +6,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +23,11 @@ import org.slf4j.LoggerFactory;
 public class WorkspaceContext {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceContext.class);
 
+  // workspace description object returned by WSM
   public WorkspaceDescription terraWorkspaceModel;
+
+  // map of cloud resources for this workspace (name -> object)
+  public Map<String, CloudResource> cloudResources;
 
   // file paths related to persisting the workspace context on disk
   private static final Path WORKSPACE_CONTEXT_DIR = Paths.get("", ".terra");
@@ -26,6 +35,7 @@ public class WorkspaceContext {
 
   private WorkspaceContext() {
     this.terraWorkspaceModel = null;
+    this.cloudResources = new HashMap<>();
   }
 
   // ====================================================
@@ -70,7 +80,11 @@ public class WorkspaceContext {
   // ====================================================
   // Workspace
 
-  /** Setter for the current Terra workspace. Persists on disk. */
+  /**
+   * Setter for the current Terra workspace. Persists on disk.
+   *
+   * @param terraWorkspaceModel the workspace description object
+   */
   public void updateWorkspace(WorkspaceDescription terraWorkspaceModel) {
     logger.debug(
         "Updating workspace from {} to {}.",
@@ -81,13 +95,21 @@ public class WorkspaceContext {
     writeToFile();
   }
 
-  /** Getter for the Terra workspace id. */
+  /**
+   * Getter for the Terra workspace id.
+   *
+   * @return the Terra workspace id
+   */
   @JsonIgnore
   public UUID getWorkspaceId() {
     return terraWorkspaceModel == null ? null : terraWorkspaceModel.getId();
   }
 
-  /** Getter for the Google project backing the current Terra workspace. */
+  /**
+   * Getter for the Google project backing the current Terra workspace.
+   *
+   * @return the Google project id
+   */
   @JsonIgnore
   public String getGoogleProject() {
     return terraWorkspaceModel == null || terraWorkspaceModel.getGoogleContext() == null
@@ -111,13 +133,73 @@ public class WorkspaceContext {
   }
 
   // ====================================================
+  // Cloud resources
+
+  /**
+   * Lookup a cloud resource by its name. Names are unique within a workspace.
+   *
+   * @param name cloud resource name
+   * @return cloud resource object
+   */
+  public CloudResource getCloudResource(String name) {
+    return cloudResources.get(name);
+  }
+
+  /**
+   * Add a cloud resource to the list for this workspace. Persists on disk.
+   *
+   * @param cloudResource cloud resource to add
+   */
+  public void addCloudResource(CloudResource cloudResource) {
+    cloudResources.put(cloudResource.name, cloudResource);
+
+    writeToFile();
+  }
+
+  /**
+   * Remove a cloud resource from the list of cloud resources for this workspace. Persists on disk.
+   *
+   * @param name cloud resource name
+   */
+  public void removeCloudResource(String name) {
+    cloudResources.remove(name);
+
+    writeToFile();
+  }
+
+  /**
+   * List all cloud resources in the workspace.
+   *
+   * @return list of cloud resources in the workspace
+   */
+  public List<CloudResource> listCloudResources() {
+    return new ArrayList<>(cloudResources.values());
+  }
+
+  /**
+   * List all controlled cloud resources for the workspace. This is a utility wrapper around {@link
+   * #listControlledResources()} that filters for just the controlled ones.
+   *
+   * @return list of controlled resources in the workspace
+   */
+  public List<CloudResource> listControlledResources() {
+    return cloudResources.values().stream()
+        .filter(dataReference -> dataReference.isControlled)
+        .collect(Collectors.toList());
+  }
+
+  // ====================================================
   // Directory and file names
   //   - current working directory: .
   //   - persisted workspace context file: ./terra-cli/workspace_context.json
   //   - sub-directories for tools (e.g. ./nextflow) are defined in the SupportedToolHelper
   // sub-classes
 
-  /** Getter for the file where the workspace context is persisted. */
+  /**
+   * Getter for the file where the workspace context is persisted.
+   *
+   * @return path to the workspace context file
+   */
   public static Path resolveWorkspaceContextFile() {
     return WORKSPACE_CONTEXT_DIR.resolve(WORKSPACE_CONTEXT_FILENAME);
   }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -1,12 +1,16 @@
 package bio.terra.cli.service;
 
+import bio.terra.cli.context.CloudResource;
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.TerraUser;
 import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.GoogleCloudStorage;
 import bio.terra.cli.service.utils.WorkspaceManagerService;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.RoleBindingList;
 import bio.terra.workspace.model.WorkspaceDescription;
+import com.google.cloud.storage.Bucket;
+import java.util.List;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,5 +172,77 @@ public class WorkspaceManager {
     // call WSM to get the users + roles for the existing workspace
     return new WorkspaceManagerService(globalContext.server, currentUser)
         .getRoles(workspaceContext.getWorkspaceId());
+  }
+
+  /**
+   * Lookup a controlled resource by its name. Names are unique within a workspace.
+   *
+   * @param resourceName name of resource to lookup
+   * @return the cloud resource object
+   * @throws RuntimeException if the resource is not controlled (e.g. external bucket)
+   */
+  public CloudResource getControlledResource(String resourceName) {
+    // TODO: change this method to call WSM controlled resource endpoints once they're ready
+    CloudResource cloudResource = workspaceContext.getCloudResource(resourceName);
+    if (!cloudResource.isControlled) {
+      throw new RuntimeException(resourceName + " is not a controlled resource.");
+    }
+    return cloudResource;
+  }
+
+  /**
+   * Create a new controlled resource in the workspace.
+   *
+   * @param resourceType type of resource to create
+   * @param resourceName name of resource to create
+   * @return the cloud resource that was created
+   */
+  public CloudResource createControlledResource(
+      CloudResource.Type resourceType, String resourceName) {
+    // TODO: change this method to call WSM controlled resource endpoints once they're ready
+    // create the bucket by calling GCS directly
+    String bucketName = workspaceContext.getGoogleProject() + "-" + resourceName;
+    Bucket bucket =
+        new GoogleCloudStorage(
+                globalContext.requireCurrentTerraUser(), workspaceContext.getGoogleProject())
+            .createBucket(bucketName);
+
+    // persist the cloud resource locally
+    CloudResource resource =
+        new CloudResource(resourceName, "gs://" + bucket.getName(), resourceType, true);
+    workspaceContext.addCloudResource(resource);
+
+    return resource;
+  }
+
+  /**
+   * Delete an existing controlled resource in the workspace.
+   *
+   * @param resourceName name of resource to delete
+   * @return the cloud resource object that was removed
+   */
+  public CloudResource deleteControlledResource(String resourceName) {
+    // TODO: change this method to call WSM controlled resource endpoints once they're ready
+    // delete the bucket by calling GCS directly
+    CloudResource resource = getControlledResource(resourceName);
+    new GoogleCloudStorage(
+            globalContext.requireCurrentTerraUser(), workspaceContext.getGoogleProject())
+        .deleteBucket(resource.cloudId);
+
+    // remove the cloud resource and persist the updated list locally
+    workspaceContext.removeCloudResource(resourceName);
+
+    return resource;
+  }
+
+  /**
+   * List the controlled resources in a workspace.
+   *
+   * @return a list of controlled resources in the workspace
+   */
+  public List<CloudResource> listResources() {
+    // TODO: change this method to call WSM controlled resource endpoints once they're ready
+
+    return workspaceContext.listControlledResources();
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.model.WorkspaceDescription;
 import com.google.cloud.storage.Bucket;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -200,6 +201,11 @@ public class WorkspaceManager {
   public CloudResource createControlledResource(
       CloudResource.Type resourceType, String resourceName) {
     // TODO: change this method to call WSM controlled resource endpoints once they're ready
+    if (!isValidEnvironmentVariableName(resourceName)) {
+      throw new RuntimeException(
+          "Resource name can contain only alphanumeric and underscore characters.");
+    }
+
     // create the bucket by calling GCS directly
     String bucketName = workspaceContext.getGoogleProject() + "-" + resourceName;
     Bucket bucket =
@@ -213,6 +219,16 @@ public class WorkspaceManager {
     workspaceContext.addCloudResource(resource);
 
     return resource;
+  }
+
+  /**
+   * Check if the name only contains alphanumeric and underscore characters.
+   *
+   * @param name string to check
+   * @return true if the string is a valid environment variable name
+   */
+  private static boolean isValidEnvironmentVariableName(String name) {
+    return !Pattern.compile("[^a-zA-Z0-9_]").matcher(name).find();
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
@@ -1,0 +1,81 @@
+package bio.terra.cli.service.utils;
+
+import bio.terra.cli.context.TerraUser;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility methods for calling Google Cloud Storage endpoints. */
+public class GoogleCloudStorage {
+  private static final Logger logger = LoggerFactory.getLogger(GoogleCloudStorage.class);
+
+  // the Terra user whose credentials will be used to call authenticated requests
+  private final TerraUser terraUser;
+
+  // the google project id of the workspace
+  private final String googleProjectId;
+
+  // the client object used for talking to Google Cloud Storage
+  private Storage storageClient;
+
+  /**
+   * Constructor for class that talks to Google Cloud Storage. The user must be authenticated.
+   * Methods in this class will use its credentials to call authenticated endpoints.
+   *
+   * @param terraUser the Terra user whose credentials will be used to call authenticated endpoints
+   */
+  public GoogleCloudStorage(TerraUser terraUser, String googleProjectId) {
+    this.terraUser = terraUser;
+    this.googleProjectId = googleProjectId;
+    this.storageClient = null;
+    buildClientForTerraUser();
+  }
+
+  /**
+   * Build the GCS client object for the given Terra user. If terraUser is null, this method builds
+   * the client object without an access token set.
+   */
+  private void buildClientForTerraUser() {
+    StorageOptions.Builder storageOptions = StorageOptions.newBuilder();
+    storageOptions.setProjectId(googleProjectId);
+
+    if (terraUser != null) {
+      // fetch the user access token
+      // this method call will attempt to refresh the token if it's already expired
+      storageOptions.setCredentials(terraUser.userCredentials);
+    }
+    this.storageClient = storageOptions.build().getService();
+  }
+
+  /**
+   * Create a new GCS bucket.
+   *
+   * @param bucketName name of the bucket
+   * @return the bucket object
+   */
+  public Bucket createBucket(String bucketName) {
+    logger.info("creating bucket: {}", bucketName);
+
+    // TODO: optionally set lifecycle rules here
+    BucketInfo bucketInfo = BucketInfo.newBuilder(bucketName).build();
+    return storageClient.create(bucketInfo);
+  }
+
+  /**
+   * Delete an existing GCS bucket.
+   *
+   * @param bucketUri uri of the bucket (gs://...)
+   */
+  public void deleteBucket(String bucketUri) {
+    logger.info("deleting bucket: {}", bucketUri);
+    String bucketName = bucketUri.replaceFirst("^gs://", "");
+
+    boolean deleted = storageClient.delete(bucketName);
+    if (!deleted) {
+      throw new RuntimeException("Bucket deletion failed.");
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
@@ -34,19 +34,15 @@ public class GoogleCloudStorage {
     buildClientForTerraUser();
   }
 
-  /**
-   * Build the GCS client object for the given Terra user. If terraUser is null, this method builds
-   * the client object without an access token set.
-   */
+  /** Build the GCS client object for the given Terra user. */
   private void buildClientForTerraUser() {
     StorageOptions.Builder storageOptions = StorageOptions.newBuilder();
     storageOptions.setProjectId(googleProjectId);
 
-    if (terraUser != null) {
-      // fetch the user access token
-      // this method call will attempt to refresh the token if it's already expired
-      storageOptions.setCredentials(terraUser.userCredentials);
-    }
+    // fetch the user access token
+    // this method call will attempt to refresh the token if it's already expired
+    storageOptions.setCredentials(terraUser.userCredentials);
+
     this.storageClient = storageOptions.build().getService();
   }
 


### PR DESCRIPTION
1. Resources commands
- First pass at code structure to persist cloud resources and data references on disk only. (This will later have to be changed to use the WSM endpoints, when they are ready.)
- Call GCS directly to create bucket resource.  For this ticket, handle only GCS buckets in the workspace.

2. Resources references
- Pass in resolved resource references to Docker container as environment variables.
- Allow specifying the resource references in the command (e.g. nextflow run -work-dir {TERRA_MY_BUCKET}

3. Nextflow
- Updated Nextflow install in Dockerfile to set the mode for Google Life Sciences.