### PR TITLE
PF-452: Groups and Spend commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,14 @@ by Workspace Manager. Your email needs to either be added as a user of that spen
 to a Terra group that is a user of that spend profile. This needs to be done by someone else with
 owner access to that spend profile.
 
-- [Preferred] Add a user to a Terra group that is a user of the spend profile with `terra groups add-user --group=enterprise-pilot-testers --policy=admin mmdevverily4@gmail.com`
-- Add a user directly to the spend profile with `terra spend enable --policy=owner mmdevverily@gmail.com`
+- [Preferred] Add a user to a Terra group that is a user of the spend profile. To also grant permission
+to add new members to the group, use `policy=admin` instead.
+
+`terra groups add-user --group=enterprise-pilot-testers --policy=member mmdevverily4@gmail.com`
+
+- Add a user directly to the spend profile. To also grant permission to add new users to the spend profile,
+user `policy=owner` instead.
+`terra spend enable --policy=user mmdevverily@gmail.com`
 
 #### External data 
 To allow supported applications (i.e. the ones shown by `terra app list`) to read or write data

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 1. [Setup and run](#setup-and-run)
 2. [Requirements](#requirements)
-    * [Authentication](#authentication)
+    * [Login](#login)
+    * [Spend Profile Access](#spend-profile-access)
     * [External data](#external-data)
 3. [Example usage](#example-usage)
 4. [Commands description](#commands-description)
+    * [Authentication](#authentication)
     * [Server](#server)
     * [Workspace](#workspace)
-    * [Supported tools](#supported-tools)
+    * [Resources](#resources)
+    * [Applications](#applications)
+    * [Groups](#groups)
+    * [Spend](#spend)
 
 -----
 
@@ -23,18 +28,21 @@ terra
 1. Java 11
 2. Docker 20.10.2 (Must be running)
 
-#### Authentication
+#### Login
 1. Use a Google account that is not a Google/Verily corporate account.
 2. `terra auth login` launches an OAuth flow that pops out a browser window with a warning login
 page ("! Google hasn't verified this app"). This shows up because the CLI is not yet a Google-verified
 app. Click through the warnings ("Advanced" -> "Go to ... (unsafe)") to complete the login.
 
-Note: The default server has been temporarily changed from `terra-dev` to `wchamber-dev`.
-This is because the Terra dev services are behind a firewall that requires users to be
-on the Broad VPN. There is an open ticket with Broad DevOps to address this. In the meantime,
-personal development deployments are apparently not behind the firewall, so we're using
-one of those as a temporary workaround. If you do have access to the Broad VPN, you can run 
-`terra server set terra-dev` to change it back to official Terra dev environment.
+#### Spend Profile Access
+In order to spend money (e.g. by creating a project and resources within it) in Terra, you need
+access to a billing account via a spend profile. Currently, there is a single spend profile used
+by Workspace Manager. Your email needs to either be added as a user of that spend profile or added
+to a Terra group that is a user of that spend profile. This needs to be done by someone else with
+owner access to that spend profile.
+
+- [Preferred] Add a user to a Terra group that is a user of the spend profile with `terra groups add-user --group=enterprise-pilot-testers --policy=admin mmdevverily4@gmail.com`
+- Add a user directly to the spend profile with `terra spend enable --policy=owner mmdevverily@gmail.com`
 
 #### External data 
 To allow supported applications (i.e. the ones shown by `terra app list`) to read or write data
@@ -104,6 +112,8 @@ Commands:
   resources  Manage controlled resources in the workspace.
   app        Run applications in the workspace.
   notebooks  Use AI Notebooks in the workspace.
+  groups     Manage groups of users.
+  spend      Manage spend profiles.
 ```
 
 The `status` command prints details about the current workspace and server.
@@ -114,6 +124,8 @@ Each sub-group of commands is described in a sub-section below:
 - Workspace
 - Resources
 - Applications
+- Groups
+- Spend
 
 #### Authentication
 ```
@@ -194,3 +206,37 @@ Commands:
 The Terra CLI allows running supported external tools within the context of a workspace.
 Nextflow and the Gcloud CLIs are the first examples of supported tools.
 Exactly what it means to be a "supported" tool is still under discussion.
+
+#### Groups
+```
+Usage: terra groups [COMMAND]
+Manage groups of users.
+Commands:
+  list         List the groups to which the current user belongs.
+  create       Create a new Terra group.
+  delete       Delete an existing Terra group.
+  describe     Print the group email address.
+  list-users   List the users in a group.
+  add-user     Add a user to a group.
+  remove-user  Remove a user from a group.
+```
+
+Terra groups are managed by SAM. These commands are utility wrappers around the group endpoints.
+
+#### Spend
+```
+Usage: terra spend [COMMAND]
+Manage spend profiles.
+Commands:
+  enable      Enable use of the Workspace Manager default spend profile for a
+                user or group.
+  disable     Disable use of the Workspace Manager default spend profile for a
+                user or group.
+  list-users  List the users enabled on the Workspace Manager default spend
+                profile.
+```
+
+These commands allow managing the users authorized to spend money with Workspace Manager (e.g. by
+creating a project and resources within it). A Spend Profile Manager service has not yet been built.
+In the meantime, WSM uses a single billing account and manages access to it with a single SAM resource.
+These commands are utility wrappers around adding users to this single resource.

--- a/src/main/java/bio/terra/cli/command/Groups.java
+++ b/src/main/java/bio/terra/cli/command/Groups.java
@@ -1,0 +1,28 @@
+package bio.terra.cli.command;
+
+import bio.terra.cli.command.groups.AddUser;
+import bio.terra.cli.command.groups.Create;
+import bio.terra.cli.command.groups.Delete;
+import bio.terra.cli.command.groups.Describe;
+import bio.terra.cli.command.groups.List;
+import bio.terra.cli.command.groups.ListUsers;
+import bio.terra.cli.command.groups.RemoveUser;
+import picocli.CommandLine;
+
+/**
+ * This class corresponds to the second-level "terra groups" command. This command is not valid by
+ * itself; it is just a grouping keyword for it sub-commands.
+ */
+@CommandLine.Command(
+    name = "groups",
+    description = "Manage groups of users.",
+    subcommands = {
+      List.class,
+      Create.class,
+      Delete.class,
+      Describe.class,
+      ListUsers.class,
+      AddUser.class,
+      RemoveUser.class
+    })
+public class Groups {}

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -25,7 +25,9 @@ import picocli.CommandLine.ParseResult;
       Gsutil.class,
       Bq.class,
       Nextflow.class,
-      Notebooks.class
+      Notebooks.class,
+      Groups.class,
+      Spend.class
     },
     description = "Terra CLI")
 class Main implements Runnable {

--- a/src/main/java/bio/terra/cli/command/Spend.java
+++ b/src/main/java/bio/terra/cli/command/Spend.java
@@ -1,0 +1,16 @@
+package bio.terra.cli.command;
+
+import bio.terra.cli.command.spend.Disable;
+import bio.terra.cli.command.spend.Enable;
+import bio.terra.cli.command.spend.ListUsers;
+import picocli.CommandLine;
+
+/**
+ * This class corresponds to the second-level "terra spend" command. This command is not valid by
+ * itself; it is just a grouping keyword for it sub-commands.
+ */
+@CommandLine.Command(
+    name = "spend",
+    description = "Manage spend profiles.",
+    subcommands = {Enable.class, Disable.class, ListUsers.class})
+public class Spend {}

--- a/src/main/java/bio/terra/cli/command/groups/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/AddUser.java
@@ -1,0 +1,38 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups add-user" command. */
+@Command(name = "add-user", description = "Add a user to a group.")
+public class AddUser implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The email of the user.")
+  private String user;
+
+  @CommandLine.Option(names = "--group", required = true, description = "The name of the group")
+  private String group;
+
+  @CommandLine.Option(
+      names = "--policy",
+      required = true,
+      description = "The name of the policy: ${COMPLETION-CANDIDATES}")
+  private SamService.GroupPolicy policy;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .addUserToGroup(group, policy, user);
+
+    System.out.println("User " + user + " successfully added to group " + group + ".");
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/AddUser.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups add-user" command. */
-@Command(name = "add-user", description = "Add a user to a group.")
+@Command(name = "add-user", description = "Add a user to a group with a given policy.")
 public class AddUser implements Callable<Integer> {
   @CommandLine.Parameters(index = "0", description = "The email of the user.")
   private String user;

--- a/src/main/java/bio/terra/cli/command/groups/Create.java
+++ b/src/main/java/bio/terra/cli/command/groups/Create.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups create" command. */
+@Command(name = "create", description = "Create a new Terra group.")
+public class Create implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The name of the group")
+  private String group;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .createGroup(group);
+
+    System.out.println("Group " + group + " successfully created.");
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups delete" command. */
+@Command(name = "delete", description = "Delete an existing Terra group.")
+public class Delete implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The name of the group")
+  private String group;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .deleteGroup(group);
+
+    System.out.println("Group " + group + " successfully deleted.");
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/Describe.java
+++ b/src/main/java/bio/terra/cli/command/groups/Describe.java
@@ -1,0 +1,31 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups describe" command. */
+@Command(name = "describe", description = "Print the group email address.")
+public class Describe implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The name of the group")
+  private String group;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    String groupEmail =
+        new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+            .getGroupEmail(group);
+
+    System.out.println(groupEmail);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/List.java
+++ b/src/main/java/bio/terra/cli/command/groups/List.java
@@ -1,0 +1,29 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import org.broadinstitute.dsde.workbench.client.sam.model.ManagedGroupMembershipEntry;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups list" command. */
+@Command(name = "list", description = "List the groups to which the current user belongs.")
+public class List implements Callable<Integer> {
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    java.util.List<ManagedGroupMembershipEntry> groups =
+        new SamService(globalContext.server, globalContext.requireCurrentTerraUser()).listGroups();
+
+    for (ManagedGroupMembershipEntry group : groups) {
+      System.out.println(group.getGroupName());
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/groups/ListUsers.java
@@ -1,0 +1,40 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.List;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups list-users" command. */
+@Command(name = "list-users", description = "List the users in a group.")
+public class ListUsers implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The name of the group")
+  private String group;
+
+  @CommandLine.Option(
+      names = "--policy",
+      required = true,
+      description = "The name of the policy: ${COMPLETION-CANDIDATES}")
+  private SamService.GroupPolicy policy;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    List<String> users =
+        new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+            .listUsersInGroup(group, policy);
+
+    for (String user : users) {
+      System.out.println(user);
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/groups/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/groups/ListUsers.java
@@ -10,7 +10,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups list-users" command. */
-@Command(name = "list-users", description = "List the users in a group.")
+@Command(name = "list-users", description = "List the users in a group with a given policy.")
 public class ListUsers implements Callable<Integer> {
   @CommandLine.Parameters(index = "0", description = "The name of the group")
   private String group;

--- a/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups remove-user" command. */
-@Command(name = "remove-user", description = "Remove a user from a group.")
+@Command(name = "remove-user", description = "Remove a user from a group with a given policy.")
 public class RemoveUser implements Callable<Integer> {
   @CommandLine.Parameters(index = "0", description = "The email of the user.")
   private String user;

--- a/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
@@ -1,0 +1,38 @@
+package bio.terra.cli.command.groups;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SamService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra groups remove-user" command. */
+@Command(name = "remove-user", description = "Remove a user from a group.")
+public class RemoveUser implements Callable<Integer> {
+  @CommandLine.Parameters(index = "0", description = "The email of the user.")
+  private String user;
+
+  @CommandLine.Option(names = "--group", required = true, description = "The name of the group")
+  private String group;
+
+  @CommandLine.Option(
+      names = "--policy",
+      required = true,
+      description = "The name of the policy: ${COMPLETION-CANDIDATES}")
+  private SamService.GroupPolicy policy;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .removeUserFromGroup(group, policy, user);
+
+    System.out.println("User " + user + " successfully removed from group " + group + ".");
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/spend/Disable.java
+++ b/src/main/java/bio/terra/cli/command/spend/Disable.java
@@ -1,0 +1,41 @@
+package bio.terra.cli.command.spend;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SpendProfileManagerService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra spend disable" command. */
+@Command(
+    name = "disable",
+    description = "Disable use of the Workspace Manager default spend profile for a user or group.")
+public class Disable implements Callable<Integer> {
+
+  @CommandLine.Parameters(index = "0", description = "The email of the user or group.")
+  private String email;
+
+  @CommandLine.Option(
+      names = "--policy",
+      required = true,
+      description = "The name of the policy: ${COMPLETION-CANDIDATES}")
+  private SpendProfileManagerService.SpendProfilePolicy policy;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SpendProfileManagerService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .disableUserForDefaultSpendProfile(policy, email);
+
+    System.out.println(
+        "Email "
+            + email
+            + " successfully disabled on the Workspace Manager default spend profile.");
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/spend/Enable.java
+++ b/src/main/java/bio/terra/cli/command/spend/Enable.java
@@ -1,0 +1,39 @@
+package bio.terra.cli.command.spend;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SpendProfileManagerService;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra spend enable" command. */
+@Command(
+    name = "enable",
+    description = "Enable use of the Workspace Manager default spend profile for a user or group.")
+public class Enable implements Callable<Integer> {
+
+  @CommandLine.Parameters(index = "0", description = "The email of the user or group.")
+  private String email;
+
+  @CommandLine.Option(
+      names = "--policy",
+      required = true,
+      description = "The name of the policy: ${COMPLETION-CANDIDATES}")
+  private SpendProfileManagerService.SpendProfilePolicy policy;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    new SpendProfileManagerService(globalContext.server, globalContext.requireCurrentTerraUser())
+        .enableUserForDefaultSpendProfile(policy, email);
+
+    System.out.println(
+        "Email " + email + " successfully enabled on the Workspace Manager default spend profile.");
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/spend/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/spend/ListUsers.java
@@ -1,0 +1,38 @@
+package bio.terra.cli.command.spend;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.utils.SpendProfileManagerService;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntry;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra spend list-users" command. */
+@Command(
+    name = "list-users",
+    description = "List the users enabled on the Workspace Manager default spend profile.")
+public class ListUsers implements Callable<Integer> {
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    List<AccessPolicyResponseEntry> policies =
+        new SpendProfileManagerService(
+                globalContext.server, globalContext.requireCurrentTerraUser())
+            .listUsersOfDefaultSpendProfile();
+
+    for (AccessPolicyResponseEntry policy : policies) {
+      System.out.println(policy.getPolicyName().toUpperCase());
+      for (String member : policy.getPolicy().getMemberEmails()) {
+        System.out.println("  " + member);
+      }
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -10,10 +10,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace add-user" command. */
-@Command(name = "add-user", description = "Add a user to the workspace.")
+@Command(name = "add-user", description = "Add a user or group to the workspace.")
 public class AddUser implements Callable<Integer> {
 
-  @CommandLine.Parameters(index = "0", description = "user email")
+  @CommandLine.Parameters(index = "0", description = "user or group email")
   private String userEmail;
 
   @CommandLine.Parameters(index = "1", description = "Role to grant: ${COMPLETION-CANDIDATES}")
@@ -26,7 +26,7 @@ public class AddUser implements Callable<Integer> {
 
     new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
     new WorkspaceManager(globalContext, workspaceContext).addUserToWorkspace(userEmail, role);
-    System.out.println("User added to workspace: " + userEmail + ", " + role);
+    System.out.println("Email added to workspace: " + userEmail + ", " + role);
     return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -10,10 +10,10 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace remove-user" command. */
-@Command(name = "remove-user", description = "Remove a user from the workspace.")
+@Command(name = "remove-user", description = "Remove a user or group from the workspace.")
 public class RemoveUser implements Callable<Integer> {
 
-  @CommandLine.Parameters(index = "0", description = "user email")
+  @CommandLine.Parameters(index = "0", description = "user or group email")
   private String userEmail;
 
   @CommandLine.Parameters(index = "1", description = "Role to remove: ${COMPLETION-CANDIDATES}")
@@ -26,7 +26,7 @@ public class RemoveUser implements Callable<Integer> {
 
     new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
     new WorkspaceManager(globalContext, workspaceContext).removeUserFromWorkspace(userEmail, role);
-    System.out.println("User removed from workspace: " + userEmail + ", " + role);
+    System.out.println("Email removed from workspace: " + userEmail + ", " + role);
     return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
@@ -7,10 +7,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Utility methods for managing spend profile and talking to the future Spend Profile Manager
- * service.
- */
+/** Utility methods for talking to the future Spend Profile Manager service. */
 public class SpendProfileManagerService {
   private static final Logger logger = LoggerFactory.getLogger(SamService.class);
 
@@ -24,7 +21,7 @@ public class SpendProfileManagerService {
   // keep a reference to the SAM service instance here
   private final SamService samService;
 
-  // these are the resource type and id of the default spend profile used by WSM currently there is
+  // these are the resource type and id of the default spend profile used by WSM. currently there is
   // only one SAM resource used. in the future, if this varies per environment, move this resource
   // id into the server specification
   private static final String SPEND_PROFILE_RESOURCE_TYPE = "spend-profile";

--- a/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
@@ -1,0 +1,86 @@
+package bio.terra.cli.service.utils;
+
+import bio.terra.cli.context.ServerSpecification;
+import bio.terra.cli.context.TerraUser;
+import java.util.List;
+import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods for managing spend profile and talking to the future Spend Profile Manager
+ * service.
+ */
+public class SpendProfileManagerService {
+  private static final Logger logger = LoggerFactory.getLogger(SamService.class);
+
+  // the Terra environment where the SPM service lives
+  private final ServerSpecification server;
+
+  // the Terra user whose credentials will be used to call authenticated requests
+  private final TerraUser terraUser;
+
+  // there currently is no SPM service, so this class just wraps calls to SAM
+  // keep a reference to the SAM service instance here
+  private final SamService samService;
+
+  // these are the resource type and id of the default spend profile used by WSM currently there is
+  // only one SAM resource used. in the future, if this varies per environment, move this resource
+  // id into the server specification
+  private static final String SPEND_PROFILE_RESOURCE_TYPE = "spend-profile";
+  private static final String WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID = "wm-default-spend-profile";
+
+  /**
+   * Constructor for class that talks to the SPM service. The user must be authenticated. Methods in
+   * this class will use its credentials to call authenticated endpoints.
+   *
+   * @param server the Terra environment where the SAM service lives
+   * @param terraUser the Terra user whose credentials will be used to call authenticated endpoints
+   */
+  public SpendProfileManagerService(ServerSpecification server, TerraUser terraUser) {
+    this.server = server;
+    this.terraUser = terraUser;
+    this.samService = new SamService(server, terraUser);
+  }
+
+  /**
+   * These are the policies for the WSM default spend profile resource. They can be looked up
+   * dynamically by calling the SAM "/api/resources/v1/{resourceTypeName}/{resourceId}/policies" GET
+   * endpoint. They are hard-coded here to show the possible values in the CLI usage help. (And in
+   * the eventual SPM service, this may be an enum in their API?)
+   */
+  public enum SpendProfilePolicy {
+    owner,
+    user
+  }
+
+  /**
+   * Add the specified email to the WSM default spend profile resource in SAM.
+   *
+   * @param email email of the user or group to add
+   */
+  public void enableUserForDefaultSpendProfile(SpendProfilePolicy policy, String email) {
+    samService.addUserToResource(
+        SPEND_PROFILE_RESOURCE_TYPE, WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID, policy.name(), email);
+  }
+
+  /**
+   * Remove the specified email from the WSM default spend profile resource in SAM.
+   *
+   * @param email email of the user or group to remove
+   */
+  public void disableUserForDefaultSpendProfile(SpendProfilePolicy policy, String email) {
+    samService.removeUserFromResource(
+        SPEND_PROFILE_RESOURCE_TYPE, WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID, policy.name(), email);
+  }
+
+  /**
+   * List the members of the WSM default spend profile resource in SAM.
+   *
+   * @return a list of policies with their member emails
+   */
+  public List<AccessPolicyResponseEntry> listUsersOfDefaultSpendProfile() {
+    return samService.listPoliciesForResource(
+        SPEND_PROFILE_RESOURCE_TYPE, WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID);
+  }
+}


### PR DESCRIPTION
- Added `terra groups` commands for managing SAM groups
- Added `terra spend` commands for managing access to the WSM spend profile.

- Updated README with instructions for granting access to the spend profile, with a preference for adding new users to a group I created called `enterprise-pilot-testers`.
