### PR TITLE
PF-427 Search parent directories for context file. Preserve relative path when running in container.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -402,14 +402,7 @@ public class DockerAppsRunner {
     Path workspaceDirOnHost = WorkspaceContext.getWorkspaceDir();
 
     // remove the workspace directory part of the current working directory
-    Path relativePathToCurrentDir = currentDir.relativize(workspaceDirOnHost);
-
-    logger.info("currentDir: {}", currentDir);
-    logger.info("workspaceDirOnHost: {}", workspaceDirOnHost);
-    logger.info("relativePathToCurrentDir: {}", relativePathToCurrentDir);
-    logger.info(
-        "getWorkingDirOnContainer: {}",
-        Path.of(CONTAINER_WORKSPACE_DIR).resolve(relativePathToCurrentDir));
+    Path relativePathToCurrentDir = workspaceDirOnHost.relativize(currentDir);
 
     // working directory on container = workspace dir on container + relative path to current dir
     return Path.of(CONTAINER_WORKSPACE_DIR).resolve(relativePathToCurrentDir);
@@ -446,13 +439,6 @@ public class DockerAppsRunner {
     //      globalContextDirOnHost = $HOME/.terra/
     //      relativePathToKeyFile = pet-keys/[user id]/[workspace id]
     Path relativePathToKeyFile = globalContextDirOnHost.relativize(keyFileOnHost);
-
-    logger.info("keyFileOnHost: {}", keyFileOnHost);
-    logger.info("globalContextDirOnHost: {}", globalContextDirOnHost);
-    logger.info("relativePathToKeyFile: {}", relativePathToKeyFile);
-    logger.info(
-        "getPetSaKeyFileOnContainer: {}",
-        getGlobalContextDirOnContainer().resolve(relativePathToKeyFile));
 
     // key file path on container = global context dir on container + relative path to key file
     return getGlobalContextDirOnContainer().resolve(relativePathToKeyFile);

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -39,7 +39,10 @@ public class DockerAppsRunner {
   private final WorkspaceContext workspaceContext;
   private DockerClient dockerClient;
 
+  // default $HOME directory on the container (this is where we expect to look for the global
+  // context)
   private static final String CONTAINER_HOME_DIR = "/root";
+  // mount point for the workspace directory
   private static final String CONTAINER_WORKSPACE_DIR = "/usr/local/etc";
 
   public DockerAppsRunner(GlobalContext globalContext, WorkspaceContext workspaceContext) {

--- a/src/main/java/bio/terra/cli/apps/Nextflow.java
+++ b/src/main/java/bio/terra/cli/apps/Nextflow.java
@@ -2,27 +2,12 @@ package bio.terra.cli.apps;
 
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.WorkspaceContext;
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** This class contains logic related to running the supported app nextflow. */
 public class Nextflow {
-  private static final Logger logger = LoggerFactory.getLogger(Nextflow.class);
-
-  // Mount point for the nextflow sub-directory on the Docker container.
-  public static final String NEXTFLOW_MOUNT_POINT = "/usr/local/etc/nextflow";
-
-  // Default nextflow sub-directory relative to the directory where the Terra CLI is running.
-  // TODO: walk up the directory tree to find this directory relative to the top-level workspace
-  // dir, not the current dir
-  private static final Path DEFAULT_NEXTFLOW_DIR = Paths.get(".", "nextflow");
-
   private final GlobalContext globalContext;
   private final WorkspaceContext workspaceContext;
 
@@ -38,27 +23,10 @@ public class Nextflow {
    * @param cmdArgs command arguments to pass through to nextflow
    */
   public void run(List<String> cmdArgs) {
-    // mount the nextflow sub-directory of the current directory
-    createSubDirectory();
-    Map<String, File> bindMounts = new HashMap<>();
-    bindMounts.put(NEXTFLOW_MOUNT_POINT, DEFAULT_NEXTFLOW_DIR.toFile());
-
     Map<String, String> envVars = new HashMap<>();
     envVars.put("NXF_MODE", "google");
 
     String fullCommand = DockerAppsRunner.buildFullCommand("nextflow", cmdArgs);
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(fullCommand, NEXTFLOW_MOUNT_POINT, envVars, bindMounts);
-  }
-
-  /** Create the nextflow sub-directory on the host machine if it does not already exist. */
-  private void createSubDirectory() {
-    File nextflowDir = DEFAULT_NEXTFLOW_DIR.toFile();
-    if (!nextflowDir.exists() || !nextflowDir.isDirectory()) {
-      boolean nextflowDirCreated = nextflowDir.mkdirs();
-      if (!nextflowDirCreated) {
-        throw new RuntimeException("Error creating nextflow sub-directory.");
-      }
-    }
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(fullCommand, envVars);
   }
 }

--- a/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
+++ b/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
@@ -80,7 +80,7 @@ public class AuthenticationManager {
               terraUser.cliGeneratedUserKey,
               SCOPES,
               inputStream,
-              globalContext.resolveGlobalContextDir().toFile(),
+              globalContext.getGlobalContextDir().toFile(),
               globalContext.launchBrowserAutomatically);
     } catch (IOException | GeneralSecurityException ex) {
       throw new RuntimeException("Error fetching user credentials.", ex);
@@ -116,7 +116,7 @@ public class AuthenticationManager {
           currentTerraUser.cliGeneratedUserKey,
           SCOPES,
           inputStream,
-          globalContext.resolveGlobalContextDir().toFile());
+          globalContext.getGlobalContextDir().toFile());
 
       // delete the pet SA credentials
       deletePetSaCredentials(currentTerraUser);
@@ -149,7 +149,7 @@ public class AuthenticationManager {
               currentTerraUser.cliGeneratedUserKey,
               SCOPES,
               inputStream,
-              globalContext.resolveGlobalContextDir().toFile());
+              globalContext.getGlobalContextDir().toFile());
 
       // if there are no valid credentials, then return here because there's nothing to populate
       if (userCredentials == null) {
@@ -180,7 +180,7 @@ public class AuthenticationManager {
     }
 
     // if the key file for this user + workspace already exists, then no need to re-fetch
-    Path jsonKeyPath = GlobalContext.getPetSaKeyFile(terraUser, workspaceContext.getWorkspaceId());
+    Path jsonKeyPath = GlobalContext.getPetSaKeyFile(terraUser, workspaceContext);
     logger.info("Looking for pet SA key file at: {}", jsonKeyPath);
     if (jsonKeyPath.toFile().exists()) {
       logger.info("Pet SA key file for this user and workspace already exists.");
@@ -199,8 +199,7 @@ public class AuthenticationManager {
         // persist the key file in the global context directory
         jsonKeyPath =
             FileUtils.writeStringToFile(
-                GlobalContext.getPetSaKeyDirForUser(terraUser),
-                GlobalContext.getPetSaKeyFilename(workspaceContext.getWorkspaceId()),
+                GlobalContext.getPetSaKeyFile(terraUser, workspaceContext).toFile(),
                 petSaKeySamResponse.responseBody);
         logger.info("Stored pet SA key file for this user and workspace.");
       } catch (IOException ioEx) {
@@ -222,7 +221,7 @@ public class AuthenticationManager {
 
   /** Delete all pet SA credentials for the given user. */
   public void deletePetSaCredentials(TerraUser terraUser) {
-    File jsonKeysDir = GlobalContext.getPetSaKeyDirForUser(terraUser).toFile();
+    File jsonKeysDir = GlobalContext.getPetSaKeyDirHandle(terraUser);
 
     // delete all key files
     File[] keyFiles = jsonKeysDir.listFiles();

--- a/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
+++ b/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
@@ -221,7 +221,7 @@ public class AuthenticationManager {
 
   /** Delete all pet SA credentials for the given user. */
   public void deletePetSaCredentials(TerraUser terraUser) {
-    File jsonKeysDir = GlobalContext.getPetSaKeyDirHandle(terraUser);
+    File jsonKeysDir = GlobalContext.getPetSaKeyDir(terraUser).toFile();
 
     // delete all key files
     File[] keyFiles = jsonKeysDir.listFiles();

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -96,9 +96,7 @@ public class Create implements Callable<Integer> {
     // each zone.
     envVars.put("SUBNET", "projects/" + projectId + "/regions/" + zone + "/subnetworks/subnetwork");
 
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     System.out.println(
         "Notebook instance starting. This will take ~5-10 minutes.\n"

--- a/src/main/java/bio/terra/cli/command/notebooks/Delete.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Delete.java
@@ -39,9 +39,7 @@ public class Delete implements Callable<Integer> {
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
 
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/notebooks/Describe.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Describe.java
@@ -40,9 +40,7 @@ public class Describe implements Callable<Integer> {
     envVars.put("LOCATION", location);
 
     // TODO(wchamber): Consider reformatting the ouptut or otherwise highlighting the proxy uri.
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/notebooks/List.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/List.java
@@ -35,9 +35,7 @@ public class List implements Callable<Integer> {
     envVars.put("LOCATION", location);
 
     // TODO(wchamber): Output more relevant information, like the proxy uri.
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -39,9 +39,7 @@ public class Start implements Callable<Integer> {
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
 
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -39,9 +39,7 @@ public class Stop implements Callable<Integer> {
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
 
-    new DockerAppsRunner(globalContext, workspaceContext)
-        .runToolCommand(
-            command, /* workingDir =*/ null, envVars, /* bindMounts =*/ new HashMap<>());
+    new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -4,6 +4,7 @@ import bio.terra.cli.apps.DockerAppsRunner;
 import bio.terra.cli.context.utils.FileUtils;
 import bio.terra.cli.service.ServerManager;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -59,8 +60,7 @@ public class GlobalContext {
     GlobalContext globalContext = null;
     try {
       globalContext =
-          FileUtils.readFileIntoJavaObject(
-              resolveGlobalContextFile().toFile(), GlobalContext.class);
+          FileUtils.readFileIntoJavaObject(resolveGlobalContextFile(), GlobalContext.class);
     } catch (IOException ioEx) {
       logger.error("Global context file not found.", ioEx);
     }
@@ -78,7 +78,7 @@ public class GlobalContext {
   /** Write an instance of this class to a JSON-formatted file in the global context directory. */
   private void writeToFile() {
     try {
-      FileUtils.writeJavaObjectToFile(resolveGlobalContextFile().toFile(), this);
+      FileUtils.writeJavaObjectToFile(resolveGlobalContextFile(), this);
     } catch (IOException ioEx) {
       logger.error("Error persisting global context.", ioEx);
     }
@@ -206,7 +206,7 @@ public class GlobalContext {
   }
 
   /** Getter for the file where the global context is persisted. */
-  public static Path resolveGlobalContextFile() {
-    return resolveGlobalContextDir().resolve(GLOBAL_CONTEXT_FILENAME);
+  public static File resolveGlobalContextFile() {
+    return resolveGlobalContextDir().resolve(GLOBAL_CONTEXT_FILENAME).toFile();
   }
 }

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -41,9 +41,13 @@ public class GlobalContext {
   private static final String GLOBAL_CONTEXT_FILENAME = "global-context.json";
   private static final String PET_KEYS_DIRNAME = "pet-keys";
 
-  private GlobalContext() {
+  // defaut constructor needed for Jackson de/serialization
+  private GlobalContext() {}
+
+  private GlobalContext(ServerSpecification server, String dockerImageId) {
     this.terraUsers = new HashMap<>();
-    this.server = null;
+    this.server = server;
+    this.dockerImageId = dockerImageId;
   }
 
   // ====================================================
@@ -57,22 +61,15 @@ public class GlobalContext {
    */
   public static GlobalContext readFromFile() {
     // try to read in an instance of the global context file
-    GlobalContext globalContext = null;
     try {
-      globalContext =
-          FileUtils.readFileIntoJavaObject(resolveGlobalContextFile(), GlobalContext.class);
+      return FileUtils.readFileIntoJavaObject(resolveGlobalContextFile(), GlobalContext.class);
     } catch (IOException ioEx) {
-      logger.error("Global context file not found.", ioEx);
+      logger.warn("Global context file not found or error reading it.", ioEx);
     }
 
-    // if the global context file does not exist, return an object populated with default values
-    if (globalContext == null) {
-      globalContext = new GlobalContext();
-      globalContext.server = ServerManager.defaultServer();
-      globalContext.dockerImageId = DockerAppsRunner.defaultImageId();
-    }
-
-    return globalContext;
+    // if the global context file does not exist or there is an error reading it, return an object
+    // populated with default values
+    return new GlobalContext(ServerManager.defaultServer(), DockerAppsRunner.defaultImageId());
   }
 
   /** Write an instance of this class to a JSON-formatted file in the global context directory. */

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -194,7 +194,7 @@ public class GlobalContext {
    * @return handle to the global context file
    */
   @JsonIgnore
-  public static File getGlobalContextFileHandle() {
+  private static File getGlobalContextFileHandle() {
     return getGlobalContextDir().resolve(GLOBAL_CONTEXT_FILENAME).toFile();
   }
 

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -203,16 +203,16 @@ public class WorkspaceContext {
   }
 
   /**
-   * Get a handle for the workspace context file.
+   * Get the workspace context file.
    *
    * <p>This method first searches for an existing workspace context file in the current directory
-   * hierarchy. If it finds one, then it returns a handle to that file.
+   * hierarchy. If it finds one, then it returns that file.
    *
-   * <p>If it does not find one, then it returns a handle to the file where a new workspace context
-   * can be written. This handle will be relative to the current directory (i.e. current directory =
+   * <p>If it does not find one, then it returns the file where a new workspace context can be
+   * written. This file will be relative to the current directory (i.e. current directory =
    * workspace top-level directory)
    *
-   * @return a handle for the workspace context file
+   * @return absolute path to the workspace context file
    */
   @JsonIgnore
   private static Path getWorkspaceContextFile() {
@@ -225,12 +225,12 @@ public class WorkspaceContext {
   }
 
   /**
-   * Get a handle for an existing workspace context file in the current directory hierarchy.
+   * Get the existing workspace context file in the current directory hierarchy.
    *
    * <p>For each directory, it checks for the existence of a workspace context file (i.e.
    * ./.terra/workspace-context.json).
    *
-   * <p>-If it finds one, then it returns a handle to that file.
+   * <p>-If it finds one, then it returns that file.
    *
    * <p>-Otherwise, it recursively checks the parent directory, until it hits the root directory.
    *
@@ -238,7 +238,7 @@ public class WorkspaceContext {
    * an exception.
    *
    * @param currentDir the directory to search
-   * @return the file handle for an existing workspace context file
+   * @return absolute path to the existing workspace context file
    * @throws FileNotFoundException if no existing workspace context file is found
    */
   @JsonIgnore
@@ -253,7 +253,7 @@ public class WorkspaceContext {
       // get the workspace context file relative to the sub-directory and check if it exists
       Path workspaceContextFile = workspaceContextDir.resolve(WORKSPACE_CONTEXT_FILENAME);
       if (workspaceContextFile.toFile().exists() && workspaceContextFile.toFile().isFile()) {
-        return workspaceContextFile;
+        return workspaceContextFile.toAbsolutePath();
       }
     }
 

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -50,20 +50,16 @@ public class WorkspaceContext {
    */
   public static WorkspaceContext readFromFile() {
     // try to read in an instance of the workspace context file
-    WorkspaceContext workspaceContext = null;
     try {
-      workspaceContext =
-          FileUtils.readFileIntoJavaObject(resolveWorkspaceContextFile(), WorkspaceContext.class);
+      return FileUtils.readFileIntoJavaObject(
+          resolveWorkspaceContextFile(), WorkspaceContext.class);
     } catch (IOException ioEx) {
-      logger.error("Workspace context file not found.", ioEx);
+      logger.warn("Workspace context file not found or error reading it.", ioEx);
     }
 
-    // if the workspace context file does not exist, return an object populated with default values
-    if (workspaceContext == null) {
-      workspaceContext = new WorkspaceContext();
-    }
-
-    return workspaceContext;
+    // if the workspace context file does not exist or there is an error reading it, return an
+    // object populated with default values
+    return new WorkspaceContext();
   }
 
   /**

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -188,6 +188,15 @@ public class WorkspaceContext {
   // Resolving file and directory paths
 
   /**
+   * Getter for the workspace directory file handle. (i.e. the parent of the .terra directory)
+   *
+   * @return a handle for the workspace directory
+   */
+  public static File resolveWorkspaceDir() {
+    return resolveWorkspaceContextFile().getParentFile().getParentFile();
+  }
+
+  /**
    * Getter for the file handle where the workspace context is persisted.
    *
    * <p>This method first searches for an existing workspace context file in the current directory

--- a/src/main/java/bio/terra/cli/context/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/context/utils/FileUtils.java
@@ -63,8 +63,7 @@ public class FileUtils {
   /**
    * Write a string directly to a file.
    *
-   * @param directory the directory where the file is
-   * @param fileName the file name
+   * @param outputFile the file to write to
    * @param fileContents the string to write
    * @return the file that was written to
    */
@@ -72,18 +71,13 @@ public class FileUtils {
       value = "RV_RETURN_VALUE_IGNORED",
       justification =
           "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
-  public static Path writeStringToFile(Path directory, String fileName, String fileContents)
-      throws IOException {
-    // get a reference to the file
-    Path outputPath = directory.resolve(fileName);
-    logger.info("Writing to file: {}", outputPath.toAbsolutePath());
+  public static Path writeStringToFile(File outputFile, String fileContents) throws IOException {
+    logger.info("Writing to file: {}", outputFile.getAbsolutePath());
 
     // create the file and any parent directories if they don't already exist
-    File outputFile = outputPath.toFile();
     createFile(outputFile);
 
-    return Files.write(
-        directory.resolve(fileName), fileContents.getBytes(Charset.forName("UTF-8")));
+    return Files.write(outputFile.toPath(), fileContents.getBytes(Charset.forName("UTF-8")));
   }
 
   /**

--- a/src/main/java/bio/terra/cli/context/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/context/utils/FileUtils.java
@@ -25,14 +25,10 @@ public class FileUtils {
    * @param javaObjectClass the Java object class
    * @param <T> the Java object class to map the file contents to
    * @return an instance of the Java object class
+   * @throws FileNotFoundException if the file to read in does not exist
    */
   public static <T> T readFileIntoJavaObject(File inputFile, Class<T> javaObjectClass)
       throws IOException {
-    // get a reference to the file
-    if (!inputFile.exists()) {
-      return null;
-    }
-
     // use Jackson to map the file contents to an instance of the specified class
     ObjectMapper objectMapper = new ObjectMapper();
     try (FileInputStream inputStream = new FileInputStream(inputFile)) {


### PR DESCRIPTION
- Recursively search the current directory hierarchy for the workspace context file.
- Preserve the current directory, relative to the workspace directory, when running in the container.
- Cleanup the file and directory helper methods for handling the global context and workspace.
- Mount the global context directory and the workspace directory onto the Docker container.

The main goal for these changes is to use any `terra` commands, including those that start a Docker container, in sub-directories of the workspace directory. Previously, you could only use `terra` commands in the top-level workspace directory -- changing to a sub-directory would fail to find the workspace context.
```
> terra workspace create
Workspace successfully created: 03935501-8978-4188-a58a-3fb3d876fd35

> git clone https://github.com/nextflow-io/rnaseq-nf.git
[...git output...]

> cd rnaseq-nf

# command that does not start a container
> terra resources create --type=bucket --name=mybucket
bucket successfully created: gs://terra-wsm-dev-19c49e13-mybucket
Workspace resource successfully added: mybucket

# command that does start a container
> terra nextflow config main.nf
[...nextflow output...]
```

A lesser goal of these changes is to mount the entire global and workspace context directories onto the Docker container, in preparation for installing the Terra CLI on the container. (I needed to mount the workspace directory onto the container for these changes anyway, so I went ahead and mounted the global context directory while I was there.) Installing the Terra CLI on the container would let users include things like `$(terra data-refs resolve my_bucket)` in a bash script called by their app.