### PR TITLE
PF-421: Change project id env var to GOOGLE_CLOUD_PROJECT.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ For any change in this directory to take effect:
     ```
 2. Update the image id that the CLI uses. (See output of previous command for image name and tag.)
     ```
-    > terra app set-image terra-cli/local:b5fdce0
+    > terra app set-image --image=terra-cli/local:b5fdce0
     ```
 
 #### Pull an existing image
@@ -61,7 +61,7 @@ To use a specific Docker image from GCR:
     ```
 2. Update the image id that the CLI uses. (See output of previous command for image name and tag.)
     ```
-    > terra app set-image gcr.io/terra-cli-dev/terra-cli/v0.0:b5fdce0
+    > terra app set-image --image=gcr.io/terra-cli-dev/terra-cli/v0.0:b5fdce0
     ```
 
 #### Publish a new image

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ To update the default image:
     ```
 3. Bump the version number in the image name in `gradle.properties`.
     ```
-    dockerImageName=terra-cli/v0.1
+    dockerImageName=terra-cli/v0.2
     ```
 4. Publish the new (`stable`-tagged) image to GCR (see above).
 5. Update the `DockerAppsRunner.DEFAULT_DOCKER_IMAGE_ID` property in the Java code.
@@ -186,8 +186,8 @@ To add a new supported tool:
    7. You can pass environment variables through to the Docker container by populating a `Map` and
    passing it to the `DockerAppsRunner.runToolCommand` method. Two environment variables are always
    passed:
-       - `GOOGLE_PROJECT_ID` = the workspace project id
-       - `PET_KEY_FILE` = the pet service account key file
+       - `GOOGLE_CLOUD_PROJECT` = the workspace project id
+       - `GOOGLE_APPLICATION_CREDENTIALS` = the pet service account key file
    8.  You can mount directories on the host machine to the Docker container by populating a second
    `Map` and passing it to the same `DockerAppsRunner.runToolCommand` method. The `nextflow` command
    has an example of this (see `bio.terra.cli.apps.Nextflow` class `run` method).

--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -3,7 +3,7 @@
 echo "Setting up Terra app environment..."
 
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-gcloud config set project ${TERRA_GOOGLE_PROJECT_ID}
+gcloud config set project ${GOOGLE_CLOUD_PROJECT}
 
 echo "Done setting up Terra app environment..."
 echo

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # concatenate the below properties into a single path: dockerGcrHostname/dockerGcrProject/dockerImageName:dockerImageTag
 dockerGcrHostname=gcr.io
 dockerGcrProject=terra-cli-dev
-dockerImageName=terra-cli/v0.0
+dockerImageName=terra-cli/v0.1
 dockerImageTag=stable
 
 # name used when building the Docker image locally

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -50,7 +50,7 @@ public class DockerAppsRunner {
   // This variable specifies the default Docker image id or tag that the CLI uses to run external
   // tools. Keep this property in-sync with the dockerImageName Gradle property
   private static final String DEFAULT_DOCKER_IMAGE_ID =
-      "gcr.io/terra-cli-dev/terra-cli/v0.0:stable";
+      "gcr.io/terra-cli-dev/terra-cli/v0.1:stable";
 
   /** Returns the default image id. */
   public static String defaultImageId() {
@@ -186,7 +186,7 @@ public class DockerAppsRunner {
         PET_KEYS_MOUNT_POINT
             + "/"
             + GlobalContext.getPetSaKeyFilename(workspaceContext.getWorkspaceId()));
-    terraInitEnvVars.put("TERRA_GOOGLE_PROJECT_ID", workspaceContext.getGoogleProject());
+    terraInitEnvVars.put("GOOGLE_CLOUD_PROJECT", workspaceContext.getGoogleProject());
     for (Map.Entry<String, String> terraInitEnvVar : terraInitEnvVars.entrySet()) {
       if (envVars.get(terraInitEnvVar.getKey()) != null) {
         throw new RuntimeException(

--- a/src/main/java/bio/terra/cli/command/app/SetImage.java
+++ b/src/main/java/bio/terra/cli/command/app/SetImage.java
@@ -13,22 +13,32 @@ import picocli.CommandLine.Command;
     description = "[FOR DEBUG] Set the Docker image to use for launching applications.")
 public class SetImage implements Callable<Integer> {
 
-  @CommandLine.Parameters(index = "0", description = "image id or tag")
-  private String imageId;
+  @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+  ImageIdArgGroup argGroup;
+
+  static class ImageIdArgGroup {
+    @CommandLine.Option(names = "--image", description = "image id or tag")
+    private String imageId;
+
+    @CommandLine.Option(names = "--default", description = "use the default image id or tag")
+    private boolean useDefault;
+  }
 
   @Override
   public Integer call() {
     GlobalContext globalContext = GlobalContext.readFromFile();
     WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
 
+    String newImageId = argGroup.useDefault ? DockerAppsRunner.defaultImageId() : argGroup.imageId;
+
     String prevImageId = globalContext.dockerImageId;
-    new DockerAppsRunner(globalContext, workspaceContext).updateImageId(imageId);
+    new DockerAppsRunner(globalContext, workspaceContext).updateImageId(newImageId);
 
     if (globalContext.dockerImageId.equals(prevImageId)) {
       System.out.println("Docker image: " + globalContext.dockerImageId + " (UNCHANGED)");
     } else {
       System.out.println(
-          "Docker image: " + prevImageId + " (CHANGED FROM " + globalContext.dockerImageId + ")");
+          "Docker image: " + globalContext.dockerImageId + " (CHANGED FROM " + prevImageId + ")");
     }
 
     return 0;

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -211,8 +211,12 @@ public class WorkspaceManager {
       throw new RuntimeException("Resource of this name already exists.");
     }
 
+    // replace underscores in the resource name with hyphens so that the bucket path will be a valid
+    // url
+    String bucketName =
+        workspaceContext.getGoogleProject() + "-" + resourceName.replaceAll("_", "-");
+
     // create the bucket by calling GCS directly
-    String bucketName = workspaceContext.getGoogleProject() + "-" + resourceName;
     Bucket bucket =
         new GoogleCloudStorage(
                 globalContext.requireCurrentTerraUser(), workspaceContext.getGoogleProject())

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -11,3 +11,6 @@ echo "Building Java code"
 
 echo "Aliasing JAR file"
 alias terra=$(pwd)/build/install/terra-cli/bin/terra-cli
+
+echo "Setting the Docker image id to the default"
+terra app set-image --default


### PR DESCRIPTION
- Changed the name of the environment variable that we use to store the workspace project id, from `TERRA_GOOGLE_PROJECT_ID` -> `GOOGLE_CLOUD_PROJECT`. This new environment variable overrides the project specified in the `nextflow.config` file and is also documented in the Google Cloud Java client library [README](https://github.com/googleapis/google-cloud-java/blob/master/README.md#specifying-a-project-id), so it seems like the better choice here (similar to how GOOGLE_APPLICATION_CREDENTIALS is recognized by different apps).
- Published a new Docker image and bumped the default version used by the CLI.
- Updated the instructions for publishing a new Docker image to include authentication. (I think I didn't need to do this before because I happened to be logged in with a user that had permissions.)
- Added a new `--default` flag to the `terra app set-image` command, so that we have a way to set the default image. Called this new command in the `tools/local-dev.sh` script so we don't have to alert everyone every time we publish a new Docker image. Instead, running `source tools/local-dev.sh` should update their default.
- Replaced underscores with hyphens in the "controlled resource" bucket creation command. I think this is in line with "help users do the right thing", since Nextflow requires bucket paths to be valid URLs and according to the solutions team they've run into other tools with the same requirement. The allowed set of characters for resource names is still alphanumeric characters and underscores, which I think makes sense because users will type the environment variables directly in their app code/files, so better to have the user-facing names all be consistent with underscores. This will eventually need to be a discussion with WSM/larger team on how to avoid collisions in resource naming.
```
> terra resources describe --name=my_bucket
Name: my_bucket
Type: bucket
Cloud Id: gs://terra-wsm-dev-e844792d-my-bucket
> terra app execute echo \${TERRA_MY_BUCKET}
[...]
gs://terra-wsm-dev-e844792d-my-bucket
```

These changes came from debugging Nextflow on a WSM-provided project (notes are [here](https://docs.google.com/document/d/1Wqa5ssHpp8M--RPCbD_fibEs0gn98XaFGngxzH-m1h4/edit#bookmark=id.puo7xa9tdmuv) for reference).