### PR TITLE
PF-446: Common base class for commands. (part 5)

### DIFF
--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -7,7 +7,6 @@ import bio.terra.cli.command.app.passthrough.Nextflow;
 import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.command.exception.UserActionableException;
 import bio.terra.cli.context.GlobalContext;
-import bio.terra.cli.context.utils.Logger;
 import java.util.Map;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -60,11 +59,6 @@ class Main implements Runnable {
    * @param args from stdin
    */
   public static void main(String... args) {
-    // TODO (PF-446): Can we move this to a common base class so we only read the global context
-    // file once?
-    GlobalContext globalContext = GlobalContext.readFromFile();
-    new Logger(globalContext).setupLogging();
-
     CommandLine cmd = new CommandLine(new Main());
     cmd.setExecutionStrategy(new CommandLine.RunLast());
     cmd.setExecutionExceptionHandler(new UserActionableAndSystemExceptionHandler());

--- a/src/main/java/bio/terra/cli/command/helperclasses/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/BaseCommand.java
@@ -27,7 +27,7 @@ public abstract class BaseCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    // read in the global and setup logging
+    // read in the global context and setup logging
     globalContext = GlobalContext.readFromFile();
     new Logger(globalContext).setupLogging();
 

--- a/src/main/java/bio/terra/cli/command/helperclasses/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/BaseCommand.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.helperclasses;
 import bio.terra.cli.auth.AuthenticationManager;
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.context.utils.Logger;
 import java.io.PrintStream;
 import java.util.concurrent.Callable;
 
@@ -26,8 +27,11 @@ public abstract class BaseCommand implements Callable<Integer> {
 
   @Override
   public Integer call() {
-    // read in the global and workspace context
+    // read in the global and setup logging
     globalContext = GlobalContext.readFromFile();
+    new Logger(globalContext).setupLogging();
+
+    // read in the workspace context
     workspaceContext = WorkspaceContext.readFromFile();
 
     // do the login flow if required


### PR DESCRIPTION
This is **part 5** of the changes to have:
- all commands extend a common base class
- optionally include a --format=json flag

The initial changes, including the definition of the common base class and optional format flag are in PR #40.

This PR is the **final** change. It moves logging setup from the `Main` picocli entrypoint class into the `BaseCommand` class. Logging levels are stored in the global context, so we need to setup logging after reading in the global context file. This change moves the logging setup into `BaseCommand` so that we're not reading in the global context file twice for each command.

**NOTE** All the previous PRs (parts 2,3, and 4) can be merged in any order. This PR (part 5) must be merged last. Otherwise, commands that are not yet migrated to use the common base class will not respect the logging levels set in the global context.