### PR TITLE
PF-474: Change default server back to terra-dev.

### DIFF
--- a/src/main/java/bio/terra/cli/service/ServerManager.java
+++ b/src/main/java/bio/terra/cli/service/ServerManager.java
@@ -74,7 +74,7 @@ public class ServerManager {
   }
 
   // This variable defines the server that the CLI points to by default.
-  private static final String DEFAULT_SERVER_FILENAME = "wchamber-dev.json";
+  private static final String DEFAULT_SERVER_FILENAME = "terra-dev.json";
 
   /**
    * Returns the default server specification, or null if there was an error reading it in from


### PR DESCRIPTION
Change back from wchamber-dev now that VPN access is no longer required for accessing terra-dev.