### PR TITLE
PF-527 Add the workspace id to the Notebooks instance metadata.

### DIFF
--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -79,7 +79,9 @@ public class Create implements Callable<Integer> {
             // The metadata installed-extensions causes the AI Notebooks setup to install some
             // Google JupyterLab extensions. Found by manual inspection of what is created with the
             // cloud console GUI.
-            + "--metadata=^:^installed-extensions=jupyterlab_bigquery-latest.tar.gz,jupyterlab_gcsfilebrowser-latest.tar.gz,jupyterlab_gcpscheduler-latest.tar.gz";
+            + "--metadata=^:^installed-extensions=jupyterlab_bigquery-latest.tar.gz,jupyterlab_gcsfilebrowser-latest.tar.gz,jupyterlab_gcpscheduler-latest.tar.gz"
+            // Also set the id of this workspace as metadata on the VM instance.
+            + ":terra-workspace-id=$TERRA_WORKSPACE_ID";
     Map<String, String> envVars = new HashMap<>();
     envVars.put("INSTANCE_NAME", instanceName);
     envVars.put("LOCATION", location);
@@ -96,6 +98,7 @@ public class Create implements Callable<Integer> {
     // Like 'network', 'subnetwork is the name of the subnetwork created by the Buffer Service in
     // each zone.
     envVars.put("SUBNET", "projects/" + projectId + "/regions/" + zone + "/subnetworks/subnetwork");
+    envVars.put("TERRA_WORKSPACE_ID", workspaceContext.getWorkspaceId().toString());
 
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
 


### PR DESCRIPTION
Set the terra workspace id as metadata on created Notebooks instance VM metadata.
While this isn't a full solution for auto populating useful Terra variables for a seamless notebooks experience, this does make the workspace id accessible programmatically from the VM, which we can use for further integration.
See https://cloud.google.com/compute/docs/storing-retrieving-metadata