### PR TITLE
PF-609: Add CLI server definition for Verily deployment.

### DIFF
--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,1 +1,1 @@
-[ "terra-dev.json", "terra-verily.json", "mm-dev.json", "wchamber-dev.json" ]
+[ "terra-dev.json", "terra-verily-dev.json", "mm-dev.json", "wchamber-dev.json" ]

--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,1 +1,1 @@
-[ "terra-dev.json", "mm-dev.json", "wchamber-dev.json" ]
+[ "terra-dev.json", "terra-verily.json", "mm-dev.json", "wchamber-dev.json" ]

--- a/src/main/resources/servers/terra-verily-dev.json
+++ b/src/main/resources/servers/terra-verily-dev.json
@@ -1,6 +1,6 @@
 {
-  "name": "terra-verily",
-  "description": "Terra environment deployed at Verily.",
+  "name": "terra-verily-dev",
+  "description": "Terra development environment deployed at Verily.",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",

--- a/src/main/resources/servers/terra-verily.json
+++ b/src/main/resources/servers/terra-verily.json
@@ -1,0 +1,8 @@
+{
+  "name": "terra-verily",
+  "description": "Terra environment deployed at Verily.",
+
+  "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "workspaceManagerUri": "http://35.223.106.37:8080"
+}


### PR DESCRIPTION
Added a new server specification that points to the Verily deployment of dev WSM + Broad dev SAM.

CLI users can switch the server they're talking to with:
```
> terra server set terra-verily-dev
Terra server: terra-verily-dev (CHANGED FROM terra-dev)

> terra server status
Current server: terra-verily-dev (Terra development environment deployed at Verily.)
Server status: OKAY
```