### PR TITLE
PF-603: Hold pointers to output streams in a central place.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerAppsRunner.java
@@ -4,6 +4,7 @@ import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.TerraUser;
 import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.context.utils.Printer;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -20,6 +21,7 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import java.io.File;
+import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -350,12 +352,9 @@ public class DockerAppsRunner {
     @Override
     public void onNext(Frame frame) {
       String logStr = new String(frame.getPayload(), Charset.forName("UTF-8"));
-
-      // TODO: PF-423. Calling sysout.println here breaks the model of printing user-facing output
-      // from the command classes only.
-      // Revisit this once we have better model for centralizing output across all commands/rest of
-      // the codebase.
-      System.out.print(logStr); // write to stdout
+      PrintWriter err = Printer.getErr();
+      err.print(logStr);
+      err.flush();
 
       if (buildSingleStringOutput) {
         log.append(logStr);

--- a/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.auth;
 
 import bio.terra.cli.command.exception.SystemException;
+import bio.terra.cli.context.utils.Printer;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.extensions.java6.auth.oauth2.AbstractPromptReceiver;
@@ -22,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
 import java.util.List;
@@ -109,8 +111,9 @@ public final class GoogleCredentialUtils {
   private static class NoLaunchBrowser implements AuthorizationCodeInstalledApp.Browser {
     @Override
     public void browse(String url) {
-      System.out.println("Please open the following address in a browser on any machine:");
-      System.out.println("  " + url);
+      PrintWriter out = Printer.getOut();
+      out.println("Please open the following address in a browser on any machine:");
+      out.println("  " + url);
     }
   }
 

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -7,6 +7,7 @@ import bio.terra.cli.command.app.passthrough.Nextflow;
 import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.command.exception.UserActionableException;
 import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.utils.Printer;
 import java.util.Map;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -64,6 +65,11 @@ class Main implements Runnable {
     cmd.setExecutionExceptionHandler(new UserActionableAndSystemExceptionHandler());
     cmd.setColorScheme(colorScheme);
 
+    // set the output and error streams to the defaults: stdout, stderr
+    // save pointers to these streams in a singleton class, so we can access them throughout the
+    // codebase without passing them around
+    Printer.setupPrinting(cmd);
+
     // allow mixing options and parameters for all commands except the pass-through app commands.
     // this is because any options that follow the app command name should NOT be interpreted by the
     // Terra CLI, we want to pass those through to the app instead
@@ -76,7 +82,7 @@ class Main implements Runnable {
     // delegate to the appropriate command class, or print the usage if no command was specified
     cmd.execute(args);
     if (args.length == 0) {
-      cmd.usage(System.out);
+      cmd.usage(cmd.getOut());
     }
   }
 

--- a/src/main/java/bio/terra/cli/command/groups/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/groups/ListUsers.java
@@ -33,7 +33,7 @@ public class ListUsers extends BaseCommand {
   /** Print this command's output in text format. */
   private static void printText(java.util.List<String> returnValue) {
     for (String user : returnValue) {
-      System.out.println(user);
+      OUT.println(user);
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/FormatOption.java
@@ -1,10 +1,10 @@
 package bio.terra.cli.command.helperclasses;
 
 import bio.terra.cli.command.exception.SystemException;
+import bio.terra.cli.context.utils.Printer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import java.io.PrintStream;
 import java.util.function.Consumer;
 import picocli.CommandLine;
 
@@ -28,9 +28,6 @@ public class FormatOption {
     json,
     text;
   }
-
-  // output stream to use for writing command return value
-  private static final PrintStream OUT = System.out;
 
   /**
    * This method calls the {@link #printJson} method if the --format flag is set to JSON. Otherwise,
@@ -84,7 +81,7 @@ public class FormatOption {
     ObjectMapper objectMapper = new ObjectMapper();
     ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
     try {
-      OUT.println(objectWriter.writeValueAsString(returnValue));
+      Printer.getOut().println(objectWriter.writeValueAsString(returnValue));
     } catch (JsonProcessingException jsonEx) {
       throw new SystemException("Error JSON-formatting the command return value.", jsonEx);
     }
@@ -98,7 +95,7 @@ public class FormatOption {
    */
   public static <T> void printText(T returnValue) {
     if (returnValue != null) {
-      OUT.println(returnValue.toString());
+      Printer.getOut().println(returnValue.toString());
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -47,7 +47,7 @@ public class List extends BaseCommand {
                   && workspaceContext.getWorkspaceId().equals(workspace.getId()))
               ? " * "
               : "   ";
-      System.out.println(prefix + workspace.getId());
+      OUT.println(prefix + workspace.getId());
     }
   }
 }

--- a/src/main/java/bio/terra/cli/context/utils/Printer.java
+++ b/src/main/java/bio/terra/cli/context/utils/Printer.java
@@ -1,0 +1,89 @@
+package bio.terra.cli.context.utils;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Singleton class for holding a reference to output streams (e.g. stdout, stderr). The purpose of
+ * holding these references in a single place is so that we can write output throughout the codebase
+ * without passing around the output streams from the top-level command classes.
+ */
+public class Printer {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Printer.class);
+
+  public static final PrintWriter DEFAULT_OUT_WRITER = getPrintWriter(System.out);
+  public static final PrintWriter DEFAULT_ERR_WRITER = getPrintWriter(System.err);
+
+  private final PrintWriter outWriter;
+  private final PrintWriter errWriter;
+
+  private static Printer printer;
+
+  /** Constructor that initializes the printer with default values. */
+  private Printer() {
+    this(DEFAULT_OUT_WRITER, DEFAULT_ERR_WRITER);
+  }
+
+  /** Constructor that initializes the printer with the specified output streams. */
+  private Printer(PrintWriter outWriter, PrintWriter errWriter) {
+    this.outWriter = outWriter;
+    this.errWriter = errWriter;
+  }
+
+  /**
+   * This method should be called exactly once to setup printing in the top-level command (i.e.
+   * Main). It sets up the following:
+   *
+   * <p>- Sets the output stream pointers on the top-level command. This will recursively set the
+   * pointers on all sub-commands also.
+   *
+   * <p>- Initializes the singleton Printer object that holds pointers to the output streams for use
+   * elsewhere in the codebase (i.e. outside of command classes). This method uses default values
+   * for these output streams.
+   *
+   * @param cmd picocli top-level command line object that holds pointers to the output streams
+   */
+  public static void setupPrinting(CommandLine cmd) {
+    if (printer == null) {
+      printer = new Printer();
+    } else {
+      logger.warn("Printing setup called multiple times.");
+    }
+    cmd.setOut(printer.outWriter);
+    cmd.setErr(printer.errWriter);
+  }
+
+  /**
+   * Utility method to get the output stream from the singleton.
+   *
+   * @return stream to write output (e.g. stdout)
+   */
+  public static PrintWriter getOut() {
+    if (printer == null) {
+      logger.warn("Attempt to access printer output stream before setup.");
+      return DEFAULT_OUT_WRITER;
+    }
+    return printer.outWriter;
+  }
+
+  /**
+   * Utility method to get the error stream from the singleton.
+   *
+   * @return stream to write errors and running status (e.g. stderr)
+   */
+  public static PrintWriter getErr() {
+    if (printer == null) {
+      logger.warn("Attempt to access printer error stream before setup.");
+      return DEFAULT_ERR_WRITER;
+    }
+    return printer.errWriter;
+  }
+
+  /** Utility method to get a UTF-8 encoded character output stream from a raw byte stream. */
+  private static PrintWriter getPrintWriter(PrintStream printStream) {
+    return new PrintWriter(printStream, true, Charset.forName("UTF-8"));
+  }
+}


### PR DESCRIPTION
- Added a singleton `Printer` utility class that holds pointers to the output streams we can write to.
- This removes the various places that hard-coded `System.out` and `System.err`, so that this is only specified in a single central place. The goal is to make this easy to change (in code or by users via global context) in the future.
- Also changed the Docker command output to write to stderr instead of stdout. This should make it easier for the commands that invoke Docker to also specify a return value by writing to stdout.

(This is a follow-on ticket from the JSON format flag/base command general overhaul/cleanup.)

- Note that one [approach for picocli testing](https://picocli.info/#_black_box_and_white_box_testing) is to specify output streams other than `System.out` and `System.err` in the `CommandLine` setup (i.e. in `Main`). For this reason, I think we want to setup printing in `Main` instead of in `BaseCommand`, so that for testing, we can override the default output streams by constructing our own `CommandLine` class as shown in the documentation.