### PR TITLE
PF-533: List workspaces command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,56 @@ terra workspace create
 terra status
 ```
 
-If you wanted to use an existing Terra workspace, use the mount command instead of create.
+List all workspaces the user has read access to.
+```
+terra workspace list
+```
+
+If you want to use an existing Terra workspace, use the mount command instead of create.
 ```
 terra workspace mount eb0753f9-5c45-46b3-b3b4-80b4c7bea248
 ```
+
+Run a Nextflow hello world example.
+```
+terra nextflow run hello
+```
+
+Run an [example Nextflow workflow](https://github.com/nextflow-io/rnaseq-nf).
+This is the same example workflow used in the [GCLS tutorial](https://cloud.google.com/life-sciences/docs/tutorials/nextflow).
+- Fetch the workflow code
+    ```
+    git clone https://github.com/nextflow-io/rnaseq-nf.git
+    cd rnaseq-nf
+    git checkout v2.0
+    cd ..
+    ```
+- Create a bucket in the workspace for Nextflow to use.
+    ```
+    terra resources create --name=mybucket --type=bucket
+    ```
+- Update the `gls` section of the `nextflow.config` file to point to the workspace project and the bucket we just created.
+    ```
+      gls {
+          params.transcriptome = 'gs://rnaseq-nf/data/ggal/transcript.fa'
+          params.reads = 'gs://rnaseq-nf/data/ggal/gut_{1,2}.fq'
+          params.multiqc = 'gs://rnaseq-nf/multiqc'
+          process.executor = 'google-lifesciences'
+          process.container = 'nextflow/rnaseq-nf:latest'
+          workDir = "$TERRA_MYBUCKET/scratch"
+          google.location = 'europe-west2'
+          google.region  = 'europe-west1'
+          google.project = "$GOOGLE_CLOUD_PROJECT"
+      }
+    ```
+- Do a dry-run to confirm the config is set correctly.
+    ```
+    ./terra nextflow config rnaseq-nf/main.nf -profile gls
+    ```
+- Kick off the workflow. (This takes about 10 minutes to complete.)
+    ```
+    ./terra nextflow run rnaseq-nf/main.nf -profile gls
+    ```
 
 Call the Gcloud CLI tools within the workspace context.
 This means the commands are executed against the workspace project and as the current user.
@@ -140,13 +186,6 @@ This means the commands are executed against the workspace project and as the cu
 terra gcloud config get-value project
 terra gsutil ls
 terra bq version
-```
-
-Enable the Nextflow tool. This will create a sub-directory called `nextflow`.
-Run a Nextflow hello world example.
-```
-terra app enable nextflow
-terra nextflow run hello
 ```
 
 See the list of supported (external) tools.
@@ -246,6 +285,7 @@ The server is part of the global context, so this value applies across workspace
 Usage: terra workspace [COMMAND]
 Setup a Terra workspace.
 Commands:
+  list         List all workspaces the current user can access.
   create       Create a new workspace.
   mount        Mount an existing workspace to the current directory.
   delete       Delete an existing workspace.
@@ -422,21 +462,6 @@ profiles {
 
   }
 }
-```
-
-Example commands for creating a new controlled bucket resource and then running a Nextflow workflow using
-this bucket as the working directory.
-```
-> terra resources create --name=mybucket --type=bucket
-bucket successfully created: gs://terra-wsm-dev-e3d8e1f5-mybucket
-Workspace resource successfully added: mybucket
-
-> terra nextflow run rnaseq-nf/main.nf -profile gls
-  Setting up Terra app environment...
-  Activated service account credentials for: [pet-110017243614237806241@terra-wsm-dev-e3d8e1f5.iam.gserviceaccount.com]
-  Updated property [core/project].
-  Done setting up Terra app environment...
-[...Nextflow output...]
 ```
 
 #### See all environment variables

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ if (hasProperty('buildScan')) {
 }
 
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.9.0'
+version = '0.16.0'
 group = 'terra-cli'
 sourceCompatibility = JavaVersion.VERSION_11
 

--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -125,7 +125,7 @@ public class DockerAppsRunner {
    *
    * @param command the full string command to execute in a bash shell (bash -c ..cmd..)
    * @param envVars a mapping of environment variable names to values
-   * @throws RuntimeException if an environment variable or bind mount used by the terra_init script
+   * @throws SystemException if an environment variable or bind mount used by the terra_init script
    *     overlaps or conflicts with one passed into this method
    */
   public void runToolCommand(String command, Map<String, String> envVars) {
@@ -197,7 +197,7 @@ public class DockerAppsRunner {
    * @param command the full string command to execute in a bash shell (bash -c ..cmd..)
    * @param envVars a mapping of environment variable names to values
    * @param bindMounts a mapping of container mount point to the local directory being mounted
-   * @throws RuntimeException if an environment variable or bind mount used by the terra_init script
+   * @throws SystemException if an environment variable or bind mount used by the terra_init script
    *     overlaps or conflicts with one passed into this method
    */
   private String startDockerContainerWithTerraInit(
@@ -252,7 +252,7 @@ public class DockerAppsRunner {
    * @param workingDir the directory where the commmand will be executed
    * @param envVars a mapping of environment variable names to values
    * @param bindMounts a mapping of container mount point to the local directory being mounted
-   * @throws RuntimeException if the local directory does not exist or is not a directory
+   * @throws SystemException if the local directory does not exist or is not a directory
    */
   private String startDockerContainer(
       String command, String workingDir, Map<String, String> envVars, Map<Path, Path> bindMounts) {

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command;
 import bio.terra.cli.command.workspace.AddUser;
 import bio.terra.cli.command.workspace.Create;
 import bio.terra.cli.command.workspace.Delete;
+import bio.terra.cli.command.workspace.List;
 import bio.terra.cli.command.workspace.ListUsers;
 import bio.terra.cli.command.workspace.Mount;
 import bio.terra.cli.command.workspace.RemoveUser;
@@ -16,6 +17,7 @@ import picocli.CommandLine.Command;
     name = "workspace",
     description = "Setup a Terra workspace.",
     subcommands = {
+      List.class,
       Create.class,
       Mount.class,
       Delete.class,

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -24,6 +24,13 @@ public class List implements Callable<Integer> {
           "The offset to use when listing workspaces. (Zero means to start from the beginning.)")
   private int offset;
 
+  @CommandLine.Option(
+      names = "--limit",
+      required = false,
+      defaultValue = "30",
+      description = "The maximum number of workspaces to return.")
+  private int limit;
+
   @Override
   public Integer call() {
     GlobalContext globalContext = GlobalContext.readFromFile();
@@ -33,7 +40,7 @@ public class List implements Callable<Integer> {
         new AuthenticationManager(globalContext, workspaceContext);
     authenticationManager.loginTerraUser();
     java.util.List<WorkspaceDescription> workspaces =
-        new WorkspaceManager(globalContext, workspaceContext).listWorkspaces(offset);
+        new WorkspaceManager(globalContext, workspaceContext).listWorkspaces(offset, limit);
 
     for (WorkspaceDescription workspace : workspaces) {
       String prefix =

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -1,0 +1,48 @@
+package bio.terra.cli.command.workspace;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.service.WorkspaceManager;
+import bio.terra.workspace.model.WorkspaceDescription;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra workspace list" command. */
+@Command(
+    name = "list",
+    description = "List all workspaces the current user can access.",
+    showDefaultValues = true)
+public class List implements Callable<Integer> {
+
+  @CommandLine.Option(
+      names = "--offset",
+      required = false,
+      defaultValue = "0",
+      description =
+          "The offset to use when listing workspaces. (Zero means to start from the beginning.)")
+  private int offset;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+
+    AuthenticationManager authenticationManager =
+        new AuthenticationManager(globalContext, workspaceContext);
+    authenticationManager.loginTerraUser();
+    java.util.List<WorkspaceDescription> workspaces =
+        new WorkspaceManager(globalContext, workspaceContext).listWorkspaces(offset);
+
+    for (WorkspaceDescription workspace : workspaces) {
+      String prefix =
+          (!workspaceContext.isEmpty()
+                  && workspaceContext.getWorkspaceId().equals(workspace.getId()))
+              ? " * "
+              : "   ";
+      System.out.println(prefix + workspace.getId());
+    }
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -29,6 +29,22 @@ public class WorkspaceManager {
     this.workspaceContext = workspaceContext;
   }
 
+  /**
+   * List all workspaces that a user has read access to.
+   *
+   * @param offset the offset to use when listing workspaces (zero to start from the beginning)
+   * @return list of workspaces
+   */
+  public List<WorkspaceDescription> listWorkspaces(int offset) {
+    // check that there is a current user, we will use their credentials to communicate with WSM
+    TerraUser currentUser = globalContext.requireCurrentTerraUser();
+
+    // fetch the list of workspaces from WSM
+    return new WorkspaceManagerService(globalContext.server, currentUser)
+        .listWorkspaces(offset)
+        .getWorkspaces();
+  }
+
   /** Create a new workspace. */
   public void createWorkspace() {
     // check that there is no existing workspace already mounted
@@ -53,8 +69,8 @@ public class WorkspaceManager {
   /**
    * Fetch an existing workspace and mount it to the current directory.
    *
-   * @throws RuntimeException if there is already a different workspace mounted to the current
-   *     directory
+   * @throws UserActionableException if there is already a different workspace mounted to the
+   *     current directory
    */
   public void mountWorkspace(String workspaceId) {
     // check that the workspace id is a valid UUID
@@ -86,7 +102,7 @@ public class WorkspaceManager {
    * Delete the workspace that is mounted to the current directory.
    *
    * @return the deleted workspace id
-   * @throws RuntimeException if there is no workspace currently mounted
+   * @throws UserActionableException if there is no workspace currently mounted
    */
   public UUID deleteWorkspace() {
     // check that there is a workspace currently mounted
@@ -115,7 +131,7 @@ public class WorkspaceManager {
    *
    * @param userEmail the user to add
    * @param iamRole the role to assign the user
-   * @throws RuntimeException if there is no workspace currently mounted
+   * @throws UserActionableException if there is no workspace currently mounted
    */
   public void addUserToWorkspace(String userEmail, IamRole iamRole) {
     // check that there is a workspace currently mounted
@@ -140,7 +156,7 @@ public class WorkspaceManager {
    *
    * @param userEmail the user to remove
    * @param iamRole the role to remove from the user
-   * @throws RuntimeException if there is no workspace currently mounted
+   * @throws UserActionableException if there is no workspace currently mounted
    */
   public void removeUserFromWorkspace(String userEmail, IamRole iamRole) {
     // check that there is a workspace currently mounted
@@ -181,7 +197,7 @@ public class WorkspaceManager {
    *
    * @param resourceName name of resource to lookup
    * @return the cloud resource object
-   * @throws RuntimeException if the resource is not controlled (e.g. external bucket)
+   * @throws UserActionableException if the resource is not controlled (e.g. external bucket)
    */
   public CloudResource getControlledResource(String resourceName) {
     // TODO: change this method to call WSM controlled resource endpoints once they're ready
@@ -282,7 +298,7 @@ public class WorkspaceManager {
    *
    * @param referenceName name of reference to lookup
    * @return the data reference object
-   * @throws RuntimeException if the resource is not a data reference (e.g. VM)
+   * @throws UserActionableException if the resource is not a data reference (e.g. VM)
    */
   public CloudResource getDataReference(String referenceName) {
     // TODO: change this method to call WSM data reference endpoints once they're ready

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -33,15 +33,16 @@ public class WorkspaceManager {
    * List all workspaces that a user has read access to.
    *
    * @param offset the offset to use when listing workspaces (zero to start from the beginning)
+   * @param limit the maximum number of workspaces to return
    * @return list of workspaces
    */
-  public List<WorkspaceDescription> listWorkspaces(int offset) {
+  public List<WorkspaceDescription> listWorkspaces(int offset, int limit) {
     // check that there is a current user, we will use their credentials to communicate with WSM
     TerraUser currentUser = globalContext.requireCurrentTerraUser();
 
     // fetch the list of workspaces from WSM
     return new WorkspaceManagerService(globalContext.server, currentUser)
-        .listWorkspaces(offset)
+        .listWorkspaces(offset, limit)
         .getWorkspaces();
   }
 

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -41,9 +41,6 @@ public class WorkspaceManagerService {
   // the client object used for talking to WSM
   private final ApiClient apiClient;
 
-  // the maximum number of workspaces to fetch at once when listing all workspaces a user can read
-  private static final int LIST_WORKSPACES_LIMIT = 30;
-
   /**
    * Constructor for class that talks to the Workspace Manager service. The user must be
    * authenticated. Methods in this class will use its credentials to call authenticated endpoints.
@@ -119,12 +116,13 @@ public class WorkspaceManagerService {
    * can read.
    *
    * @param offset the offset to use when listing workspaces (zero to start from the beginning)
+   * @param limit the maximum number of workspaces to return
    * @return the Workspace Manager workspsace list object
    */
-  public WorkspaceDescriptionList listWorkspaces(int offset) {
+  public WorkspaceDescriptionList listWorkspaces(int offset, int limit) {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
-      return workspaceApi.listWorkspaces(offset, LIST_WORKSPACES_LIMIT);
+      return workspaceApi.listWorkspaces(offset, limit);
     } catch (ApiException ex) {
       throw new SystemException("Error fetching list of workspaces", ex);
     }


### PR DESCRIPTION
- Added a `terra workspace list` command to list all workspaces the user has read access to.
  * If there is a workspace already mounted, it starts this one.
  * Optional `--offset` flag for users with many workspaces. Default is to start from the beginning. Each call fetches up to 30 workspaces.
- Updated the README to include the new command, and notes from yesterday's NF demo.
- Cleaned up some incorrect `@throws` Javadocs after the recent exception handling refactoring.