### PR TITLE
PF-563: Clear workspace context file on delete.

### DIFF
--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -84,10 +84,17 @@ public class WorkspaceContext {
    */
   public void updateWorkspace(WorkspaceDescription terraWorkspaceModel) {
     logger.debug(
-        "Updating workspace from {} to {}.",
-        getWorkspaceId(),
-        terraWorkspaceModel == null ? null : terraWorkspaceModel.getId());
+        "Updating workspace from {} to {}.", getWorkspaceId(), terraWorkspaceModel.getId());
     this.terraWorkspaceModel = terraWorkspaceModel;
+
+    writeToFile();
+  }
+
+  /** Delete the current Terra workspace context. Persists on disk. */
+  public void deleteWorkspace() {
+    logger.debug("Deleting workspace {}", getWorkspaceId());
+    this.terraWorkspaceModel = null;
+    this.cloudResources = null;
 
     writeToFile();
   }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -103,7 +103,7 @@ public class WorkspaceManager {
     // unset the workspace in the current context
     // note that this state is persisted to disk. it will be useful for code called in the same or a
     // later CLI command/process
-    workspaceContext.updateWorkspace(null);
+    workspaceContext.deleteWorkspace();
 
     return workspace.getId();
   }


### PR DESCRIPTION
Fixed a bug where the list of cloud resources were not being cleared by `terra workspace delete`.

Note that the CLI is not yet calling WSM to manage controlled resources or data references. This code change is to the temporary code that manages these things locally.