### PR TITLE
PF-483: Add data-refs commands.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,7 @@
 HELP.md
 .gradle
 build/
-scratch/
-scratch2/
+scratch*/
 rendered/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     * [Server](#server)
     * [Workspace](#workspace)
     * [Resources](#resources)
+    * [Data References](#data-references)
     * [Applications](#applications)
     * [Notebooks](#notebooks)
     * [Groups](#groups)
@@ -125,6 +126,7 @@ Commands:
   server     Connect to a Terra server.
   workspace  Setup a Terra workspace.
   resources  Manage controlled resources in the workspace.
+  data-refs  Reference data in the workspace context.
   app        Run applications in the workspace.
   notebooks  Use AI Notebooks in the workspace.
   groups     Manage groups of users.
@@ -138,7 +140,9 @@ Each sub-group of commands is described in a sub-section below:
 - Server
 - Workspace
 - Resources
+- Data References
 - Applications
+- Notebooks
 - Groups
 - Spend
 
@@ -226,6 +230,23 @@ Commands:
 
 A controlled resource is a cloud resource managed by the Terra workspace on behalf of the user.
 Currently, the only supported controlled resource is a bucket.
+
+#### Data References
+```
+Usage: terra data-refs [COMMAND]
+Reference data in the workspace context.
+Commands:
+  list          List all data references.
+  add           Add a new data reference.
+  delete        Delete an existing data reference.
+  check-access  Check if you have access to a data reference.
+  resolve       Resolve a data reference to its cloud id or path.
+```
+
+A data reference points to a cloud resource that the user wants to read or write data to.
+Data references include some types of controlled resources (e.g. bucket but not VM) and 
+un-controlled resources that are external to the workspace.
+Currently, the only supported data reference is a GCS bucket.
 
 #### Applications
 ```

--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ Commands:
   resolve       Resolve a data reference to its cloud id or path.
 ```
 
-A data reference points to a cloud resource that the user wants to read or write data to.
-Data references include some types of controlled resources (e.g. bucket but not VM) and 
-un-controlled resources that are external to the workspace.
+A data reference points to a data (i.e. not compute) type of cloud resource that the user wants to
+read or write to. Data references include some types of controlled resources (e.g. bucket but not
+VM) within the workspace and un-controlled resources external to the workspace.
 Currently, the only supported data reference is a GCS bucket.
 
 #### Applications

--- a/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
+++ b/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
@@ -89,7 +89,9 @@ public class AuthenticationManager {
 
     // fetch the user information from SAM, if it's not already populated
     if (!currentTerraUser.isPresent()) {
-      new SamService(globalContext.server, terraUser).getOrRegisterUser();
+      SamService samService = new SamService(globalContext.server, terraUser);
+      samService.getOrRegisterUser();
+      samService.getProxyGroupEmail();
     }
     fetchPetSaCredentials(terraUser);
 
@@ -161,8 +163,12 @@ public class AuthenticationManager {
     currentTerraUser.userCredentials = userCredentials;
 
     // fetch the user information from SAM
-    new SamService(globalContext.server, currentTerraUser).getUser();
+    SamService samService = new SamService(globalContext.server, currentTerraUser);
+    samService.getUser();
     if (currentTerraUser.terraUserId != null) {
+      // populate the user's proxy group email also
+      samService.getProxyGroupEmail();
+
       // fetch the pet SA credentials if they don't already exist
       fetchPetSaCredentials(currentTerraUser);
     }

--- a/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
+++ b/src/main/java/bio/terra/cli/auth/AuthenticationManager.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,8 +91,10 @@ public class AuthenticationManager {
     // fetch the user information from SAM, if it's not already populated
     if (!currentTerraUser.isPresent()) {
       SamService samService = new SamService(globalContext.server, terraUser);
-      samService.getOrRegisterUser();
-      samService.getProxyGroupEmail();
+      UserStatusInfo userInfo = samService.getUserInfoOrRegisterUser();
+      terraUser.terraUserId = userInfo.getUserSubjectId();
+      terraUser.terraUserEmail = userInfo.getUserEmail();
+      terraUser.terraProxyGroupEmail = samService.getProxyGroupEmail();
     }
     fetchPetSaCredentials(terraUser);
 
@@ -164,10 +167,13 @@ public class AuthenticationManager {
 
     // fetch the user information from SAM
     SamService samService = new SamService(globalContext.server, currentTerraUser);
-    samService.getUser();
+    UserStatusInfo userInfo = samService.getUserInfo();
+    currentTerraUser.terraUserId = userInfo.getUserSubjectId();
+    currentTerraUser.terraUserEmail = userInfo.getUserEmail();
+
     if (currentTerraUser.terraUserId != null) {
       // populate the user's proxy group email also
-      samService.getProxyGroupEmail();
+      currentTerraUser.terraProxyGroupEmail = samService.getProxyGroupEmail();
 
       // fetch the pet SA credentials if they don't already exist
       fetchPetSaCredentials(currentTerraUser);

--- a/src/main/java/bio/terra/cli/command/DataRefs.java
+++ b/src/main/java/bio/terra/cli/command/DataRefs.java
@@ -1,0 +1,18 @@
+package bio.terra.cli.command;
+
+import bio.terra.cli.command.datarefs.Add;
+import bio.terra.cli.command.datarefs.CheckAccess;
+import bio.terra.cli.command.datarefs.Delete;
+import bio.terra.cli.command.datarefs.List;
+import bio.terra.cli.command.datarefs.Resolve;
+import picocli.CommandLine;
+
+/**
+ * This class corresponds to the second-level "terra data-refs" command. This command is not valid
+ * by itself; it is just a grouping keyword for it sub-commands.
+ */
+@CommandLine.Command(
+    name = "data-refs",
+    description = "Reference data in the workspace context.",
+    subcommands = {List.class, Add.class, Delete.class, CheckAccess.class, Resolve.class})
+public class DataRefs {}

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -20,6 +20,7 @@ import picocli.CommandLine.ParseResult;
       Server.class,
       Workspace.class,
       Resources.class,
+      DataRefs.class,
       App.class,
       Gcloud.class,
       Gsutil.class,

--- a/src/main/java/bio/terra/cli/command/auth/Status.java
+++ b/src/main/java/bio/terra/cli/command/auth/Status.java
@@ -27,6 +27,8 @@ public class Status implements Callable<Integer> {
     }
     TerraUser currentTerraUser = currentTerraUserOpt.get();
     System.out.println("Current Terra user: " + currentTerraUser.terraUserEmail);
+    System.out.println(
+        "Current Terra user's proxy group: " + currentTerraUser.terraProxyGroupEmail);
 
     // check if the current user needs to re-authenticate (i.e. is logged out)
     System.out.println("LOGGED " + (currentTerraUser.requiresReauthentication() ? "OUT" : "IN"));

--- a/src/main/java/bio/terra/cli/command/datarefs/Add.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Add.java
@@ -40,8 +40,12 @@ public class Add implements Callable<Integer> {
     CloudResource dataReference =
         new WorkspaceManager(globalContext, workspaceContext).addDataReference(type, name, uri);
 
-    System.out.println(dataReference.type + " successfully created: " + dataReference.cloudId);
-    System.out.println("Workspace data reference successfully added: " + dataReference.name);
+    System.out.println(
+        "Workspace data reference successfully added: "
+            + dataReference.name
+            + " ("
+            + dataReference.cloudId
+            + ")");
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/datarefs/Add.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Add.java
@@ -1,0 +1,48 @@
+package bio.terra.cli.command.datarefs;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra data-refs add" command. */
+@CommandLine.Command(name = "add", description = "Add a new data reference.")
+public class Add implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--type",
+      required = true,
+      description = "The type of data reference to create: ${COMPLETION-CANDIDATES}")
+  private CloudResource.Type type;
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description =
+          "The name of the data reference, scoped to the workspace. Only alphanumeric and underscore characters are permitted.")
+  private String name;
+
+  @CommandLine.Option(
+      names = "--uri",
+      required = true,
+      description = "The bucket path (e.g. gs://my-bucket)")
+  private String uri;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource dataReference =
+        new WorkspaceManager(globalContext, workspaceContext).addDataReference(type, name, uri);
+
+    System.out.println(dataReference.type + " successfully created: " + dataReference.cloudId);
+    System.out.println("Workspace data reference successfully added: " + dataReference.name);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
@@ -31,13 +31,19 @@ public class CheckAccess implements Callable<Integer> {
         new WorkspaceManager(globalContext, workspaceContext).getDataReference(name);
 
     TerraUser currentTerraUser = globalContext.requireCurrentTerraUser();
-    boolean userHasAccess = dataReference.checkAccessForUser(currentTerraUser);
-    boolean petSaHasAccess = dataReference.checkAccessForPetSa(currentTerraUser);
+    boolean userHasAccess = dataReference.checkAccessForUser(currentTerraUser, workspaceContext);
+    boolean petSaHasAccess = dataReference.checkAccessForPetSa(currentTerraUser, workspaceContext);
 
     System.out.println(
-        "User DOES " + (userHasAccess ? "" : "NOT ") + "have access to this data reference.");
+        "User ("
+            + currentTerraUser.terraUserEmail
+            + ") DOES "
+            + (userHasAccess ? "" : "NOT ")
+            + "have access to this data reference.");
     System.out.println(
-        "User's pet service account DOES "
+        "User's pet SA in their proxy group ("
+            + currentTerraUser.terraProxyGroupEmail
+            + ") DOES "
             + (petSaHasAccess ? "" : "NOT ")
             + "have access to this data reference.");
 

--- a/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
@@ -1,0 +1,46 @@
+package bio.terra.cli.command.datarefs;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.TerraUser;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra data-refs check-access" command. */
+@CommandLine.Command(
+    name = "check-access",
+    description = "Check if you have access to a data reference.")
+public class CheckAccess implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the data reference, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource dataReference =
+        new WorkspaceManager(globalContext, workspaceContext).getDataReference(name);
+
+    TerraUser currentTerraUser = globalContext.requireCurrentTerraUser();
+    boolean userHasAccess = dataReference.checkAccessForUser(currentTerraUser);
+    boolean petSaHasAccess = dataReference.checkAccessForPetSa(currentTerraUser);
+
+    System.out.println(
+        "User DOES " + (userHasAccess ? "" : "NOT ") + "have access to this data reference.");
+    System.out.println(
+        "User's pet service account DOES "
+            + (petSaHasAccess ? "" : "NOT ")
+            + "have access to this data reference.");
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/datarefs/Delete.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Delete.java
@@ -27,8 +27,6 @@ public class Delete implements Callable<Integer> {
     CloudResource dataReference =
         new WorkspaceManager(globalContext, workspaceContext).deleteDataReference(name);
 
-    System.out.println(
-        dataReference.type + " reference successfully deleted: " + dataReference.cloudId);
     System.out.println("Workspace data reference successfully deleted: " + dataReference.name);
 
     return 0;

--- a/src/main/java/bio/terra/cli/command/datarefs/Delete.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Delete.java
@@ -1,0 +1,36 @@
+package bio.terra.cli.command.datarefs;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra data-refs delete" command. */
+@CommandLine.Command(name = "delete", description = "Delete an existing data reference.")
+public class Delete implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the data reference, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource dataReference =
+        new WorkspaceManager(globalContext, workspaceContext).deleteDataReference(name);
+
+    System.out.println(
+        dataReference.type + " reference successfully deleted: " + dataReference.cloudId);
+    System.out.println("Workspace data reference successfully deleted: " + dataReference.name);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/datarefs/List.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/List.java
@@ -1,0 +1,31 @@
+package bio.terra.cli.command.datarefs;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra data-refs list" command. */
+@CommandLine.Command(name = "list", description = "List all data references.")
+public class List implements Callable<Integer> {
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    java.util.List<CloudResource> dataReferences =
+        new WorkspaceManager(globalContext, workspaceContext).listDataReferences();
+
+    for (CloudResource dataReference : dataReferences) {
+      System.out.println(
+          dataReference.name + " (" + dataReference.type + "): " + dataReference.cloudId);
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/datarefs/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Resolve.java
@@ -1,0 +1,36 @@
+package bio.terra.cli.command.datarefs;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra data-refs resolve" command. */
+@CommandLine.Command(
+    name = "resolve",
+    description = "Resolve a data reference to its cloud id or path.")
+public class Resolve implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the data reference, scoped to the workspace.")
+  private String name;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+    CloudResource dataReference =
+        new WorkspaceManager(globalContext, workspaceContext).getDataReference(name);
+
+    System.out.println(dataReference.cloudId);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/CloudResource.java
+++ b/src/main/java/bio/terra/cli/context/CloudResource.java
@@ -46,8 +46,9 @@ public class CloudResource {
    * @param terraUser the user whose credentials we use to do the check
    * @return true if the user has access
    */
-  public boolean checkAccessForUser(TerraUser terraUser) {
-    return new GoogleCloudStorage(terraUser.userCredentials).checkAccess(cloudId);
+  public boolean checkAccessForUser(TerraUser terraUser, WorkspaceContext workspaceContext) {
+    return new GoogleCloudStorage(terraUser.userCredentials, workspaceContext.getGoogleProject())
+        .checkObjectsListAccess(cloudId);
   }
 
   /**
@@ -56,7 +57,8 @@ public class CloudResource {
    * @param terraUser the user whose pet SA credentials we use to do the check
    * @return true if the user's pet SA has access
    */
-  public boolean checkAccessForPetSa(TerraUser terraUser) {
-    return new GoogleCloudStorage(terraUser.petSACredentials).checkAccess(cloudId);
+  public boolean checkAccessForPetSa(TerraUser terraUser, WorkspaceContext workspaceContext) {
+    return new GoogleCloudStorage(terraUser.petSACredentials, workspaceContext.getGoogleProject())
+        .checkObjectsListAccess(cloudId);
   }
 }

--- a/src/main/java/bio/terra/cli/context/TerraUser.java
+++ b/src/main/java/bio/terra/cli/context/TerraUser.java
@@ -29,6 +29,11 @@ public class TerraUser {
   // user's email to populate this field.
   public String terraUserEmail;
 
+  // This field stores the proxy group email that Terra associates with this user. Permissions
+  // granted to the proxy group are transitively granted to the user and all of their pet SAs. The
+  // CLI queries SAM to populate this field.
+  public String terraProxyGroupEmail;
+
   @JsonIgnore public UserCredentials userCredentials;
   @JsonIgnore public ServiceAccountCredentials petSACredentials;
 

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -175,13 +175,25 @@ public class WorkspaceContext {
 
   /**
    * List all controlled cloud resources for the workspace. This is a utility wrapper around {@link
-   * #listControlledResources()} that filters for just the controlled ones.
+   * #listCloudResources()} that filters for just the controlled ones.
    *
    * @return list of controlled resources in the workspace
    */
   public List<CloudResource> listControlledResources() {
     return cloudResources.values().stream()
-        .filter(dataReference -> dataReference.isControlled)
+        .filter(cloudResource -> cloudResource.isControlled)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * List all data references for this workspace. This is a utility wrapper around {@link
+   * #listCloudResources()} that filters for just the data references.
+   *
+   * @return list of data references in the workspace
+   */
+  public List<CloudResource> listDataReferences() {
+    return cloudResources.values().stream()
+        .filter(cloudResource -> cloudResource.type.isDataReference)
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -303,6 +303,8 @@ public class WorkspaceManager {
    *
    * @param referenceType type of reference to add
    * @param referenceName name of reference to add
+   * @param cloudId unique identifier for this resource in the cloud (e.g. bucket uri, bq dataset
+   *     id)
    * @return the data reference that was added
    */
   public CloudResource addDataReference(

--- a/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
@@ -14,9 +14,6 @@ import org.slf4j.LoggerFactory;
 public class GoogleCloudStorage {
   private static final Logger logger = LoggerFactory.getLogger(GoogleCloudStorage.class);
 
-  // the Terra user whose credentials will be used to call authenticated requests
-  private final GoogleCredentials googleCredentials;
-
   // the google project id of the workspace
   private final String googleProjectId;
 
@@ -33,9 +30,8 @@ public class GoogleCloudStorage {
    * @param googleProjectId scope Storage requests to this project
    */
   public GoogleCloudStorage(GoogleCredentials googleCredentials, String googleProjectId) {
-    this.googleCredentials = googleCredentials;
     this.googleProjectId = googleProjectId;
-    this.storageClient = buildClientForTerraUser();
+    this.storageClient = buildClient(googleCredentials);
   }
 
   /**
@@ -43,7 +39,7 @@ public class GoogleCloudStorage {
    *
    * @return the GCS client object
    */
-  private Storage buildClientForTerraUser() {
+  private Storage buildClient(GoogleCredentials googleCredentials) {
     StorageOptions.Builder storageOptions = StorageOptions.newBuilder();
     if (googleProjectId != null) {
       storageOptions.setProjectId(googleProjectId);

--- a/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
@@ -1,9 +1,11 @@
 package bio.terra.cli.service.utils;
 
-import bio.terra.cli.context.TerraUser;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,37 +15,56 @@ public class GoogleCloudStorage {
   private static final Logger logger = LoggerFactory.getLogger(GoogleCloudStorage.class);
 
   // the Terra user whose credentials will be used to call authenticated requests
-  private final TerraUser terraUser;
+  private final GoogleCredentials googleCredentials;
 
   // the google project id of the workspace
   private final String googleProjectId;
 
   // the client object used for talking to Google Cloud Storage
-  private Storage storageClient;
+  private final Storage storageClient;
 
   /**
-   * Constructor for class that talks to Google Cloud Storage. The user must be authenticated.
-   * Methods in this class will use its credentials to call authenticated endpoints.
+   * Constructor for class that talks to Google Cloud Storage. Methods in this class will use its
+   * credentials to call authenticated endpoints.
    *
-   * @param terraUser the Terra user whose credentials will be used to call authenticated endpoints
+   * <p>This constructor does not scope Storage requests to a single project.
+   *
+   * @param googleCredentials the credentials that will be used to call authenticated endpoints
    */
-  public GoogleCloudStorage(TerraUser terraUser, String googleProjectId) {
-    this.terraUser = terraUser;
-    this.googleProjectId = googleProjectId;
-    this.storageClient = null;
-    buildClientForTerraUser();
+  public GoogleCloudStorage(GoogleCredentials googleCredentials) {
+    this(googleCredentials, null);
   }
 
-  /** Build the GCS client object for the given Terra user. */
-  private void buildClientForTerraUser() {
+  /**
+   * Constructor for class that talks to Google Cloud Storage. Methods in this class will use the
+   * given credentials to call authenticated endpoints.
+   *
+   * <p>This constructor scopes Storage requests to the given project.
+   *
+   * @param googleCredentials the credentials that will be used to call authenticated endpoints
+   * @param googleProjectId scope Storage requests to this project
+   */
+  public GoogleCloudStorage(GoogleCredentials googleCredentials, String googleProjectId) {
+    this.googleCredentials = googleCredentials;
+    this.googleProjectId = googleProjectId;
+    this.storageClient = buildClientForTerraUser();
+  }
+
+  /**
+   * Build the GCS client object for the given credentials and project.
+   *
+   * @return the GCS client object
+   */
+  private Storage buildClientForTerraUser() {
     StorageOptions.Builder storageOptions = StorageOptions.newBuilder();
-    storageOptions.setProjectId(googleProjectId);
+    if (googleProjectId != null) {
+      storageOptions.setProjectId(googleProjectId);
+    }
 
-    // fetch the user access token
-    // this method call will attempt to refresh the token if it's already expired
-    storageOptions.setCredentials(terraUser.userCredentials);
+    // set the credentials to use when talking to GCS
+    storageOptions.setCredentials(googleCredentials);
 
-    this.storageClient = storageOptions.build().getService();
+    return storageOptions.build().getService();
   }
 
   /**
@@ -72,6 +93,27 @@ public class GoogleCloudStorage {
     boolean deleted = storageClient.delete(bucketName);
     if (!deleted) {
       throw new RuntimeException("Bucket deletion failed.");
+    }
+  }
+
+  /**
+   * Check whether we have access to the bucket information.
+   *
+   * @param bucketUri uri of the bucket (gs://...)
+   * @return true if access is allowed
+   */
+  public boolean checkAccess(String bucketUri) {
+    try {
+      String bucketName = bucketUri.replaceFirst("^gs://", "");
+      storageClient.get(bucketName, Storage.BucketGetOption.fields());
+      return true;
+    } catch (StorageException storageEx) {
+      logger.error("storage exception http code = {}", storageEx.getCode(), storageEx);
+      if (storageEx.getCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND
+          || storageEx.getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
+        return false;
+      }
+      throw storageEx;
     }
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleCloudStorage.java
@@ -24,18 +24,6 @@ public class GoogleCloudStorage {
   private final Storage storageClient;
 
   /**
-   * Constructor for class that talks to Google Cloud Storage. Methods in this class will use its
-   * credentials to call authenticated endpoints.
-   *
-   * <p>This constructor does not scope Storage requests to a single project.
-   *
-   * @param googleCredentials the credentials that will be used to call authenticated endpoints
-   */
-  public GoogleCloudStorage(GoogleCredentials googleCredentials) {
-    this(googleCredentials, null);
-  }
-
-  /**
    * Constructor for class that talks to Google Cloud Storage. Methods in this class will use the
    * given credentials to call authenticated endpoints.
    *
@@ -97,15 +85,23 @@ public class GoogleCloudStorage {
   }
 
   /**
-   * Check whether we have access to the bucket information.
+   * Check whether we have permission to list objects in the bucket.
+   *
+   * <p>List access is included in the Storage Object Viewer and Storage Legacy Bucket Reader. It is
+   * NOT included in the Storage Legacy Object Reader.
    *
    * @param bucketUri uri of the bucket (gs://...)
    * @return true if access is allowed
    */
-  public boolean checkAccess(String bucketUri) {
+  public boolean checkObjectsListAccess(String bucketUri) {
     try {
       String bucketName = bucketUri.replaceFirst("^gs://", "");
-      storageClient.get(bucketName, Storage.BucketGetOption.fields());
+
+      // try listing objects in the bucket
+      storageClient.list(
+          bucketName,
+          Storage.BlobListOption.userProject(googleProjectId),
+          Storage.BlobListOption.fields());
       return true;
     } catch (StorageException storageEx) {
       logger.error("storage exception http code = {}", storageEx.getCode(), storageEx);

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 import org.broadinstitute.dsde.workbench.client.sam.ApiException;
+import org.broadinstitute.dsde.workbench.client.sam.api.GoogleApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.GroupApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.ResourcesApi;
 import org.broadinstitute.dsde.workbench.client.sam.api.StatusApi;
@@ -163,6 +164,25 @@ public class SamService {
       } catch (ApiException | InterruptedException secondEx) {
         throw new RuntimeException("Error reading user information from SAM.", secondEx);
       }
+    } finally {
+      closeConnectionPool();
+    }
+  }
+
+  /**
+   * Call the SAM "/api/google/v1/user/proxyGroup/{email}" endpoint to get the email for the current
+   * user's proxy group.
+   *
+   * <p>Update the Terra User object with the proxy group email.
+   */
+  public void getProxyGroupEmail() {
+    GoogleApi googleApi = new GoogleApi(apiClient);
+    try {
+      terraUser.terraProxyGroupEmail =
+          HttpUtils.callWithRetries(
+              () -> googleApi.getProxyGroup(terraUser.terraUserEmail), SamService::isRetryable);
+    } catch (ApiException | InterruptedException ex) {
+      throw new RuntimeException("Error getting proxy group email from SAM.", ex);
     } finally {
       closeConnectionPool();
     }


### PR DESCRIPTION
- Added `terra data-refs` commands: `list`, `add`, `delete`, `check-access`, `resolve`.
- Included the user's proxy group email in the TerraUser object and the output of the `terra auth status` command. This is so that it's easier to look up the email that you need to share a bucket with.
```
terra auth status
Current Terra user: mmdevverily@gmail.com
Current Terra user's proxy group: PROXY_110017243614237806241@dev.test.firecloud.org
LOGGED IN
```
- The `check-access` command (currently only for buckets) checks for `objects.list` permission. I'm not sure if this is the right thing long-term -- perhaps we need flags for different access checks (e.g. `terra check-access --writer`)? -- but this is just a guess at what might be useful.