### PR TITLE
Add '--' prefixes to option parameters of notebooks commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     * [Workspace](#workspace)
     * [Resources](#resources)
     * [Applications](#applications)
+    * [Notebooks](#notebooks)
     * [Groups](#groups)
     * [Spend](#spend)
 5. [Workspace context for applications](#workspace-context-for-applications)
@@ -240,6 +241,22 @@ Commands:
 The Terra CLI allows running supported external tools within the context of a workspace.
 Nextflow and the Gcloud CLIs are the first examples of supported tools.
 Exactly what it means to be a "supported" tool is still under discussion.
+
+#### Notebooks
+```
+Usage: terra notebooks [COMMAND]
+Use AI Notebooks in the workspace.
+Commands:
+  create    Create a new AI Notebook instance within your workspace.
+  delete    Delete an AI Notebook instance within your workspace.
+  describe  Describe an AI Notebook instance within your workspace.
+  list      List the AI Notebook instance within your workspace for the
+              specified location.
+  start     Start a stopped AI Notebook instance within your workspace.
+  stop      Stop a running AI Notebook instance within your workspace.
+```
+The Terra CLI provides convenience for running
+[AI Platform Notebooks](https://cloud.google.com/ai-platform-notebooks) within a workspace.
 
 #### Groups
 ```

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -26,25 +26,25 @@ public class Create implements Callable<Integer> {
   private String instanceName;
 
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;
 
   @CommandLine.Option(
-      names = "machine-type",
+      names = "--machine-type",
       defaultValue = "n1-standard-4",
       description = "The Compute Engine machine type of this instance.")
   private String machineType;
 
   @CommandLine.Option(
-      names = "vm-image-project",
+      names = "--vm-image-project",
       defaultValue = "deeplearning-platform-release",
       description = "The ID of the Google Cloud project that this VM image belongs to.")
   private String vmImageProject;
 
   @CommandLine.Option(
-      names = "vm-image-family",
+      names = "--vm-image-family",
       defaultValue = "tf-latest-gpu",
       description =
           "Use this VM image family to find the image; the newest image in this family will be used.")

--- a/src/main/java/bio/terra/cli/command/notebooks/Delete.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Delete.java
@@ -19,7 +19,7 @@ public class Delete implements Callable<Integer> {
   private String instanceName;
 
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;

--- a/src/main/java/bio/terra/cli/command/notebooks/Describe.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Describe.java
@@ -19,7 +19,7 @@ public class Describe implements Callable<Integer> {
   private String instanceName;
 
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;

--- a/src/main/java/bio/terra/cli/command/notebooks/List.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/List.java
@@ -15,7 +15,7 @@ import picocli.CommandLine;
     description = "List the AI Notebook instance within your workspace for the specified location.")
 public class List implements Callable<Integer> {
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -19,7 +19,7 @@ public class Start implements Callable<Integer> {
   private String instanceName;
 
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -19,7 +19,7 @@ public class Stop implements Callable<Integer> {
   private String instanceName;
 
   @CommandLine.Option(
-      names = "location",
+      names = "--location",
       defaultValue = "us-central1-a",
       description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
   private String location;


### PR DESCRIPTION
This will make the notebooks commands consistent with the other commands, which should help usability.