### PR TITLE
PF-542: Config command for logging level

### DIFF
--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -65,20 +65,20 @@ public class DockerAppsRunner {
   /**
    * Update the Docker image property of the global context.
    *
+   * <p>Logs a warning if the Docker image is not found locally (i.e. hasn't yet been downloaded
+   * with `docker pull`)
+   *
    * @param imageId id or tag of the image
-   * @return true if the Docker image property was updated, false otherwise
    */
-  public boolean updateImageId(String imageId) {
+  public void updateImageId(String imageId) {
     // check if image exists
     try {
       dockerClient.inspectImageCmd(imageId).exec();
     } catch (NotFoundException nfEx) {
-      logger.error("Image not found: {}", imageId, nfEx);
-      return false;
+      logger.warn("Image not found: {}", imageId, nfEx);
     }
 
     globalContext.updateDockerImageId(imageId);
-    return true;
   }
 
   // ====================================================

--- a/src/main/java/bio/terra/cli/command/config/GetValue.java
+++ b/src/main/java/bio/terra/cli/command/config/GetValue.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.config;
 
 import bio.terra.cli.command.config.getvalue.Browser;
 import bio.terra.cli.command.config.getvalue.Image;
+import bio.terra.cli.command.config.getvalue.Logging;
 import picocli.CommandLine.Command;
 
 /**
@@ -11,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "get-value",
     description = "Get a configuration property value.",
-    subcommands = {Browser.class, Image.class})
+    subcommands = {Browser.class, Image.class, Logging.class})
 public class GetValue {}

--- a/src/main/java/bio/terra/cli/command/config/List.java
+++ b/src/main/java/bio/terra/cli/command/config/List.java
@@ -16,6 +16,11 @@ public class List implements Callable<Integer> {
 
     System.out.println("[browser] browser launch for login = " + globalContext.browserLaunchOption);
     System.out.println("[image] docker image id = " + globalContext.dockerImageId);
+    System.out.println(
+        "[logging] console logging level = "
+            + globalContext.consoleLoggingLevel
+            + ", file logging level = "
+            + globalContext.fileLoggingLevel);
 
     return 0;
   }

--- a/src/main/java/bio/terra/cli/command/config/Set.java
+++ b/src/main/java/bio/terra/cli/command/config/Set.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.config;
 
 import bio.terra.cli.command.config.set.Browser;
 import bio.terra.cli.command.config.set.Image;
+import bio.terra.cli.command.config.set.Logging;
 import picocli.CommandLine.Command;
 
 /**
@@ -11,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "set",
     description = "Set a configuration property value.",
-    subcommands = {Browser.class, Image.class})
+    subcommands = {Browser.class, Image.class, Logging.class})
 public class Set {}

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
@@ -18,7 +18,9 @@ public class Logging implements Callable<Integer> {
         "[console] logging level for printing directly to the terminal = "
             + globalContext.consoleLoggingLevel);
     System.out.println(
-        "[file] logging level for writing to files in $HOME/.terra/logs/ = "
+        "[file] logging level for writing to files in "
+            + GlobalContext.getLogFile().getParent()
+            + " = "
             + globalContext.fileLoggingLevel);
 
     return 0;

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
@@ -1,0 +1,26 @@
+package bio.terra.cli.command.config.getvalue;
+
+import bio.terra.cli.context.GlobalContext;
+import java.util.concurrent.Callable;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the fourth-level "terra config get-value logging" command. */
+@Command(name = "logging", description = "Get the logging level.")
+public class Logging implements Callable<Integer> {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Logging.class);
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+
+    System.out.println(
+        "[console] logging level for printing directly to the terminal = "
+            + globalContext.consoleLoggingLevel);
+    System.out.println(
+        "[file] logging level for writing to files in $HOME/.terra/logs/ = "
+            + globalContext.fileLoggingLevel);
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -1,0 +1,51 @@
+package bio.terra.cli.command.config.set;
+
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.utils.Logger;
+import java.util.concurrent.Callable;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the fourth-level "terra config set logging" command. */
+@Command(name = "logging", description = "Set the logging level.")
+public class Logging implements Callable<Integer> {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Logging.class);
+
+  @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+  Logging.LogLevelArgGroup argGroup;
+
+  static class LogLevelArgGroup {
+    @CommandLine.Option(names = "--console", description = "console logging level")
+    private boolean console;
+
+    @CommandLine.Option(names = "--file", description = "file logging level")
+    private boolean file;
+  }
+
+  @CommandLine.Option(
+      names = "--level",
+      required = true,
+      description = "logging level: ${COMPLETION-CANDIDATES}")
+  private Logger.LogLevel level;
+
+  @Override
+  public Integer call() {
+    GlobalContext globalContext = GlobalContext.readFromFile();
+
+    // note that this new log level will take effect on the NEXT command.
+    // for the log level to take effect for the rest of THIS command, we'd need to re-initialize the
+    // logger(s) (e.g. by calling Logger.setupLogging or some subset of that method). there's
+    // currently no reason to update the log level in the same command because this command exits
+    // immediately after updating the global context, so keeping it simple for now.
+    if (argGroup.console) {
+      globalContext.updateConsoleLoggingLevel(level);
+      System.out.println("CONSOLE logging level set to: " + level);
+    } else {
+      globalContext.updateFileLoggingLevel(level);
+      System.out.println("FILE logging level set to: " + level);
+    }
+
+    return 0;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -37,7 +37,6 @@ public class GlobalContext {
   // global apps context = docker image id or tag
   public String dockerImageId;
 
-  // TODO (PF-542): add a config command to allow modifying these levels without re-compiling
   // global logging context = log levels for file and stdout
   public LogLevel fileLoggingLevel = LogLevel.INFO;
   public LogLevel consoleLoggingLevel = LogLevel.OFF;

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -156,6 +156,34 @@ public class GlobalContext {
     writeToFile();
   }
 
+  /**
+   * Setter for the console logging level. Persists on disk.
+   *
+   * @param consoleLoggingLevel new value for the console logging level
+   */
+  public void updateConsoleLoggingLevel(LogLevel consoleLoggingLevel) {
+    logger.info(
+        "Updating console logging level from {} to {}.",
+        this.consoleLoggingLevel,
+        consoleLoggingLevel);
+    this.consoleLoggingLevel = consoleLoggingLevel;
+
+    writeToFile();
+  }
+
+  /**
+   * Setter for the file logging level. Persists on disk.
+   *
+   * @param fileLoggingLevel new value for the file logging level
+   */
+  public void updateFileLoggingLevel(LogLevel fileLoggingLevel) {
+    logger.info(
+        "Updating file logging level from {} to {}.", this.fileLoggingLevel, fileLoggingLevel);
+    this.fileLoggingLevel = fileLoggingLevel;
+
+    writeToFile();
+  }
+
   // ====================================================
   // Server
 

--- a/src/main/java/bio/terra/cli/context/utils/Logger.java
+++ b/src/main/java/bio/terra/cli/context/utils/Logger.java
@@ -110,7 +110,11 @@ public class Logger {
     consoleAppender.start();
 
     // on the root logger, clear any existing appenders and attach the two created above
+    // also set the root log level to ALL, so that each appender can set its level independently.
+    // if we don't sent the root log level to ALL, then it acts as a second filter for any messages
+    // below its default level DEBUG.
     ch.qos.logback.classic.Logger rootLogger = loggerContext.getLogger(ROOT_LOGGER_NAME);
+    rootLogger.setLevel(Level.ALL);
     rootLogger.detachAndStopAllAppenders();
     rootLogger.addAppender(rollingFileAppender);
     rootLogger.addAppender(consoleAppender);
@@ -143,7 +147,7 @@ public class Logger {
     encoder.start();
     appender.setEncoder(encoder);
 
-    // filter out any logs that are below the fileLoggingLevel specified in the global context
+    // filter out any logs that are below the logging level specified in the global context
     appender.clearAllFilters();
     ThresholdFilter thresholdFilter = new ThresholdFilter();
     thresholdFilter.setLevel(loggingLevel.levelStr);


### PR DESCRIPTION
- Added two new config commands: `terra config set logging`, `terra config get-value logging`.
- The `set` command allows updating the logging level in the global context without re-compiling.
<img width="1206" alt="Screen Shot 2021-03-24 at 11 31 06 AM" src="https://user-images.githubusercontent.com/12446128/112337607-74597400-8c94-11eb-9c7c-46f2bbacd0ed.png">

- Also fixed a small un-related bug. The `terra config set image` command was not updating the image path in the global context if the image had not yet been downloaded with `docker pull`. Changed the behavior to always update the global context property, but log a warning if the image is not found.