### PR TITLE
PF-459: Remove manual environment variable substitution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,8 +309,8 @@ profiles {
       params.multiqc = 'gs://rnaseq-nf/multiqc'
       process.executor = 'google-lifesciences'
       process.container = 'nextflow/rnaseq-nf:latest'
-      google.project = ${TERRA_GOOGLE_PROJECT_ID}
       google.region  = 'europe-west2'
+      google.project = "$TERRA_GOOGLE_PROJECT_ID"
   }
 }
 ```
@@ -322,7 +322,7 @@ this bucket as the working directory.
 bucket successfully created: gs://terra-wsm-dev-e3d8e1f5-my_bucket
 Workspace resource successfully added: my_bucket
 
-> terra nextflow run rnaseq-nf/main.nf -profile gls -work-dir \${TERRA_MY_BUCKET}
+> terra nextflow config rnaseq-nf/main.nf -profile gls -work-dir \${TERRA_MY_BUCKET}
   Setting up Terra app environment...
   Activated service account credentials for: [pet-110017243614237806241@terra-wsm-dev-e3d8e1f5.iam.gserviceaccount.com]
   Updated property [core/project].

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
     * [Applications](#applications)
     * [Groups](#groups)
     * [Spend](#spend)
-    * [Supported tools](#supported-tools)
 5. [Workspace context for applications](#workspace-context-for-applications)
     * [Reference in a CLI command](#reference-in-a-cli-command)
     * [Reference in file](#reference-in-file)

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -114,7 +114,15 @@ public class DockerAppsRunner {
     workspaceContext.requireCurrentWorkspace();
 
     // add the Terra references as environment variables in the container
-    envVars.putAll(buildMapOfTerraReferences());
+    Map<String, String> terraReferences = buildMapOfTerraReferences();
+    for (Map.Entry<String, String> workspaceReferenceEnvVar : terraReferences.entrySet()) {
+      if (envVars.get(workspaceReferenceEnvVar.getKey()) != null) {
+        throw new RuntimeException(
+            "Workspace reference cannot overwrite an environment variable used by the tool command: "
+                + workspaceReferenceEnvVar.getKey());
+      }
+    }
+    envVars.putAll(terraReferences);
 
     buildDockerClient();
 

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -113,11 +113,8 @@ public class DockerAppsRunner {
     // check that the current workspace is defined
     workspaceContext.requireCurrentWorkspace();
 
-    // substitute any Terra references in the command
-    // also add the Terra references as environment variables in the container
-    Map<String, String> terraReferences = buildMapOfTerraReferences();
-    command = replaceTerraReferences(terraReferences, command);
-    envVars.putAll(terraReferences);
+    // add the Terra references as environment variables in the container
+    envVars.putAll(buildMapOfTerraReferences());
 
     buildDockerClient();
 
@@ -380,24 +377,5 @@ public class DockerAppsRunner {
                     "TERRA_" + cloudResource.name.toUpperCase(), cloudResource.cloudId));
 
     return terraReferences;
-  }
-
-  /**
-   * Replace any Terra references in the command string with the resolved values. The references are
-   * case insensitive.
-   *
-   * @param cmd the original command string
-   * @return the modified command string
-   */
-  private String replaceTerraReferences(Map<String, String> terraReferences, String cmd) {
-    // loop through the map entries
-    String modifiedCmd = cmd;
-    for (Map.Entry<String, String> terraReference : terraReferences.entrySet()) {
-      // loop through the map entries, replacing each one in the command string (case insensitive)
-      modifiedCmd =
-          modifiedCmd.replaceAll(
-              "(?i)\\{" + terraReference.getKey() + "}", terraReference.getValue());
-    }
-    return modifiedCmd;
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -206,6 +206,11 @@ public class WorkspaceManager {
           "Resource name can contain only alphanumeric and underscore characters.");
     }
 
+    // check for any collisions with existing references
+    if (workspaceContext.getCloudResource(resourceName) != null) {
+      throw new RuntimeException("Resource of this name already exists.");
+    }
+
     // create the bucket by calling GCS directly
     String bucketName = workspaceContext.getGoogleProject() + "-" + resourceName;
     Bucket bucket =


### PR DESCRIPTION
- Added a section in the README about workspace context for applications and how to use references.

- Removed manual environment variable substitution. For now we'll just escape the environment variable to bypass the host machine.

(If that syntax turns out to be too clunky, we can add this back later and make it less error-prone. For now, better to have it working reliably, especially since we're still not exactly sure about how invoking applications will look post solutions team + others feedback.)
