### PR TITLE
PF-484: Store multiple pet SA key files per user.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -181,11 +181,12 @@ public class DockerAppsRunner {
     // the terra_init script relies on environment variables to pass in global and workspace
     // context information
     Map<String, String> terraInitEnvVars = new HashMap<>();
-    String googleProjectId = workspaceContext.getGoogleProject();
     terraInitEnvVars.put(
         "GOOGLE_APPLICATION_CREDENTIALS",
-        PET_KEYS_MOUNT_POINT + "/" + currentUser.getPetKeyFile(googleProjectId).getName());
-    terraInitEnvVars.put("TERRA_GOOGLE_PROJECT_ID", googleProjectId);
+        PET_KEYS_MOUNT_POINT
+            + "/"
+            + GlobalContext.getPetSaKeyFilename(workspaceContext.getWorkspaceId()));
+    terraInitEnvVars.put("TERRA_GOOGLE_PROJECT_ID", workspaceContext.getGoogleProject());
     for (Map.Entry<String, String> terraInitEnvVar : terraInitEnvVars.entrySet()) {
       if (envVars.get(terraInitEnvVar.getKey()) != null) {
         throw new RuntimeException(
@@ -197,7 +198,8 @@ public class DockerAppsRunner {
 
     // the terra_init script requires that the pet SA key file is accessible to it
     Map<String, File> terraInitBindMounts = new HashMap<>();
-    terraInitBindMounts.put(PET_KEYS_MOUNT_POINT, GlobalContext.resolvePetSaKeyDir().toFile());
+    terraInitBindMounts.put(
+        PET_KEYS_MOUNT_POINT, GlobalContext.getPetSaKeyDirForUser(currentUser).toFile());
     for (Map.Entry<String, File> terraInitBindMount : terraInitBindMounts.entrySet()) {
       if (bindMounts.get(terraInitBindMount.getKey()) != null) {
         throw new RuntimeException(

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -153,9 +153,9 @@ public class GlobalContext {
   // ====================================================
   // Directory and file names
   //   - top-level directory: $HOME/.terra
-  //   - persisted global context file: global-context.json
-  //   - sub-directory for persisting pet SA keys: pet-keys/[terra user id]
-  //   - pet SA key filename: [workspace id]
+  //       - persisted global context file: global-context.json
+  //       - sub-directory for persisting pet SA keys: pet-keys/[terra user id]
+  //           - pet SA key filename: [workspace id]
 
   /** Getter for the global context directory. */
   public static Path resolveGlobalContextDir() {

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,7 +154,8 @@ public class GlobalContext {
   // Directory and file names
   //   - top-level directory: $HOME/.terra
   //   - persisted global context file: global-context.json
-  //   - sub-directory for persisting pet SA keys: pet-keys
+  //   - sub-directory for persisting pet SA keys: pet-keys/[terra user id]
+  //   - pet SA key filename: [workspace id]
 
   /** Getter for the global context directory. */
   public static Path resolveGlobalContextDir() {
@@ -162,10 +164,32 @@ public class GlobalContext {
   }
 
   /**
-   * Getter for the sub-directory of the global context directory that holds the pet SA key files.
+   * Getter for the sub-directory of the global context directory that holds the pet SA key files
+   * for all users.
    */
-  public static Path resolvePetSaKeyDir() {
+  private static Path resolvePetSaKeyDir() {
     return resolveGlobalContextDir().resolve(PET_KEYS_DIRNAME);
+  }
+
+  /**
+   * Getter for the sub-directory of the global context directory that holds the pet SA key files
+   * for the given user.
+   */
+  @JsonIgnore
+  public static Path getPetSaKeyDirForUser(TerraUser terraUser) {
+    return resolvePetSaKeyDir().resolve(terraUser.terraUserId);
+  }
+
+  /** Getter for the pet SA key file name for the given user + workspace. */
+  @JsonIgnore
+  public static String getPetSaKeyFilename(UUID workspaceId) {
+    return workspaceId.toString();
+  }
+
+  /** Getter for the pet SA key file handle for the given user + workspace. */
+  @JsonIgnore
+  public static Path getPetSaKeyFile(TerraUser terraUser, UUID workspaceId) {
+    return getPetSaKeyDirForUser(terraUser).resolve(getPetSaKeyFilename(workspaceId));
   }
 
   /** Getter for the file where the global context is persisted. */

--- a/src/main/java/bio/terra/cli/context/TerraUser.java
+++ b/src/main/java/bio/terra/cli/context/TerraUser.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
-import java.io.File;
 import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,12 +57,5 @@ public class TerraUser {
   /** Fetch the access token for the user credentials. */
   public AccessToken fetchUserAccessToken() {
     return GoogleCredentialUtils.getAccessToken(userCredentials);
-  }
-
-  /** Return a pointer to the pet key file for the given Google project id. */
-  public File getPetKeyFile(String googleProjectId) {
-    // TODO: move each user's keys into its own sub-directory (easier to mount on container), and
-    // maintain an index by project
-    return GlobalContext.resolvePetSaKeyDir().resolve(terraUserId).toFile();
   }
 }

--- a/src/main/java/bio/terra/cli/service/ServerManager.java
+++ b/src/main/java/bio/terra/cli/service/ServerManager.java
@@ -52,8 +52,7 @@ public class ServerManager {
       }
     } catch (IOException ioEx) {
     }
-    logger.error("Error reading in server specification file ({}).", serverName);
-    return false;
+    throw new RuntimeException("Error reading in server specification file (" + serverName + ").");
   }
 
   /** Ping the service URLs to check their status. Return true if all return OK. */
@@ -84,8 +83,8 @@ public class ServerManager {
     try {
       return ServerSpecification.fromJSONFile(DEFAULT_SERVER_FILENAME);
     } catch (IOException ioEx) {
-      logger.error("Error reading in default server file. ({})", DEFAULT_SERVER_FILENAME, ioEx);
-      return null;
+      throw new RuntimeException(
+          "Error reading in default server file. (" + DEFAULT_SERVER_FILENAME + ")", ioEx);
     }
   }
 
@@ -110,8 +109,7 @@ public class ServerManager {
       }
       return servers;
     } catch (IOException ioEx) {
-      logger.error("Error reading in all possible servers.", ioEx);
-      return new ArrayList<>();
+      throw new RuntimeException("Error reading in all possible servers.", ioEx);
     }
   }
 }


### PR DESCRIPTION
1. pet SA key file path = [global context dir]/pet-keys/[user id]/[workspace id]
    * Each user now has a sub-directory of the global context directory for their pet SA key files.
    * Each pet SA key file is named for the workspace that it belongs to.
    * Only the user-specific sub-directory is mounted to the Docker image when running app commands. Previously, the entire pet-keys directory was mounted. The GOOGLE_APPLICATION_CREDENTIALS environment variable is still pointed to the pet SA key file for the current workspace.

2. Added existence checks to AuthenticationManager.loginTerraUser().
    * Skip the SAM fetches if the user information is already populated.
    * Only update the global context persisted on disk if the user has changed.

If you have a previous installation of the CLI, you'll need to wipe the global context directory so it can be re-generated with the updated format. `rm -R ~/.terra`