### PR TITLE
PF-446: Common base class for commands. (part 3)

### DIFF
--- a/src/main/java/bio/terra/cli/command/Status.java
+++ b/src/main/java/bio/terra/cli/command/Status.java
@@ -18,7 +18,7 @@ public class Status extends BaseCommand {
   protected void execute() {
     StatusReturnValue statusReturnValue =
         new StatusReturnValue(globalContext.server, workspaceContext.terraWorkspaceModel);
-    formatOption.printReturnValue(statusReturnValue, returnValue -> this.printText(returnValue));
+    formatOption.printReturnValue(statusReturnValue, this::printText);
   }
 
   /** POJO class for printing out this command's output. */

--- a/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
@@ -18,7 +18,6 @@ public class FormatOption {
 
   @CommandLine.Option(
       names = "--format",
-      hidden = true,
       description = "Set the format for printing command output: ${COMPLETION-CANDIDATES}")
   private FormatOptions format;
 

--- a/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
@@ -19,8 +19,8 @@ public class FormatOption {
   @CommandLine.Option(
       names = "--format",
       defaultValue = "text",
-      description =
-          "Set the format for printing command output: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})")
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
+      description = "Set the format for printing command output: ${COMPLETION-CANDIDATES}")
   private FormatOptions format;
 
   /** This enum specifies the format options for printing the command output. */

--- a/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
@@ -18,7 +18,9 @@ public class FormatOption {
 
   @CommandLine.Option(
       names = "--format",
-      description = "Set the format for printing command output: ${COMPLETION-CANDIDATES}")
+      defaultValue = "text",
+      description =
+          "Set the format for printing command output: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE})")
   private FormatOptions format;
 
   /** This enum specifies the format options for printing the command output. */

--- a/src/main/java/bio/terra/cli/command/notebooks/Delete.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Delete.java
@@ -1,12 +1,9 @@
 package bio.terra.cli.command.notebooks;
 
 import bio.terra.cli.apps.DockerAppsRunner;
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebooks delete" command. */
@@ -14,7 +11,7 @@ import picocli.CommandLine;
     name = "delete",
     description = "Delete an AI Notebook instance within your workspace.",
     showDefaultValues = true)
-public class Delete implements Callable<Integer> {
+public class Delete extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -26,14 +23,8 @@ public class Delete implements Callable<Integer> {
   private String location;
 
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  protected void execute() {
     workspaceContext.requireCurrentWorkspace();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
 
     String command = "gcloud notebooks instances delete $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
@@ -41,7 +32,5 @@ public class Delete implements Callable<Integer> {
     envVars.put("LOCATION", location);
 
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/notebooks/Describe.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Describe.java
@@ -1,12 +1,9 @@
 package bio.terra.cli.command.notebooks;
 
 import bio.terra.cli.apps.DockerAppsRunner;
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebooks describe" command. */
@@ -14,7 +11,7 @@ import picocli.CommandLine;
     name = "describe",
     description = "Describe an AI Notebook instance within your workspace.",
     showDefaultValues = true)
-public class Describe implements Callable<Integer> {
+public class Describe extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -26,14 +23,8 @@ public class Describe implements Callable<Integer> {
   private String location;
 
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  protected void execute() {
     workspaceContext.requireCurrentWorkspace();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
 
     String command = "gcloud notebooks instances describe $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
@@ -42,7 +33,5 @@ public class Describe implements Callable<Integer> {
 
     // TODO(wchamber): Consider reformatting the ouptut or otherwise highlighting the proxy uri.
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/notebooks/List.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/List.java
@@ -1,12 +1,9 @@
 package bio.terra.cli.command.notebooks;
 
 import bio.terra.cli.apps.DockerAppsRunner;
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebooks describe" command. */
@@ -14,7 +11,7 @@ import picocli.CommandLine;
     name = "list",
     description = "List the AI Notebook instance within your workspace for the specified location.",
     showDefaultValues = true)
-public class List implements Callable<Integer> {
+public class List extends BaseCommand {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
@@ -22,14 +19,8 @@ public class List implements Callable<Integer> {
   private String location;
 
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  protected void execute() {
     workspaceContext.requireCurrentWorkspace();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
 
     String command = "gcloud notebooks instances list --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
@@ -37,7 +28,5 @@ public class List implements Callable<Integer> {
 
     // TODO(wchamber): Output more relevant information, like the proxy uri.
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -1,12 +1,9 @@
 package bio.terra.cli.command.notebooks;
 
 import bio.terra.cli.apps.DockerAppsRunner;
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebooks start" command. */
@@ -14,7 +11,7 @@ import picocli.CommandLine;
     name = "start",
     description = "Start a stopped AI Notebook instance within your workspace.",
     showDefaultValues = true)
-public class Start implements Callable<Integer> {
+public class Start extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -26,14 +23,8 @@ public class Start implements Callable<Integer> {
   private String location;
 
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  protected void execute() {
     workspaceContext.requireCurrentWorkspace();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
 
     String command = "gcloud notebooks instances start $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
@@ -41,7 +32,5 @@ public class Start implements Callable<Integer> {
     envVars.put("LOCATION", location);
 
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -1,12 +1,9 @@
 package bio.terra.cli.command.notebooks;
 
 import bio.terra.cli.apps.DockerAppsRunner;
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebooks stop" command. */
@@ -14,7 +11,7 @@ import picocli.CommandLine;
     name = "stop",
     description = "Stop a running AI Notebook instance within your workspace.",
     showDefaultValues = true)
-public class Stop implements Callable<Integer> {
+public class Stop extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The name of the notebook instance.")
   private String instanceName;
@@ -26,14 +23,8 @@ public class Stop implements Callable<Integer> {
   private String location;
 
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  protected void execute() {
     workspaceContext.requireCurrentWorkspace();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
 
     String command = "gcloud notebooks instances stop $INSTANCE_NAME --location=$LOCATION";
     Map<String, String> envVars = new HashMap<>();
@@ -41,7 +32,5 @@ public class Stop implements Callable<Integer> {
     envVars.put("LOCATION", location);
 
     new DockerAppsRunner(globalContext, workspaceContext).runToolCommand(command, envVars);
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/Create.java
+++ b/src/main/java/bio/terra/cli/command/resources/Create.java
@@ -1,17 +1,15 @@
 package bio.terra.cli.command.resources;
 
-import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.CloudResource;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
 import bio.terra.cli.service.WorkspaceManager;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra resources create" command. */
 @Command(name = "create", description = "Create a new controlled resource.")
-public class Create implements Callable<Integer> {
+public class Create extends BaseCommand {
 
   @CommandLine.Option(
       names = "--type",
@@ -26,18 +24,19 @@ public class Create implements Callable<Integer> {
           "The name of the resource, scoped to the workspace. Only alphanumeric and underscore characters are permitted.")
   private String name;
 
-  @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  @CommandLine.Mixin FormatOption formatOption;
 
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  /** Create a new controlled resource. */
+  @Override
+  protected void execute() {
     CloudResource resource =
         new WorkspaceManager(globalContext, workspaceContext).createControlledResource(type, name);
+    formatOption.printReturnValue(resource, Create::printText);
+  }
 
-    System.out.println(resource.type + " successfully created: " + resource.cloudId);
-    System.out.println("Workspace resource successfully added: " + resource.name);
-
-    return 0;
+  /** Print this command's output in text format. */
+  private static void printText(CloudResource returnValue) {
+    OUT.println(returnValue.type + " successfully created: " + returnValue.cloudId);
+    OUT.println("Workspace resource successfully added: " + returnValue.name);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -1,17 +1,14 @@
 package bio.terra.cli.command.resources;
 
-import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.context.CloudResource;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
 import bio.terra.cli.service.WorkspaceManager;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra resources delete" command. */
 @Command(name = "delete", description = "Delete an existing controlled resource.")
-public class Delete implements Callable<Integer> {
+public class Delete extends BaseCommand {
 
   @CommandLine.Option(
       names = "--name",
@@ -19,18 +16,12 @@ public class Delete implements Callable<Integer> {
       description = "The name of the resource, scoped to the workspace.")
   private String name;
 
+  /** Delete an existing controlled resource. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     CloudResource resource =
         new WorkspaceManager(globalContext, workspaceContext).deleteControlledResource(name);
-
-    System.out.println(resource.type + " successfully deleted: " + resource.cloudId);
-    System.out.println("Workspace resource successfully removed: " + resource.name);
-
-    return 0;
+    OUT.println(resource.type + " successfully deleted: " + resource.cloudId);
+    OUT.println("Workspace resource successfully removed: " + resource.name);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/Describe.java
+++ b/src/main/java/bio/terra/cli/command/resources/Describe.java
@@ -1,17 +1,15 @@
 package bio.terra.cli.command.resources;
 
-import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.CloudResource;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
 import bio.terra.cli.service.WorkspaceManager;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra resources describe" command. */
 @Command(name = "describe", description = "Describe an existing controlled resource.")
-public class Describe implements Callable<Integer> {
+public class Describe extends BaseCommand {
 
   @CommandLine.Option(
       names = "--name",
@@ -19,19 +17,20 @@ public class Describe implements Callable<Integer> {
       description = "The name of the resource, scoped to the workspace.")
   private String name;
 
-  @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
+  @CommandLine.Mixin FormatOption formatOption;
 
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  /** Describe an existing controlled resource. */
+  @Override
+  protected void execute() {
     CloudResource resource =
         new WorkspaceManager(globalContext, workspaceContext).getControlledResource(name);
+    formatOption.printReturnValue(resource, Describe::printText);
+  }
 
-    System.out.println("Name: " + resource.name);
-    System.out.println("Type: " + resource.type);
-    System.out.println("Cloud Id: " + resource.cloudId);
-
-    return 0;
+  /** Print this command's output in text format. */
+  private static void printText(CloudResource returnValue) {
+    OUT.println("Name: " + returnValue.name);
+    OUT.println("Type: " + returnValue.type);
+    OUT.println("Cloud Id: " + returnValue.cloudId);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/List.java
+++ b/src/main/java/bio/terra/cli/command/resources/List.java
@@ -1,30 +1,30 @@
 package bio.terra.cli.command.resources;
 
-import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.CloudResource;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
 import bio.terra.cli.service.WorkspaceManager;
-import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra resources list" command. */
 @Command(name = "list", description = "List all controlled resources.")
-public class List implements Callable<Integer> {
+public class List extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** List all controlled resources. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     java.util.List<CloudResource> resources =
         new WorkspaceManager(globalContext, workspaceContext).listResources();
+    formatOption.printReturnValue(resources, List::printText);
+  }
 
-    for (CloudResource resource : resources) {
-      System.out.println(resource.name + " (" + resource.type + "): " + resource.cloudId);
+  /** Print this command's output in text format. */
+  private static void printText(java.util.List<CloudResource> returnValue) {
+    for (CloudResource resource : returnValue) {
+      OUT.println(resource.name + " (" + resource.type + "): " + resource.cloudId);
     }
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/server/List.java
+++ b/src/main/java/bio/terra/cli/command/server/List.java
@@ -1,25 +1,36 @@
 package bio.terra.cli.command.server;
 
-import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.context.ServerSpecification;
 import bio.terra.cli.service.ServerManager;
-import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra server list" command. */
 @Command(name = "list", description = "List all available Terra servers.")
-public class List implements Callable<Integer> {
+public class List extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** List all Terra environments. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
+  protected void execute() {
     java.util.List<ServerSpecification> allPossibleServers = ServerManager.allPossibleServers();
+    formatOption.printReturnValue(allPossibleServers, this::printText);
+  }
 
-    for (ServerSpecification server : allPossibleServers) {
+  /** Print this command's output in text format. */
+  private void printText(java.util.List<ServerSpecification> returnValue) {
+    for (ServerSpecification server : returnValue) {
       String prefix = (globalContext.server.equals(server)) ? " * " : "   ";
-      System.out.println(prefix + server.name + ": " + server.description);
+      OUT.println(prefix + server.name + ": " + server.description);
     }
+  }
 
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/server/Set.java
+++ b/src/main/java/bio/terra/cli/command/server/Set.java
@@ -1,32 +1,26 @@
 package bio.terra.cli.command.server;
 
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.ServerSpecification;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.ServerManager;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra server set" command. */
 @Command(name = "set", description = "Set the Terra server to connect to.")
-public class Set implements Callable<Integer> {
+public class Set extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "server name")
   private String serverName;
 
+  /** Update the Terra environment to which the CLI is pointing. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    ServerSpecification prevServer = globalContext.server;
+  protected void execute() {
     new ServerManager(globalContext).updateServer(serverName);
+  }
 
-    if (globalContext.server.equals(prevServer)) {
-      System.out.println("Terra server: " + globalContext.server.name + " (UNCHANGED)");
-    } else {
-      System.out.println(
-          "Terra server: " + globalContext.server.name + " (CHANGED FROM " + prevServer.name + ")");
-    }
-
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/command/server/Status.java
+++ b/src/main/java/bio/terra/cli/command/server/Status.java
@@ -1,27 +1,39 @@
 package bio.terra.cli.command.server;
 
-import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.ServerManager;
-import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra server status" command. */
 @Command(name = "status", description = "Print status and details of the Terra server context.")
-public class Status implements Callable<Integer> {
+public class Status extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Update the Terra environment to which the CLI is pointing. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    System.out.println(
+  protected void execute() {
+    boolean serverIsOk = new ServerManager(globalContext).pingServerStatus();
+    String serverIsOkMsg = serverIsOk ? "OKAY" : "ERROR CONNECTING";
+    formatOption.printReturnValue(serverIsOkMsg, this::printText);
+  }
+
+  /** Print this command's output in text format. */
+  private void printText(String returnValue) {
+    OUT.println(
         "Current server: "
             + globalContext.server.name
             + " ("
             + globalContext.server.description
             + ")");
+    OUT.println("Server status: " + returnValue);
+  }
 
-    boolean serverIsOk = new ServerManager(globalContext).pingServerStatus();
-    System.out.println("Server status: " + (serverIsOk ? "OKAY" : "ERROR CONNECTING"));
-
-    return 0;
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
   }
 }


### PR DESCRIPTION
This is part 3 of the changes to have:
- all commands extend a common base class
- optionally include a --format=json flag

The initial changes, including the definition of the common base class and optional format flag are in PR #40.

This PR includes changes to the `notebooks`, `resources` and `server` commands. Also:
- I made the `--format` option visible to command help.
- I removed the output for the `server set` command. To see the current/updated values, users can call the `terra status` command, instead. I think this makes it a little more consistent (i.e. always call `terra status` instead of relying sometimes on the output of `server set`).