### PR TITLE
PF-446: Common base class for commands. (part 4)

### DIFF
--- a/src/main/java/bio/terra/cli/command/spend/Disable.java
+++ b/src/main/java/bio/terra/cli/command/spend/Disable.java
@@ -1,10 +1,7 @@
 package bio.terra.cli.command.spend;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SpendProfileManagerService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -12,7 +9,7 @@ import picocli.CommandLine.Command;
 @Command(
     name = "disable",
     description = "Disable use of the Workspace Manager default spend profile for a user or group.")
-public class Disable implements Callable<Integer> {
+public class Disable extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The email of the user or group.")
   private String email;
@@ -23,19 +20,15 @@ public class Disable implements Callable<Integer> {
       description = "The name of the policy: ${COMPLETION-CANDIDATES}")
   private SpendProfileManagerService.SpendProfilePolicy policy;
 
+  /** Remove access to the WSM default spend profile for the given email. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SpendProfileManagerService(globalContext.server, globalContext.requireCurrentTerraUser())
         .disableUserForDefaultSpendProfile(policy, email);
 
-    System.out.println(
+    OUT.println(
         "Email "
             + email
             + " successfully disabled on the Workspace Manager default spend profile.");
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/spend/Enable.java
+++ b/src/main/java/bio/terra/cli/command/spend/Enable.java
@@ -1,10 +1,7 @@
 package bio.terra.cli.command.spend;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.utils.SpendProfileManagerService;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -12,7 +9,7 @@ import picocli.CommandLine.Command;
 @Command(
     name = "enable",
     description = "Enable use of the Workspace Manager default spend profile for a user or group.")
-public class Enable implements Callable<Integer> {
+public class Enable extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "The email of the user or group.")
   private String email;
@@ -23,17 +20,13 @@ public class Enable implements Callable<Integer> {
       description = "The name of the policy: ${COMPLETION-CANDIDATES}")
   private SpendProfileManagerService.SpendProfilePolicy policy;
 
+  /** Enable access to the WSM default spend profile for the given email. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new SpendProfileManagerService(globalContext.server, globalContext.requireCurrentTerraUser())
         .enableUserForDefaultSpendProfile(policy, email);
 
-    System.out.println(
+    OUT.println(
         "Email " + email + " successfully enabled on the Workspace Manager default spend profile.");
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/spend/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/spend/ListUsers.java
@@ -1,38 +1,38 @@
 package bio.terra.cli.command.spend;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.utils.SpendProfileManagerService;
 import java.util.List;
-import java.util.concurrent.Callable;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntry;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra spend list-users" command. */
 @Command(
     name = "list-users",
     description = "List the users enabled on the Workspace Manager default spend profile.")
-public class ListUsers implements Callable<Integer> {
+public class ListUsers extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** List all users that have access to the WSM default spend profile. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     List<AccessPolicyResponseEntry> policies =
         new SpendProfileManagerService(
                 globalContext.server, globalContext.requireCurrentTerraUser())
             .listUsersOfDefaultSpendProfile();
+    formatOption.printReturnValue(policies, ListUsers::printText);
+  }
 
-    for (AccessPolicyResponseEntry policy : policies) {
-      System.out.println(policy.getPolicyName().toUpperCase());
+  /** Print this command's output in text format. */
+  private static void printText(List<AccessPolicyResponseEntry> returnValue) {
+    for (AccessPolicyResponseEntry policy : returnValue) {
+      OUT.println(policy.getPolicyName().toUpperCase());
       for (String member : policy.getPolicy().getMemberEmails()) {
-        System.out.println("  " + member);
+        OUT.println("  " + member);
       }
     }
-
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -1,17 +1,14 @@
 package bio.terra.cli.command.workspace;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.WorkspaceManager;
 import bio.terra.workspace.model.IamRole;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace add-user" command. */
 @Command(name = "add-user", description = "Add a user or group to the workspace.")
-public class AddUser implements Callable<Integer> {
+public class AddUser extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "user or group email")
   private String userEmail;
@@ -19,14 +16,10 @@ public class AddUser implements Callable<Integer> {
   @CommandLine.Parameters(index = "1", description = "Role to grant: ${COMPLETION-CANDIDATES}")
   private IamRole role;
 
+  /** Add an email to the workspace. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new WorkspaceManager(globalContext, workspaceContext).addUserToWorkspace(userEmail, role);
-    System.out.println("Email added to workspace: " + userEmail + ", " + role);
-    return 0;
+    OUT.println("Email added to workspace: " + userEmail + ", " + role);
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -1,28 +1,30 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.WorkspaceManager;
-import java.util.concurrent.Callable;
+import bio.terra.workspace.model.WorkspaceDescription;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace create" command. */
 @Command(name = "create", description = "Create a new workspace.")
-public class Create implements Callable<Integer> {
+public class Create extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Create a new workspace. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
+  protected void execute() {
     new WorkspaceManager(globalContext, workspaceContext).createWorkspace();
-    authenticationManager.fetchPetSaCredentials(globalContext.requireCurrentTerraUser());
+    new AuthenticationManager(globalContext, workspaceContext)
+        .fetchPetSaCredentials(globalContext.requireCurrentTerraUser());
+    formatOption.printReturnValue(workspaceContext.terraWorkspaceModel, this::printText);
+  }
 
-    System.out.println("Workspace successfully created: " + workspaceContext.getWorkspaceId());
-    return 0;
+  /** Print this command's output in text format. */
+  private void printText(WorkspaceDescription returnValue) {
+    OUT.println("Workspace successfully created: " + workspaceContext.getWorkspaceId());
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -1,30 +1,23 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.WorkspaceManager;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace delete" command. */
 @Command(name = "delete", description = "Delete an existing workspace.")
-public class Delete implements Callable<Integer> {
+public class Delete extends BaseCommand {
 
+  /** Delete an existing workspace. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    AuthenticationManager authenticationManager =
-        new AuthenticationManager(globalContext, workspaceContext);
-    authenticationManager.loginTerraUser();
+  protected void execute() {
     UUID workspaceIdDeleted =
         new WorkspaceManager(globalContext, workspaceContext).deleteWorkspace();
-    authenticationManager.deletePetSaCredentials(globalContext.requireCurrentTerraUser());
+    new AuthenticationManager(globalContext, workspaceContext)
+        .deletePetSaCredentials(globalContext.requireCurrentTerraUser());
 
-    System.out.println("Workspace successfully deleted: " + workspaceIdDeleted);
-    return 0;
+    OUT.println("Workspace successfully deleted: " + workspaceIdDeleted);
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
@@ -1,32 +1,34 @@
 package bio.terra.cli.command.workspace;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
 import bio.terra.cli.service.WorkspaceManager;
 import bio.terra.workspace.model.RoleBinding;
 import bio.terra.workspace.model.RoleBindingList;
-import java.util.concurrent.Callable;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace list-users" command. */
 @Command(name = "list-users", description = "List the users of the workspace.")
-public class ListUsers implements Callable<Integer> {
+public class ListUsers extends BaseCommand {
 
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** List all users of the workspace. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     RoleBindingList roleBindings =
         new WorkspaceManager(globalContext, workspaceContext).listUsersOfWorkspace();
-    for (RoleBinding roleBinding : roleBindings) {
-      System.out.println(roleBinding.getRole());
+    formatOption.printReturnValue(roleBindings, ListUsers::printText);
+  }
+
+  /** Print this command's output in text format. */
+  private static void printText(RoleBindingList returnValue) {
+    for (RoleBinding roleBinding : returnValue) {
+      OUT.println(roleBinding.getRole());
       for (String member : roleBinding.getMembers()) {
-        System.out.println("  " + member);
+        OUT.println("  " + member);
       }
     }
-    return 0;
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -1,17 +1,14 @@
 package bio.terra.cli.command.workspace;
 
-import bio.terra.cli.auth.AuthenticationManager;
-import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.WorkspaceManager;
 import bio.terra.workspace.model.IamRole;
-import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace remove-user" command. */
 @Command(name = "remove-user", description = "Remove a user or group from the workspace.")
-public class RemoveUser implements Callable<Integer> {
+public class RemoveUser extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "user or group email")
   private String userEmail;
@@ -19,14 +16,10 @@ public class RemoveUser implements Callable<Integer> {
   @CommandLine.Parameters(index = "1", description = "Role to remove: ${COMPLETION-CANDIDATES}")
   private IamRole role;
 
+  /** Remove a user from a workspace. */
   @Override
-  public Integer call() {
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    WorkspaceContext workspaceContext = WorkspaceContext.readFromFile();
-
-    new AuthenticationManager(globalContext, workspaceContext).loginTerraUser();
+  protected void execute() {
     new WorkspaceManager(globalContext, workspaceContext).removeUserFromWorkspace(userEmail, role);
-    System.out.println("Email removed from workspace: " + userEmail + ", " + role);
-    return 0;
+    OUT.println("Email removed from workspace: " + userEmail + ", " + role);
   }
 }


### PR DESCRIPTION
This is part 4 of the changes to have:
- all commands extend a common base class
- optionally include a --format=json flag

The initial changes, including the definition of the common base class and optional format flag are in PR #40.

This PR includes changes to the `spend` and `workspace` commands.