### PR TITLE
PF-569: Bump version on merge to main with GH action.

### DIFF
--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+  pull_request:
+    branches: [ '**' ]
 jobs:
   bump-version-publish-release:
     runs-on: ubuntu-latest
@@ -20,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: ^version
+          VERSION_LINE_MATCH: "^version\ "
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: "^version\ "
+          VERSION_LINE_MATCH: ^version\
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - main
+      - main, mm-PF-569-add-bumper-gha
   pull_request:
     branches: [ '**' ]
 jobs:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout current code
         uses: actions/checkout@master
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
       - name: Bump tag and build version
         uses: databiosphere/github-actions/actions/bumper@v0.0.3
         env:
@@ -27,5 +27,5 @@ jobs:
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           RELEASE_VERSION: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: ^version\
+          VERSION_LINE_MATCH: ^version
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches: [ '**' ]
 
 jobs:
   bump-version-publish-release:

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Bump tag and build version
         uses: databiosphere/github-actions/actions/bumper@v0.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
           VERSION_LINE_MATCH: ^version

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch: {}
   push:
     branches:
-      - main, mm-PF-569-add-bumper-gha
-  pull_request:
-    branches: [ '**' ]
+      - main
+
 jobs:
   bump-version-publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: ^version\ =
+          VERSION_LINE_MATCH: ^version
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: ^version
+          VERSION_LINE_MATCH: ^version\ 
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -1,0 +1,31 @@
+name: Bump version and publish release
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  bump-version-publish-release:
+    runs-on: ubuntu-latest
+    if: "!contains( github.event.sender.login, 'broadbot')"
+    steps:
+      - name: Checkout current code
+        uses: actions/checkout@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump tag and build version
+        uses: databiosphere/github-actions/actions/bumper@v0.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCHES: main
+          VERSION_FILE_PATH: build.gradle
+          VERSION_LINE_MATCH: ^version
+      - name: Publish a release
+        run: |
+          echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -21,7 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
           VERSION_FILE_PATH: build.gradle
-          VERSION_LINE_MATCH: ^version\ 
+          VERSION_LINE_MATCH: ^version\ =
       - name: Publish a release
         run: |
           echo "TODO (PF-570): ./tools/publish-release.sh $RELEASE_VERSION true"


### PR DESCRIPTION
- Added a GH action to add a GH tag and bump the version string in `build.gradle` on each merge to the `main` branch.
- The tag bumper action uses the BroadBot GH token, added to this repo by DevOps.
- Left a placeholder step for calling the `publish-release.sh` script in a future PR (needs secrets added to GH repo).