### PR TITLE
PF-399: Gradle tasks for pull, build, publish Docker image.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ HELP.md
 build/
 scratch/
 scratch2/
+rendered/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**
 !**/src/test/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ The `gradle.properties` file specifies the path to the default Docker image used
 
 #### Build a new image
 For any change in this directory to take effect:
-1. Build a new image.
+1. Build a new image. This uses a short Git hash for the current commit as the tag.
     ```
     > ./gradlew buildDockerImage
     [...Docker build output...]
@@ -170,7 +170,6 @@ The list of supported tools that can be called is specified in an enum in the `t
 To add a new supported tool:
    1. Install the app in the `docker/Dockerfile`
    2. Build the new image (see instructions in section above).
-   3. Set the image that the CLI will use 
    3. Test that the install worked by calling the app through the `terra app execute` command.
    (e.g. `terra app execute dsub --version`). This command just runs the Docker container and 
    executes the command, without requiring any new Java code. This `terra app execute` command
@@ -195,4 +194,4 @@ To add a new supported tool:
    `Map` and passing it to the same `DockerAppsRunner.runToolCommand` method. The `nextflow` command
    has an example of this (see `bio.terra.cli.apps.Nextflow` class `run` method).
    9. Publish the new Docker image and update the default image that the CLI uses to the new version
-   (see instructions above).
+   (see instructions in section above).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ For any change in this directory to take effect:
 #### Pull an existing image
 The `tools/local-dev.sh` script pulls the default image already.
 
+The gcr.io/terra-cli-dev registry is public readable, so anyone should be able to pull images.
+
 To use a specific Docker image from GCR:
 1. Pull the image with that tag.
     ```
@@ -63,6 +65,9 @@ To use a specific Docker image from GCR:
     ```
 
 #### Publish a new image
+The Gradle publishDockerImage task expects the caller to be logged into Vault already, because it fetches
+a SA key file in order to write to GCR. In the future, we should probably do this with a GH action instead.
+
 To publish a new image to GCR:
 1. Build the image (see above).
 2. Push it to GCR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ a SA key file in order to write to GCR. In the future, we should probably do thi
 
 To publish a new image to GCR:
 1. Build the image (see above).
-2. Push it to GCR.
+2. Push it to GCR. (See output of build command for local image tag.)
     ```
     > ./gradlew publishDockerImage -PdockerLocalImageTag=b5fdce0
       

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,8 @@ To publish a new image to GCR:
       BUILD SUCCESSFUL in 26s
       1 actionable task: 1 executed
     ```
-3. Update the image id that the CLI uses. (See output of previous command for image name and tag.)
-    ```
-    > terra app set-image gcr.io/terra-cli-dev/terra-cli/v0.0:b5fdce0
-    ```
+2. Pull the image from GCR (see above). This is so that the name and tag on your local image matches what it will
+look like for someone who did not build the image.
 
 #### Update the default image
 To update the default image:

--- a/build.gradle
+++ b/build.gradle
@@ -136,3 +136,22 @@ spotbugsTest {
         }
     }
 }
+
+// task: pull default image
+task pullDockerImage(type: Exec) {
+    workingDir '.'
+    commandLine 'docker', 'pull', dockerGcrHostname + '/' + dockerGcrProject + '/' + dockerImageName + ':' + dockerImageTag
+}
+
+// task: build image (use default local image name & short git hash tag)
+task buildDockerImage(type: Exec) {
+    workingDir '.'
+    commandLine 'sh', 'tools/build-docker.sh', dockerLocalImageName
+}
+
+// task: publish image (use default local image name & tag)
+// expect caller to override the local tag property on the command line (-PdockerLocalImageTag=b5fdce0)
+task publishDockerImage(type: Exec) {
+    workingDir '.'
+    commandLine 'tools/publish-docker.sh', dockerLocalImageName, dockerLocalImageTag, dockerGcrHostname + '/' + dockerGcrProject + '/' + dockerImageName, dockerLocalImageTag
+}

--- a/build.gradle
+++ b/build.gradle
@@ -143,13 +143,13 @@ task pullDockerImage(type: Exec) {
     commandLine 'docker', 'pull', dockerGcrHostname + '/' + dockerGcrProject + '/' + dockerImageName + ':' + dockerImageTag
 }
 
-// task: build image (use default local image name & short git hash tag)
+// task: build image
 task buildDockerImage(type: Exec) {
     workingDir '.'
     commandLine 'sh', 'tools/build-docker.sh', dockerLocalImageName
 }
 
-// task: publish image (use default local image name & tag)
+// task: publish image
 // expect caller to override the local tag property on the command line (-PdockerLocalImageTag=b5fdce0)
 task publishDockerImage(type: Exec) {
     workingDir '.'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,11 @@
+# default Docker image to use for launching applications
+# keep these properties in-sync with the DockerAppsRunner.DEFAULT_DOCKER_IMAGE_ID Java property
+# dockerGcrHostname/dockerGcrProject/dockerImageName:dockerImageTag
+dockerGcrHostname=gcr.io
+dockerGcrProject=terra-cli-dev
+dockerImageName=terra-cli/v0.0
+dockerImageTag=stable
+
+# name used when building the Docker image locally
+dockerLocalImageName=terra-cli/local
+dockerLocalImageTag=draft

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # default Docker image to use for launching applications
 # keep these properties in-sync with the DockerAppsRunner.DEFAULT_DOCKER_IMAGE_ID Java property
-# dockerGcrHostname/dockerGcrProject/dockerImageName:dockerImageTag
+# concatenate the below properties into a single path: dockerGcrHostname/dockerGcrProject/dockerImageName:dockerImageTag
 dockerGcrHostname=gcr.io
 dockerGcrProject=terra-cli-dev
 dockerImageName=terra-cli/v0.0

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -48,9 +48,9 @@ public class DockerAppsRunner {
   }
 
   // This variable specifies the default Docker image id or tag that the CLI uses to run external
-  // tools.
-  // TODO: change this to a DockerHub or GCR path
-  private static final String DEFAULT_DOCKER_IMAGE_ID = "terra/cli:v0.0";
+  // tools. Keep this property in-sync with the dockerImageName Gradle property
+  private static final String DEFAULT_DOCKER_IMAGE_ID =
+      "gcr.io/terra-cli-dev/terra-cli/v0.0:stable";
 
   /** Returns the default image id. */
   public static String defaultImageId() {

--- a/tools/build-docker.sh
+++ b/tools/build-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Run this script from the top-level directory "terra-cli/".
+# e.g. tools/build-docker.sh terra-cli/local
+
+usage="Usage: tools/publish-docker.sh [localImageName]"
+
+# check required arguments
+localImageName=$1
+if [ -z "$localImageName" ]
+  then
+    echo $usage
+    exit 1
+fi
+
+echo "Generating an image tag from the Git commit hash"
+gitHash=$(git rev-parse --short HEAD)
+
+echo "Building the image"
+localImageNameAndTag="$localImageName:$gitHash"
+docker build -t $localImageNameAndTag ./docker
+
+# write out the path to the local image
+echo "$localImageNameAndTag successfully built"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -3,9 +3,11 @@
 # Run this script from the top-level directory "terra-cli/".
 # source tools/local-dev.sh
 
-# build Docker image
-docker build -t terra/cli:v0.0 ./docker
+echo "Pulling the default Docker image from GCR"
+./gradlew pullDockerImage
 
-# build and alias JAR file
+echo "Building Java code"
 ./gradlew install
+
+echo "Aliasing JAR file"
 alias terra=$(pwd)/build/install/terra-cli/bin/terra-cli

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Run this script from the top-level directory "terra-cli/".
+# e.g. tools/publish-docker.sh terra-cli/local test123 terra-cli/v0.0 stable
+
+usage="Usage: tools/publish-docker.sh [localImageName] [localImageTag] [remoteImageName] [remoteImageTag]"
+
+# check required arguments
+localImageName=$1
+localImageTag=$2
+remoteImageName=$3
+remoteImageTag=$4
+if [ -z "$localImageName" ] || [ -z "$localImageTag" ] || [ -z "$remoteImageName" ] || [ -z "$remoteImageTag" ]
+  then
+    echo $usage
+    exit 1
+fi
+
+echo "Reading the CI service account key file from Vault"
+vault read -format json secret/dsde/terra/kernel/dev/common/ci/ci-account.json | jq .data > rendered/ci-account.json
+
+echo "Logging in to docker using this key file"
+cat rendered/ci-account.json | docker login -u _json_key --password-stdin https://gcr.io
+
+echo "Tagging the local docker image with the name to use in GCR"
+localImageNameAndTag="$localImageName:$localImageTag"
+remoteImageNameAndTag="$remoteImageName:$remoteImageTag"
+docker tag $localImageNameAndTag $remoteImageNameAndTag
+
+echo "Pushing the image to GCR"
+docker push $remoteImageNameAndTag
+
+# write out the path to the remote image
+echo "$remoteImageNameAndTag successfully pushed to GCR"


### PR DESCRIPTION
1. Added scripts for building and publishing a Docker image.
2. Added Gradle tasks that wrap those scripts and direct Docker commands: pullDockerImage, buildDockerImage, publishDockerImage.
3. Added instructions for building, pulling, publishing and updating the default image.
4. Changed the `tools/local-dev.sh` script to pull the default image from GCR instead of building it locally.

This is a temporary stand-in for an actual release process. But once we have GH actions or some automated way to do releases, we can have it call these scripts/tasks.

The main purpose of this PR is to un-block Nicole, who was having problems building the image locally on a Cloud Remote Desktop. The goal for this is to have CLI testers just run `source tools/local-dev.sh` and not have to build the Docker image locally anymore.