### PR TITLE
PF-445: Add flag for launching browser automatically or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ terra
 2. `terra auth login` launches an OAuth flow that pops out a browser window with a warning login
 page ("! Google hasn't verified this app"). This shows up because the CLI is not yet a Google-verified
 app. Click through the warnings ("Advanced" -> "Go to ... (unsafe)") to complete the login.
+3. If the machine where you're running the CLI does not have a browser available to it, then use the
+manual login flow by setting the browser flag `terra auth set-browser manual`. See the [Authentication](#authentication)
+section below for more details.
 
 #### Spend profile access
 In order to spend money (e.g. by creating a project and resources within it) in Terra, you need
@@ -140,11 +143,16 @@ Each sub-group of commands is described in a sub-section below:
 #### Authentication
 ```
 Usage: terra auth [COMMAND]
-Commands related to the retrieval and management of user credentials.
+Retrieve and manage user credentials.
 Commands:
-  status  Print details about the currently authorized account.
-  login   Authorize the CLI to access Terra APIs and data with user credentials.
-  revoke  Revoke credentials from an account.
+  status       Print details about the currently authorized account.
+  login        Authorize the CLI to access Terra APIs and data with user
+                 credentials.
+  revoke       Revoke credentials from an account.
+  get-browser  Check whether a browser is launched automatically during the
+                 login process.
+  set-browser  Configure whether a browser is launched automatically during the
+                 login process.
 ```
 
 Only one user can be logged in at a time. To change the active user, revoke the existing credentials and login again.
@@ -154,10 +162,26 @@ If there is a workspace defined in the current context, then logging in also fet
 
 Credentials are part of the global context, so you don't need to login again after switching workspaces.
 
+By default, the CLI opens a browser window for the user to click through the OAuth flow. For some use cases (e.g. CloudShell,
+notebook VM), this is not practical because there is no default (or any) browser on the machine. The CLI has a browser
+flag that controls this behavior. `terra set-browser manual` means the user can copy the url into a browser on a different
+machine (e.g. their laptop), confirm the scopes and get the token response, then copy/paste that back into a shell on the
+machine where they want to use the Terra CLI. Example usage:
+```
+> terra auth set-browser manual
+Browser will be launched manually (CHANGED)
+
+> terra auth login
+Please open the following address in a browser on any machine:
+  https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force&client_id=[...]
+Please enter code: *****
+Login successful: mmdevverily@gmail.com
+```
+
 #### Server
 ```
 Usage: terra server [COMMAND]
-Commands related to the Terra server.
+Connect to a Terra server.
 Commands:
   status  Print status and details of the Terra server context.
   list    List all available Terra servers.
@@ -171,14 +195,14 @@ The server is part of the global context, so this value applies across workspace
 #### Workspace
 ```
 Usage: terra workspace [COMMAND]
-Commands related to the Terra workspace.
+Setup a Terra workspace.
 Commands:
   create       Create a new workspace.
   mount        Mount an existing workspace to the current directory.
   delete       Delete an existing workspace.
   list-users   List the users of the workspace.
-  add-user     Add a user to the workspace.
-  remove-user  Remove a user from the workspace.
+  add-user     Add a user or group to the workspace.
+  remove-user  Remove a user or group from the workspace.
 ```
 
 A Terra workspace is backed by a Google project. Creating a new workspace also creates a new backing Google 
@@ -204,11 +228,11 @@ Currently, the only supported controlled resource is a bucket.
 #### Applications
 ```
 Usage: terra app [COMMAND]
-Commands related to applications in the Terra workspace context.
+Run applications in the workspace.
 Commands:
   list       List the supported applications.
-  get-image  Get the Docker image used for launching applications.
-  set-image  Set the Docker image to use for launching applications.
+  get-image  [FOR DEBUG] Get the Docker image used for launching applications.
+  set-image  [FOR DEBUG] Set the Docker image to use for launching applications.
   execute    [FOR DEBUG] Execute a command in the application container for the
                Terra workspace, with no setup.
 ```

--- a/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
+++ b/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
@@ -80,7 +80,8 @@ public class AuthenticationManager {
               terraUser.cliGeneratedUserKey,
               SCOPES,
               inputStream,
-              globalContext.resolveGlobalContextDir().toFile());
+              globalContext.resolveGlobalContextDir().toFile(),
+              globalContext.launchBrowserAutomatically);
     } catch (IOException | GeneralSecurityException ex) {
       throw new RuntimeException("Error fetching user credentials.", ex);
     }

--- a/src/main/java/bio/terra/cli/command/Auth.java
+++ b/src/main/java/bio/terra/cli/command/Auth.java
@@ -1,7 +1,9 @@
 package bio.terra.cli.command;
 
+import bio.terra.cli.command.auth.GetBrowser;
 import bio.terra.cli.command.auth.Login;
 import bio.terra.cli.command.auth.Revoke;
+import bio.terra.cli.command.auth.SetBrowser;
 import bio.terra.cli.command.auth.Status;
 import picocli.CommandLine.Command;
 
@@ -12,5 +14,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "auth",
     description = "Retrieve and manage user credentials.",
-    subcommands = {Status.class, Login.class, Revoke.class})
+    subcommands = {Status.class, Login.class, Revoke.class, GetBrowser.class, SetBrowser.class})
 public class Auth {}

--- a/src/main/java/bio/terra/cli/command/auth/GetBrowser.java
+++ b/src/main/java/bio/terra/cli/command/auth/GetBrowser.java
@@ -1,0 +1,24 @@
+package bio.terra.cli.command.auth;
+
+import bio.terra.cli.context.GlobalContext;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra auth get-browser" command. */
+@Command(
+    name = "get-browser",
+    description = "Check whether a browser is launched automatically during the login process.")
+public class GetBrowser implements Callable<Integer> {
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+
+    System.out.println(
+        "Browser will be launched "
+            + (globalContext.launchBrowserAutomatically ? "automatically" : "manually")
+            + ".");
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/auth/SetBrowser.java
+++ b/src/main/java/bio/terra/cli/command/auth/SetBrowser.java
@@ -1,0 +1,47 @@
+package bio.terra.cli.command.auth;
+
+import bio.terra.cli.context.GlobalContext;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra auth set-browser" command. */
+@Command(
+    name = "set-browser",
+    description = "Configure whether a browser is launched automatically during the login process.")
+public class SetBrowser implements Callable<Integer> {
+
+  @CommandLine.Parameters(
+      index = "0",
+      description = "Browser launch mode: ${COMPLETION-CANDIDATES}")
+  private BrowserLaunchOptions mode;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+
+    boolean prevBrowserLaunchFlag = globalContext.launchBrowserAutomatically;
+    globalContext.updateBrowserLaunchFlag(mode.equals(BrowserLaunchOptions.auto));
+
+    System.out.println(
+        "Browser will be launched "
+            + (globalContext.launchBrowserAutomatically ? "automatically" : "manually")
+            + " ("
+            + (globalContext.launchBrowserAutomatically == prevBrowserLaunchFlag
+                ? "UNCHANGED"
+                : "CHANGED")
+            + ")");
+
+    return 0;
+  }
+
+  /**
+   * This enum provides a text translation for the boolean flag {@link
+   * GlobalContext#launchBrowserAutomatically}. This enum is not used in the auth logic, it is
+   * strictly for CLI command presentation, so it lives here instead of the auth package.
+   */
+  private enum BrowserLaunchOptions {
+    manual,
+    auto;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -22,9 +22,11 @@ import org.slf4j.LoggerFactory;
 public class GlobalContext {
   private static final Logger logger = LoggerFactory.getLogger(GlobalContext.class);
 
-  // global auth context =  list of Terra users, CLI-generated key of current Terra user
+  // global auth context =  list of Terra users, CLI-generated key of current Terra user,
+  //   flag indicating whether to launch a browser automatically or not
   public Map<String, TerraUser> terraUsers;
   public String currentTerraUserKey;
+  public boolean launchBrowserAutomatically = true;
 
   // global server context = service uris, environment name
   public ServerSpecification server;
@@ -126,6 +128,17 @@ public class GlobalContext {
    */
   public void addOrUpdateTerraUser(TerraUser terraUser) {
     addOrUpdateTerraUser(terraUser, false);
+  }
+
+  /** Setter for the browser launch flag. Persists on disk. */
+  public void updateBrowserLaunchFlag(boolean launchBrowserAutomatically) {
+    logger.debug(
+        "Updating browser launch flag from {} to {}.",
+        this.launchBrowserAutomatically,
+        launchBrowserAutomatically);
+    this.launchBrowserAutomatically = launchBrowserAutomatically;
+
+    writeToFile();
   }
 
   // ====================================================


### PR DESCRIPTION
- Added a boolean flag to the global context for the OAuth login flow.
    - true/auto = launch the browser window automatically and listen on a local port for the token response
    - false/manual = print the url to stdout, expect the user to open that url in a browser on any machine and copy/paste the token response to stdin
    - default = true/auto, which matches the existing behavior
- Added two new commands to manipulate this flag: `terra auth set-browser`, `terra auth get-browser`.

The purpose of this flag is to support logging in on a machine (e.g. CloudShell, notebook VM) that does not have a default (or any) browser available to it. Setting the flag to false/manual means the user can copy the url into a browser on a different machine (e.g. their laptop), confirm the scopes and get the token response, then copy/paste that back into a shell on the machine where they want to use the Terra CLI.

Example usage:
```
> terra auth set-browser manual
Browser will be launched manually (CHANGED)

> terra auth login
Please open the following address in a browser on any machine:
  https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force&client_id=[...]
Please enter code: *****
Login successful: mmdevverily@gmail.com
```

Side note: Long/medium-term, I'm not sure this is the right command hierarchy. It may be better to have a single `config` command grouping for things like this flag and the Docker image id. Not sure exactly which things should go there (server?), yet, but this seems lower priority to me for now.