### PR TITLE
PF-508: Invite user if workspace add-user returns bad request.

### DIFF
--- a/src/main/java/bio/terra/cli/service/ServerManager.java
+++ b/src/main/java/bio/terra/cli/service/ServerManager.java
@@ -55,17 +55,36 @@ public class ServerManager {
     throw new RuntimeException("Error reading in server specification file (" + serverName + ").");
   }
 
-  /** Ping the service URLs to check their status. Return true if all return OK. */
+  /**
+   * Ping the service URLs to check their status. Return true if all return OK.
+   *
+   * <p>Each of the status checks in this method swallow all exceptions. This means that the CLI
+   * treats all network or API exceptions when calling "/status" the same as a bad status code.
+   */
   public boolean pingServerStatus() {
-    SystemStatus samStatus = new SamService(globalContext.server).getStatus();
-    logger.info("SAM status: {}", samStatus);
+    SystemStatus samStatus = null;
+    try {
+      samStatus = new SamService(globalContext.server).getStatus();
+      logger.info("SAM status: {}", samStatus);
+    } catch (Exception ex) {
+      logger.error("Error getting SAM status.", ex);
+    }
 
-    bio.terra.workspace.model.SystemStatus wsmStatus =
-        new WorkspaceManagerService(globalContext.server).getStatus();
-    logger.info("Workspace Manager status: {}", wsmStatus);
+    bio.terra.workspace.model.SystemStatus wsmStatus = null;
+    try {
+      wsmStatus = new WorkspaceManagerService(globalContext.server).getStatus();
+      logger.info("WSM status: {}", wsmStatus);
+    } catch (Exception ex) {
+      logger.error("Error getting WSM status.", ex);
+    }
 
-    RepositoryStatusModel tdrStatus = new DataRepoService(globalContext.server).getStatus();
-    logger.info("Data Repo status: {}", tdrStatus);
+    RepositoryStatusModel tdrStatus = null;
+    try {
+      tdrStatus = new DataRepoService(globalContext.server).getStatus();
+      logger.info("TDR status: {}", tdrStatus);
+    } catch (Exception ex) {
+      logger.error("Error getting TDR status.", ex);
+    }
 
     return (samStatus != null && samStatus.getOk())
         && (wsmStatus != null && wsmStatus.isOk())

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -263,7 +263,6 @@ public class WorkspaceManager {
    */
   public List<CloudResource> listResources() {
     // TODO: change this method to call WSM controlled resource endpoints once they're ready
-
     return workspaceContext.listControlledResources();
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/utils/DataRepoService.java
@@ -84,10 +84,8 @@ public class DataRepoService {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     try {
       return unauthenticatedApi.serviceStatus();
-    } catch (Exception ex) {
-      // catch any exception, including client-side ones (e.g. UnknownHostException)
-      logger.error("Error getting Data Repo status", ex);
-      return null;
+    } catch (ApiException ex) {
+      throw new RuntimeException("Error getting Data Repo status", ex);
     }
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/utils/DataRepoService.java
@@ -4,6 +4,7 @@ import bio.terra.cli.context.ServerSpecification;
 import bio.terra.cli.context.TerraUser;
 import bio.terra.datarepo.api.UnauthenticatedApi;
 import bio.terra.datarepo.client.ApiClient;
+import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.RepositoryConfigurationModel;
 import bio.terra.datarepo.model.RepositoryStatusModel;
 import com.google.auth.oauth2.AccessToken;
@@ -68,8 +69,8 @@ public class DataRepoService {
     RepositoryConfigurationModel repositoryConfig = null;
     try {
       repositoryConfig = unauthenticatedApi.retrieveRepositoryConfig();
-    } catch (Exception ex) {
-      logger.error("Error getting Data Repo configuration", ex);
+    } catch (ApiException ex) {
+      throw new RuntimeException("Error getting Data Repo version", ex);
     }
     return repositoryConfig;
   }
@@ -81,12 +82,12 @@ public class DataRepoService {
    */
   public RepositoryStatusModel getStatus() {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
-    RepositoryStatusModel status = null;
     try {
-      status = unauthenticatedApi.serviceStatus();
+      return unauthenticatedApi.serviceStatus();
     } catch (Exception ex) {
+      // catch any exception, including client-side ones (e.g. UnknownHostException)
       logger.error("Error getting Data Repo status", ex);
+      return null;
     }
-    return status;
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEn
 import org.broadinstitute.dsde.workbench.client.sam.model.ManagedGroupMembershipEntry;
 import org.broadinstitute.dsde.workbench.client.sam.model.SystemStatus;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatus;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusDetails;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,16 +82,34 @@ public class SamService {
    */
   public SystemStatus getStatus() {
     StatusApi statusApi = new StatusApi(apiClient);
-    SystemStatus status = null;
     try {
-      status =
-          HttpUtils.callWithRetries(() -> statusApi.getSystemStatus(), SamService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
+      return HttpUtils.callWithRetries(() -> statusApi.getSystemStatus(), SamService::isRetryable);
+    } catch (Exception ex) {
+      // catch any exception, including client-side ones (e.g. UnknownHostException)
       logger.error("Error getting SAM status", ex);
+      return null;
     } finally {
       closeConnectionPool();
     }
-    return status;
+  }
+
+  /**
+   * Call the SAM "/api/users/v1/invite/{inviteeEmail}" endpoint to invite a user and track them.
+   * This is not the same thing as registering a user.
+   *
+   * @param userEmail email to invite
+   * @return SAM object with details about the user
+   */
+  public UserStatusDetails inviteUser(String userEmail) {
+    UsersApi samUsersApi = new UsersApi(apiClient);
+    try {
+      return HttpUtils.callWithRetries(
+          () -> samUsersApi.inviteUser(userEmail), SamService::isRetryable);
+    } catch (ApiException | InterruptedException ex) {
+      throw new RuntimeException("Error inviting user in SAM.", ex);
+    } finally {
+      closeConnectionPool();
+    }
   }
 
   /**
@@ -197,6 +216,7 @@ public class SamService {
    * Call the SAM "/api/groups/v1/{groupName}" GET endpoint to get the email address of a group.
    *
    * @param groupName name of the group to delete
+   * @return email address of the group
    */
   public String getGroupEmail(String groupName) {
     GroupApi groupApi = new GroupApi(apiClient);
@@ -368,6 +388,7 @@ public class SamService {
    *
    * @param resourceType type of resource
    * @param resourceId id of resource
+   * @return list of policies on the resource and their members
    */
   public List<AccessPolicyResponseEntry> listPoliciesForResource(
       String resourceType, String resourceId) {

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -84,10 +84,8 @@ public class SamService {
     StatusApi statusApi = new StatusApi(apiClient);
     try {
       return HttpUtils.callWithRetries(() -> statusApi.getSystemStatus(), SamService::isRetryable);
-    } catch (Exception ex) {
-      // catch any exception, including client-side ones (e.g. UnknownHostException)
-      logger.error("Error getting SAM status", ex);
-      return null;
+    } catch (ApiException | InterruptedException ex) {
+      throw new RuntimeException("Error getting SAM status.", ex);
     } finally {
       closeConnectionPool();
     }

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -104,10 +104,8 @@ public class WorkspaceManagerService {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     try {
       return unauthenticatedApi.serviceStatus();
-    } catch (Exception ex) {
-      // catch any exception, including client-side ones (e.g. UnknownHostException)
-      logger.error("Error getting Workspace Manager status", ex);
-      return null;
+    } catch (ApiException ex) {
+      throw new RuntimeException("Error getting Workspace Manager status", ex);
     }
   }
 


### PR DESCRIPTION
- Propagate exceptions thrown by the Workspace Manager client up to the caller. Previously, they were logged by otherwise failed silently.
- The only exception to this error propagation are calls to the `/status` endpoint, where an exception is interpreted by the CLI the same as a bad status.
- If `terra workspace add-user` fails with a bad request (i.e. code=400), then try to invite them first and then add them to the workspace.

In the future, this invite behavior might be better placed in WSM -- I'm not sure of that, but I've put it on the list of possible requests of WSM from the CLI.