### PR TITLE
PF-446: Common base class for commands. (part 2)

### DIFF
--- a/src/main/java/bio/terra/cli/command/config/List.java
+++ b/src/main/java/bio/terra/cli/command/config/List.java
@@ -1,27 +1,49 @@
 package bio.terra.cli.command.config;
 
-import bio.terra.cli.context.GlobalContext;
-import java.util.concurrent.Callable;
+import static bio.terra.cli.command.config.getvalue.Logging.LoggingReturnValue;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import java.util.HashMap;
+import java.util.Map;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra config list" command. */
 @CommandLine.Command(
     name = "list",
     description = "List all configuration properties and their values.")
-public class List implements Callable<Integer> {
+public class List extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Print out a list of all the config properties. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  protected void execute() {
+    // build a map of the config properties
+    LoggingReturnValue loggingLevels =
+        new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
+    Map<String, Object> configPropertyMap = new HashMap<>();
+    configPropertyMap.put("browser", globalContext.browserLaunchOption);
+    configPropertyMap.put("image", globalContext.dockerImageId);
+    configPropertyMap.put("logging", loggingLevels);
 
-    System.out.println("[browser] browser launch for login = " + globalContext.browserLaunchOption);
-    System.out.println("[image] docker image id = " + globalContext.dockerImageId);
-    System.out.println(
+    formatOption.printReturnValue(configPropertyMap, this::printText);
+  }
+
+  /** Print this command's output in text format. */
+  private void printText(Map<String, Object> returnValue) {
+    OUT.println("[browser] browser launch for login = " + globalContext.browserLaunchOption);
+    OUT.println("[image] docker image id = " + globalContext.dockerImageId);
+    OUT.println(
         "[logging] console logging level = "
             + globalContext.consoleLoggingLevel
             + ", file logging level = "
             + globalContext.fileLoggingLevel);
+  }
 
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/List.java
+++ b/src/main/java/bio/terra/cli/command/config/List.java
@@ -2,10 +2,10 @@ package bio.terra.cli.command.config;
 
 import static bio.terra.cli.command.config.getvalue.Logging.LoggingReturnValue;
 
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.command.config.getvalue.Logging;
 import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.command.helperclasses.FormatOption;
-import java.util.HashMap;
-import java.util.Map;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra config list" command. */
@@ -19,26 +19,37 @@ public class List extends BaseCommand {
   /** Print out a list of all the config properties. */
   @Override
   protected void execute() {
-    // build a map of the config properties
     LoggingReturnValue loggingLevels =
         new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
-    Map<String, Object> configPropertyMap = new HashMap<>();
-    configPropertyMap.put("browser", globalContext.browserLaunchOption);
-    configPropertyMap.put("image", globalContext.dockerImageId);
-    configPropertyMap.put("logging", loggingLevels);
+    ConfigListReturnValue configList =
+        new ConfigListReturnValue(
+            globalContext.browserLaunchOption, globalContext.dockerImageId, loggingLevels);
 
-    formatOption.printReturnValue(configPropertyMap, this::printText);
+    formatOption.printReturnValue(configList, List::printText);
+  }
+
+  /** POJO class for printing out this command's output. */
+  private static class ConfigListReturnValue {
+    public AuthenticationManager.BrowserLaunchOption browser;
+    public String image;
+    public LoggingReturnValue logging;
+
+    public ConfigListReturnValue(
+        AuthenticationManager.BrowserLaunchOption browser,
+        String image,
+        LoggingReturnValue logging) {
+      this.browser = browser;
+      this.image = image;
+      this.logging = logging;
+    }
   }
 
   /** Print this command's output in text format. */
-  private void printText(Map<String, Object> returnValue) {
-    OUT.println("[browser] browser launch for login = " + globalContext.browserLaunchOption);
-    OUT.println("[image] docker image id = " + globalContext.dockerImageId);
-    OUT.println(
-        "[logging] console logging level = "
-            + globalContext.consoleLoggingLevel
-            + ", file logging level = "
-            + globalContext.fileLoggingLevel);
+  private static void printText(ConfigListReturnValue returnValue) {
+    OUT.println("[browser] browser launch for login = " + returnValue.browser);
+    OUT.println("[image] docker image id = " + returnValue.image);
+    OUT.println();
+    Logging.printText(returnValue.logging);
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Browser.java
@@ -1,22 +1,27 @@
 package bio.terra.cli.command.config.getvalue;
 
-import bio.terra.cli.context.GlobalContext;
-import java.util.concurrent.Callable;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra config get-value browser" command. */
 @Command(
     name = "browser",
     description = "Check whether a browser is launched automatically during the login process.")
-public class Browser implements Callable<Integer> {
+public class Browser extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Return the browser launch option property of the global context. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  protected void execute() {
+    formatOption.printReturnValue(globalContext.browserLaunchOption);
+  }
 
-    System.out.println(
-        "Browser launch mode for login is " + globalContext.browserLaunchOption + ".");
-
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Image.java
@@ -1,19 +1,25 @@
 package bio.terra.cli.command.config.getvalue;
 
-import bio.terra.cli.context.GlobalContext;
-import java.util.concurrent.Callable;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra config get-value image" command. */
 @Command(name = "image", description = "Get the Docker image used for launching applications.")
-public class Image implements Callable<Integer> {
+public class Image extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Return the docker image id property of the global context. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  protected void execute() {
+    formatOption.printReturnValue(globalContext.dockerImageId);
+  }
 
-    System.out.println(globalContext.dockerImageId);
-
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
@@ -20,7 +20,10 @@ public class Logging extends BaseCommand {
     formatOption.printReturnValue(loggingLevels, Logging::printText);
   }
 
-  /** POJO class for printing out this command's output. */
+  /**
+   * POJO class for printing out this command's output. This class is also used by the `terra config
+   * list` command, so it needs to be public.
+   */
   public static class LoggingReturnValue {
     // global logging context = log levels for file and stdout
     public Logger.LogLevel consoleLoggingLevel;

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
@@ -39,10 +39,10 @@ public class Logging extends BaseCommand {
   /** Print this command's output in text format. */
   public static void printText(LoggingReturnValue returnValue) {
     OUT.println(
-        "[console] logging level for printing directly to the terminal = "
+        "[logging, console] logging level for printing directly to the terminal = "
             + returnValue.consoleLoggingLevel);
     OUT.println(
-        "[file] logging level for writing to files in "
+        "[logging, file] logging level for writing to files in "
             + GlobalContext.getLogFile().getParent()
             + " = "
             + returnValue.fileLoggingLevel);

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Logging.java
@@ -1,28 +1,53 @@
 package bio.terra.cli.command.config.getvalue;
 
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.GlobalContext;
-import java.util.concurrent.Callable;
-import org.slf4j.LoggerFactory;
+import bio.terra.cli.context.utils.Logger;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra config get-value logging" command. */
 @Command(name = "logging", description = "Get the logging level.")
-public class Logging implements Callable<Integer> {
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Logging.class);
+public class Logging extends BaseCommand {
+  @CommandLine.Mixin FormatOption formatOption;
 
+  /** Return the logging level properties of the global context. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  protected void execute() {
+    LoggingReturnValue loggingLevels =
+        new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
+    formatOption.printReturnValue(loggingLevels, Logging::printText);
+  }
 
-    System.out.println(
+  /** POJO class for printing out this command's output. */
+  public static class LoggingReturnValue {
+    // global logging context = log levels for file and stdout
+    public Logger.LogLevel consoleLoggingLevel;
+    public Logger.LogLevel fileLoggingLevel;
+
+    public LoggingReturnValue(
+        Logger.LogLevel consoleLoggingLevel, Logger.LogLevel fileLoggingLevel) {
+      this.consoleLoggingLevel = consoleLoggingLevel;
+      this.fileLoggingLevel = fileLoggingLevel;
+    }
+  }
+
+  /** Print this command's output in text format. */
+  public static void printText(LoggingReturnValue returnValue) {
+    OUT.println(
         "[console] logging level for printing directly to the terminal = "
-            + globalContext.consoleLoggingLevel);
-    System.out.println(
+            + returnValue.consoleLoggingLevel);
+    OUT.println(
         "[file] logging level for writing to files in "
             + GlobalContext.getLogFile().getParent()
             + " = "
-            + globalContext.fileLoggingLevel);
+            + returnValue.fileLoggingLevel);
+  }
 
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/set/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Browser.java
@@ -2,7 +2,6 @@ package bio.terra.cli.command.config.set;
 
 import bio.terra.cli.auth.AuthenticationManager.BrowserLaunchOption;
 import bio.terra.cli.command.helperclasses.BaseCommand;
-import bio.terra.cli.command.helperclasses.FormatOption;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -17,13 +16,10 @@ public class Browser extends BaseCommand {
       description = "Browser launch mode: ${COMPLETION-CANDIDATES}")
   private BrowserLaunchOption mode;
 
-  @CommandLine.Mixin FormatOption formatOption;
-
   /** Return the updated browser launch option property of the global context. */
   @Override
   protected void execute() {
     globalContext.updateBrowserLaunchFlag(mode);
-    formatOption.printReturnValue(globalContext.browserLaunchOption);
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/set/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Browser.java
@@ -1,8 +1,8 @@
 package bio.terra.cli.command.config.set;
 
 import bio.terra.cli.auth.AuthenticationManager.BrowserLaunchOption;
-import bio.terra.cli.context.GlobalContext;
-import java.util.concurrent.Callable;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -10,29 +10,25 @@ import picocli.CommandLine.Command;
 @Command(
     name = "browser",
     description = "Configure whether a browser is launched automatically during the login process.")
-public class Browser implements Callable<Integer> {
+public class Browser extends BaseCommand {
 
   @CommandLine.Parameters(
       index = "0",
       description = "Browser launch mode: ${COMPLETION-CANDIDATES}")
   private BrowserLaunchOption mode;
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Return the updated browser launch option property of the global context. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-
-    BrowserLaunchOption prevBrowserLaunchOption = globalContext.browserLaunchOption;
+  protected void execute() {
     globalContext.updateBrowserLaunchFlag(mode);
+    formatOption.printReturnValue(globalContext.browserLaunchOption);
+  }
 
-    System.out.println(
-        "Browser launch mode for login is "
-            + globalContext.browserLaunchOption
-            + " ("
-            + (globalContext.browserLaunchOption == prevBrowserLaunchOption
-                ? "UNCHANGED"
-                : "CHANGED")
-            + ").");
-
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/set/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Browser.java
@@ -19,7 +19,17 @@ public class Browser extends BaseCommand {
   /** Updates the browser launch option property of the global context. */
   @Override
   protected void execute() {
+    BrowserLaunchOption prevBrowserLaunchOption = globalContext.browserLaunchOption;
     globalContext.updateBrowserLaunchFlag(mode);
+
+    OUT.println(
+        "Browser launch mode for login is "
+            + globalContext.browserLaunchOption
+            + " ("
+            + (globalContext.browserLaunchOption == prevBrowserLaunchOption
+                ? "UNCHANGED"
+                : "CHANGED")
+            + ").");
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/set/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Browser.java
@@ -16,7 +16,7 @@ public class Browser extends BaseCommand {
       description = "Browser launch mode: ${COMPLETION-CANDIDATES}")
   private BrowserLaunchOption mode;
 
-  /** Return the updated browser launch option property of the global context. */
+  /** Updates the browser launch option property of the global context. */
   @Override
   protected void execute() {
     globalContext.updateBrowserLaunchFlag(mode);

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -2,7 +2,6 @@ package bio.terra.cli.command.config.set;
 
 import bio.terra.cli.apps.DockerAppsRunner;
 import bio.terra.cli.command.helperclasses.BaseCommand;
-import bio.terra.cli.command.helperclasses.FormatOption;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -21,15 +20,11 @@ public class Image extends BaseCommand {
     private boolean useDefault;
   }
 
-  @CommandLine.Mixin FormatOption formatOption;
-
   /** Return the updated docker image id property of the global context. */
   @Override
   protected void execute() {
     String newImageId = argGroup.useDefault ? DockerAppsRunner.defaultImageId() : argGroup.imageId;
     new DockerAppsRunner(globalContext, workspaceContext).updateImageId(newImageId);
-
-    formatOption.printReturnValue(globalContext.dockerImageId);
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -23,8 +23,16 @@ public class Image extends BaseCommand {
   /** Updates the docker image id property of the global context. */
   @Override
   protected void execute() {
+    String prevImageId = globalContext.dockerImageId;
     String newImageId = argGroup.useDefault ? DockerAppsRunner.defaultImageId() : argGroup.imageId;
     new DockerAppsRunner(globalContext, workspaceContext).updateImageId(newImageId);
+
+    if (globalContext.dockerImageId.equals(prevImageId)) {
+      OUT.println("Docker image: " + globalContext.dockerImageId + " (UNCHANGED)");
+    } else {
+      OUT.println(
+          "Docker image: " + globalContext.dockerImageId + " (CHANGED FROM " + prevImageId + ")");
+    }
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -20,7 +20,7 @@ public class Image extends BaseCommand {
     private boolean useDefault;
   }
 
-  /** Return the updated docker image id property of the global context. */
+  /** Updates the docker image id property of the global context. */
   @Override
   protected void execute() {
     String newImageId = argGroup.useDefault ? DockerAppsRunner.defaultImageId() : argGroup.imageId;

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -25,7 +25,7 @@ public class Logging extends BaseCommand {
       description = "logging level: ${COMPLETION-CANDIDATES}")
   private Logger.LogLevel level;
 
-  /** Return the updated logging level properties of the global context. */
+  /** Updates the logging level properties of the global context. */
   @Override
   protected void execute() {
     // note that this new log level will take effect on the NEXT command.

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -1,17 +1,16 @@
 package bio.terra.cli.command.config.set;
 
-import bio.terra.cli.context.GlobalContext;
+import static bio.terra.cli.command.config.getvalue.Logging.LoggingReturnValue;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.utils.Logger;
-import java.util.concurrent.Callable;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra config set logging" command. */
 @Command(name = "logging", description = "Set the logging level.")
-public class Logging implements Callable<Integer> {
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Logging.class);
-
+public class Logging extends BaseCommand {
   @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
   Logging.LogLevelArgGroup argGroup;
 
@@ -29,10 +28,11 @@ public class Logging implements Callable<Integer> {
       description = "logging level: ${COMPLETION-CANDIDATES}")
   private Logger.LogLevel level;
 
-  @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  @CommandLine.Mixin FormatOption formatOption;
 
+  /** Return the updated logging level properties of the global context. */
+  @Override
+  protected void execute() {
     // note that this new log level will take effect on the NEXT command.
     // for the log level to take effect for the rest of THIS command, we'd need to re-initialize the
     // logger(s) (e.g. by calling Logger.setupLogging or some subset of that method). there's
@@ -40,12 +40,19 @@ public class Logging implements Callable<Integer> {
     // immediately after updating the global context, so keeping it simple for now.
     if (argGroup.console) {
       globalContext.updateConsoleLoggingLevel(level);
-      System.out.println("CONSOLE logging level set to: " + level);
     } else {
       globalContext.updateFileLoggingLevel(level);
-      System.out.println("FILE logging level set to: " + level);
     }
 
-    return 0;
+    LoggingReturnValue loggingLevels =
+        new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
+    formatOption.printReturnValue(
+        loggingLevels, bio.terra.cli.command.config.getvalue.Logging::printText);
+  }
+
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -35,8 +35,10 @@ public class Logging extends BaseCommand {
     // immediately after updating the global context, so keeping it simple for now.
     if (argGroup.console) {
       globalContext.updateConsoleLoggingLevel(level);
+      OUT.println("CONSOLE logging level set to: " + level);
     } else {
       globalContext.updateFileLoggingLevel(level);
+      OUT.println("FILE logging level set to: " + level);
     }
   }
 

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -1,9 +1,6 @@
 package bio.terra.cli.command.config.set;
 
-import static bio.terra.cli.command.config.getvalue.Logging.LoggingReturnValue;
-
 import bio.terra.cli.command.helperclasses.BaseCommand;
-import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.utils.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -28,8 +25,6 @@ public class Logging extends BaseCommand {
       description = "logging level: ${COMPLETION-CANDIDATES}")
   private Logger.LogLevel level;
 
-  @CommandLine.Mixin FormatOption formatOption;
-
   /** Return the updated logging level properties of the global context. */
   @Override
   protected void execute() {
@@ -43,11 +38,6 @@ public class Logging extends BaseCommand {
     } else {
       globalContext.updateFileLoggingLevel(level);
     }
-
-    LoggingReturnValue loggingLevels =
-        new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
-    formatOption.printReturnValue(
-        loggingLevels, bio.terra.cli.command.config.getvalue.Logging::printText);
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/CheckAccess.java
@@ -34,11 +34,7 @@ public class CheckAccess extends BaseCommand {
 
     CheckAccessReturnValue checkAccessReturnValue =
         new CheckAccessReturnValue(userHasAccess, proxyGroupHasAccess);
-    formatOption.printReturnValue(
-        checkAccessReturnValue,
-        returnValue -> {
-          this.printText(returnValue);
-        });
+    formatOption.printReturnValue(checkAccessReturnValue, this::printText);
   }
 
   /** POJO class for printing out this command's output. */

--- a/src/main/java/bio/terra/cli/command/groups/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/AddUser.java
@@ -1,16 +1,13 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups add-user" command. */
 @Command(name = "add-user", description = "Add a user to a group with a given policy.")
-public class AddUser implements Callable<Integer> {
+public class AddUser extends BaseCommand {
   @CommandLine.Parameters(index = "0", description = "The email of the user.")
   private String user;
 
@@ -23,16 +20,11 @@ public class AddUser implements Callable<Integer> {
       description = "The name of the policy: ${COMPLETION-CANDIDATES}")
   private SamService.GroupPolicy policy;
 
+  /** Add a user to a Terra group. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
         .addUserToGroup(group, policy, user);
-
-    System.out.println("User " + user + " successfully added to group " + group + ".");
-    return 0;
+    OUT.println("User " + user + " successfully added to group " + group + ".");
   }
 }

--- a/src/main/java/bio/terra/cli/command/groups/Create.java
+++ b/src/main/java/bio/terra/cli/command/groups/Create.java
@@ -1,30 +1,21 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups create" command. */
 @Command(name = "create", description = "Create a new Terra group.")
-public class Create implements Callable<Integer> {
+public class Create extends BaseCommand {
   @CommandLine.Parameters(index = "0", description = "The name of the group")
   private String group;
 
+  /** Create a new Terra group. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
         .createGroup(group);
-
-    System.out.println("Group " + group + " successfully created.");
-
-    return 0;
+    OUT.println("Group " + group + " successfully created.");
   }
 }

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -1,30 +1,21 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups delete" command. */
 @Command(name = "delete", description = "Delete an existing Terra group.")
-public class Delete implements Callable<Integer> {
+public class Delete extends BaseCommand {
   @CommandLine.Parameters(index = "0", description = "The name of the group")
   private String group;
 
+  /** Delete an existing Terra group. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
         .deleteGroup(group);
-
-    System.out.println("Group " + group + " successfully deleted.");
-
-    return 0;
+    OUT.println("Group " + group + " successfully deleted.");
   }
 }

--- a/src/main/java/bio/terra/cli/command/groups/Describe.java
+++ b/src/main/java/bio/terra/cli/command/groups/Describe.java
@@ -1,31 +1,25 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups describe" command. */
 @Command(name = "describe", description = "Print the group email address.")
-public class Describe implements Callable<Integer> {
+public class Describe extends BaseCommand {
   @CommandLine.Parameters(index = "0", description = "The name of the group")
   private String group;
 
-  @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  @CommandLine.Mixin FormatOption formatOption;
 
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  /** Describe an existing Terra group. */
+  @Override
+  protected void execute() {
     String groupEmail =
         new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
             .getGroupEmail(group);
-
-    System.out.println(groupEmail);
-
-    return 0;
+    formatOption.printReturnValue(groupEmail);
   }
 }

--- a/src/main/java/bio/terra/cli/command/groups/List.java
+++ b/src/main/java/bio/terra/cli/command/groups/List.java
@@ -1,29 +1,29 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import org.broadinstitute.dsde.workbench.client.sam.model.ManagedGroupMembershipEntry;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups list" command. */
 @Command(name = "list", description = "List the groups to which the current user belongs.")
-public class List implements Callable<Integer> {
-  @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+public class List extends BaseCommand {
+  @CommandLine.Mixin FormatOption formatOption;
 
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  /** List the groups to which the current user belongs. */
+  @Override
+  protected void execute() {
     java.util.List<ManagedGroupMembershipEntry> groups =
         new SamService(globalContext.server, globalContext.requireCurrentTerraUser()).listGroups();
+    formatOption.printReturnValue(groups, List::printText);
+  }
 
-    for (ManagedGroupMembershipEntry group : groups) {
-      System.out.println(group.getGroupName());
+  /** Print this command's output in text format. */
+  private static void printText(java.util.List<ManagedGroupMembershipEntry> returnValue) {
+    for (ManagedGroupMembershipEntry group : returnValue) {
+      OUT.println(group.getGroupName());
     }
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/groups/RemoveUser.java
@@ -1,16 +1,13 @@
 package bio.terra.cli.command.groups;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SamService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups remove-user" command. */
 @Command(name = "remove-user", description = "Remove a user from a group with a given policy.")
-public class RemoveUser implements Callable<Integer> {
+public class RemoveUser extends BaseCommand {
   @CommandLine.Parameters(index = "0", description = "The email of the user.")
   private String user;
 
@@ -23,16 +20,11 @@ public class RemoveUser implements Callable<Integer> {
       description = "The name of the policy: ${COMPLETION-CANDIDATES}")
   private SamService.GroupPolicy policy;
 
+  /** Delete an existing Terra group. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SamService(globalContext.server, globalContext.requireCurrentTerraUser())
         .removeUserFromGroup(group, policy, user);
-
-    System.out.println("User " + user + " successfully removed from group " + group + ".");
-    return 0;
+    OUT.println("User " + user + " successfully removed from group " + group + ".");
   }
 }


### PR DESCRIPTION
This is part 2 of the changes to have:
- all commands extend a common base class
- optionally include a `--format=json` flag.

The initial changes, including the definition of the common base class and optional format flag are in PR #40.

This PR includes changes to the `config` and `groups` commands. Also:
- Removed the output for the `config set` commands. To see the current/updated values, users can call the `config get-value` commands, instead. I think this makes it a little more consistent (i.e. always call `get-value` instead of relying sometimes on the output of `set`).