### PR TITLE
PF-527 Change the notebooks default image family

### DIFF
--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -13,7 +13,8 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks create" command. */
 @CommandLine.Command(
     name = "create",
-    description = "Create a new AI Notebook instance within your workspace.")
+    description = "Create a new AI Notebook instance within your workspace.",
+    showDefaultValues = true)
 public class Create implements Callable<Integer> {
 
   @CommandLine.Parameters(
@@ -28,7 +29,7 @@ public class Create implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -45,7 +45,7 @@ public class Create implements Callable<Integer> {
 
   @CommandLine.Option(
       names = "--vm-image-family",
-      defaultValue = "tf-latest-gpu",
+      defaultValue = "r-latest-cpu-experimental",
       description =
           "Use this VM image family to find the image; the newest image in this family will be used.")
   private String vmImageFamily;

--- a/src/main/java/bio/terra/cli/command/notebooks/Delete.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Delete.java
@@ -12,7 +12,8 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks delete" command. */
 @CommandLine.Command(
     name = "delete",
-    description = "Delete an AI Notebook instance within your workspace.")
+    description = "Delete an AI Notebook instance within your workspace.",
+    showDefaultValues = true)
 public class Delete implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
@@ -21,7 +22,7 @@ public class Delete implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @Override

--- a/src/main/java/bio/terra/cli/command/notebooks/Describe.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Describe.java
@@ -12,7 +12,8 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks describe" command. */
 @CommandLine.Command(
     name = "describe",
-    description = "Describe an AI Notebook instance within your workspace.")
+    description = "Describe an AI Notebook instance within your workspace.",
+    showDefaultValues = true)
 public class Describe implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
@@ -21,7 +22,7 @@ public class Describe implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @Override

--- a/src/main/java/bio/terra/cli/command/notebooks/List.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/List.java
@@ -12,12 +12,13 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks describe" command. */
 @CommandLine.Command(
     name = "list",
-    description = "List the AI Notebook instance within your workspace for the specified location.")
+    description = "List the AI Notebook instance within your workspace for the specified location.",
+    showDefaultValues = true)
 public class List implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @Override

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -12,7 +12,8 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks start" command. */
 @CommandLine.Command(
     name = "start",
-    description = "Start a stopped AI Notebook instance within your workspace.")
+    description = "Start a stopped AI Notebook instance within your workspace.",
+    showDefaultValues = true)
 public class Start implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
@@ -21,7 +22,7 @@ public class Start implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @Override

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -12,7 +12,8 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra notebooks stop" command. */
 @CommandLine.Command(
     name = "stop",
-    description = "Stop a running AI Notebook instance within your workspace.")
+    description = "Stop a running AI Notebook instance within your workspace.",
+    showDefaultValues = true)
 public class Stop implements Callable<Integer> {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
@@ -21,7 +22,7 @@ public class Stop implements Callable<Integer> {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance, by default '${DEFAULT-VALUE}'.")
+      description = "The Google Cloud location of the instance.")
   private String location;
 
   @Override


### PR DESCRIPTION
Per solutions team, the r experimental image that has Java installed is a better default choice.
Later we can look at finding an image that isn't experimental, but this image at least will allow installation of the terra CLI out of the box on the notebook instance.

Add `showDefaultValues` to all notebooks commands.