### PR TITLE
PF-534: Workspace name and description.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,12 @@ application {
     mainClass = 'bio.terra.cli.command.Main'
     applicationName = 'terra'
     executableDir = 'bin'
+
+    // TODO: Suppress Jersey PATCH related warnings (PF-622)
+    applicationDefaultJvmArgs = [
+            '--add-opens', 'java.base/sun.net.www.protocol.https=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.net=ALL-UNNAMED',
+    ]
 }
 startScripts {
     // set the $APP_HOME path to $HOME/.terra

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
         // terra libraries
         samClient = "0.1-9435410-SNAP"
-        workspaceManagerClient = "0.16.0-SNAPSHOT"
+        workspaceManagerClient = "0.18.0-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/command/Status.java
+++ b/src/main/java/bio/terra/cli/command/Status.java
@@ -44,8 +44,8 @@ public class Status extends BaseCommand {
       OUT.println("There is no current Terra workspace defined.");
     } else {
       OUT.println("Terra workspace id: " + workspaceContext.getWorkspaceId());
-      OUT.println("Display name: " + workspaceContext.getWorkspaceDisplayName());
-      OUT.println("Description: " + workspaceContext.getWorkspaceDescription());
+      OUT.println("Display name: " + workspaceContext.getWorkspaceDisplayName().orElse(""));
+      OUT.println("Description: " + workspaceContext.getWorkspaceDescription().orElse(""));
       OUT.println("Google project: " + workspaceContext.getGoogleProject());
     }
   }

--- a/src/main/java/bio/terra/cli/command/Status.java
+++ b/src/main/java/bio/terra/cli/command/Status.java
@@ -43,7 +43,9 @@ public class Status extends BaseCommand {
     if (workspaceContext.isEmpty()) {
       OUT.println("There is no current Terra workspace defined.");
     } else {
-      OUT.println("Terra workspace: " + workspaceContext.getWorkspaceId());
+      OUT.println("Terra workspace id: " + workspaceContext.getWorkspaceId());
+      OUT.println("Display name: " + workspaceContext.getWorkspaceDisplayName());
+      OUT.println("Description: " + workspaceContext.getWorkspaceDescription());
       OUT.println("Google project: " + workspaceContext.getGoogleProject());
     }
   }

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -7,6 +7,7 @@ import bio.terra.cli.command.workspace.List;
 import bio.terra.cli.command.workspace.ListUsers;
 import bio.terra.cli.command.workspace.Mount;
 import bio.terra.cli.command.workspace.RemoveUser;
+import bio.terra.cli.command.workspace.Update;
 import picocli.CommandLine.Command;
 
 /**
@@ -21,6 +22,7 @@ import picocli.CommandLine.Command;
       Create.class,
       Mount.class,
       Delete.class,
+      Update.class,
       ListUsers.class,
       AddUser.class,
       RemoveUser.class

--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -12,12 +12,21 @@ import picocli.CommandLine.Command;
 @Command(name = "create", description = "Create a new workspace.")
 public class Create extends BaseCommand {
 
+  @CommandLine.Option(names = "--name", required = false, description = "workspace display name")
+  private String displayName;
+
+  @CommandLine.Option(
+      names = "--description",
+      required = false,
+      description = "workspace description")
+  private String description;
+
   @CommandLine.Mixin FormatOption formatOption;
 
   /** Create a new workspace. */
   @Override
   protected void execute() {
-    new WorkspaceManager(globalContext, workspaceContext).createWorkspace();
+    new WorkspaceManager(globalContext, workspaceContext).createWorkspace(displayName, description);
     new AuthenticationManager(globalContext, workspaceContext)
         .fetchPetSaCredentials(globalContext.requireCurrentTerraUser());
     formatOption.printReturnValue(workspaceContext.terraWorkspaceModel, this::printText);

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -47,7 +47,16 @@ public class List extends BaseCommand {
                   && workspaceContext.getWorkspaceId().equals(workspace.getId()))
               ? " * "
               : "   ";
-      System.out.println(prefix + workspace.getId());
+      OUT.println(prefix + workspace.getId());
+
+      String displayName = workspace.getDisplayName();
+      if (!(displayName == null || displayName.isBlank())) {
+        OUT.println("     Name: " + displayName);
+      }
+      String description = workspace.getDescription();
+      if (!(description == null || description.isBlank())) {
+        OUT.println("     Description: " + description);
+      }
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -49,13 +49,14 @@ public class List extends BaseCommand {
               : "   ";
       OUT.println(prefix + workspace.getId());
 
+      String propertyDescription = "%16s: %s";
       String displayName = workspace.getDisplayName();
       if (!(displayName == null || displayName.isBlank())) {
-        OUT.println("     Name: " + displayName);
+        OUT.println(String.format(propertyDescription, "Name", displayName));
       }
       String description = workspace.getDescription();
       if (!(description == null || description.isBlank())) {
-        OUT.println("     Description: " + description);
+        OUT.println(String.format(propertyDescription, "Description", description));
       }
     }
   }

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -1,0 +1,42 @@
+package bio.terra.cli.command.workspace;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import bio.terra.cli.service.WorkspaceManager;
+import bio.terra.workspace.model.WorkspaceDescription;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra workspace update" command. */
+@Command(name = "update", description = "Update an existing workspace.")
+public class Update extends BaseCommand {
+
+  @CommandLine.ArgGroup(exclusive = false, multiplicity = "1..2")
+  Update.UpdateArgGroup argGroup;
+
+  static class UpdateArgGroup {
+    @CommandLine.Option(names = "--name", required = false, description = "workspace display name")
+    private String displayName;
+
+    @CommandLine.Option(
+        names = "--description",
+        required = false,
+        description = "workspace description")
+    private String description;
+  }
+
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Update the mutable properties of an existing workspace. */
+  @Override
+  protected void execute() {
+    new WorkspaceManager(globalContext, workspaceContext)
+        .updateWorkspace(argGroup.displayName, argGroup.description);
+    formatOption.printReturnValue(workspaceContext.terraWorkspaceModel, this::printText);
+  }
+
+  /** Print this command's output in text format. */
+  private void printText(WorkspaceDescription returnValue) {
+    OUT.println("Workspace successfully updated: " + workspaceContext.getWorkspaceId());
+  }
+}

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command;
 @Command(name = "update", description = "Update an existing workspace.")
 public class Update extends BaseCommand {
 
-  @CommandLine.ArgGroup(exclusive = false, multiplicity = "1..2")
+  @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
   Update.UpdateArgGroup argGroup;
 
   static class UpdateArgGroup {

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -11,7 +11,10 @@ import picocli.CommandLine.Command;
 @Command(name = "update", description = "Update an existing workspace.")
 public class Update extends BaseCommand {
 
-  @CommandLine.ArgGroup(exclusive = false, multiplicity = "1")
+  @CommandLine.ArgGroup(
+      exclusive = false,
+      multiplicity = "1",
+      heading = "Property update parameters:%n")
   Update.UpdateArgGroup argGroup;
 
   static class UpdateArgGroup {

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -100,6 +100,32 @@ public class WorkspaceContext {
   }
 
   /**
+   * Getter for the Terra workspace display name. Returns empty string if the display name is not
+   * defined.
+   *
+   * @return the Terra workspace display name
+   */
+  @JsonIgnore
+  public String getWorkspaceDisplayName() {
+    return terraWorkspaceModel == null || terraWorkspaceModel.getDisplayName() == null
+        ? ""
+        : terraWorkspaceModel.getDisplayName();
+  }
+
+  /**
+   * Getter for the Terra workspace description. Returns empty string if the description is not
+   * defined.
+   *
+   * @return the Terra workspace description
+   */
+  @JsonIgnore
+  public String getWorkspaceDescription() {
+    return terraWorkspaceModel == null || terraWorkspaceModel.getDescription() == null
+        ? ""
+        : terraWorkspaceModel.getDescription();
+  }
+
+  /**
    * Getter for the Terra workspace id.
    *
    * @return the Terra workspace id

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -108,9 +108,7 @@ public class WorkspaceContext {
    */
   @JsonIgnore
   public Optional<String> getWorkspaceDisplayName() {
-    return terraWorkspaceModel == null
-        ? Optional.empty()
-        : Optional.ofNullable(terraWorkspaceModel.getDisplayName());
+    return Optional.ofNullable(terraWorkspaceModel).map(WorkspaceDescription::getDisplayName);
   }
 
   /**
@@ -121,9 +119,7 @@ public class WorkspaceContext {
    */
   @JsonIgnore
   public Optional<String> getWorkspaceDescription() {
-    return terraWorkspaceModel == null
-        ? Optional.empty()
-        : Optional.ofNullable(terraWorkspaceModel.getDescription());
+    return Optional.ofNullable(terraWorkspaceModel).map(WorkspaceDescription::getDescription);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -100,29 +101,29 @@ public class WorkspaceContext {
   }
 
   /**
-   * Getter for the Terra workspace display name. Returns empty string if the display name is not
+   * Getter for the Terra workspace display name. Returns empty Optional if the display name is not
    * defined.
    *
    * @return the Terra workspace display name
    */
   @JsonIgnore
-  public String getWorkspaceDisplayName() {
-    return terraWorkspaceModel == null || terraWorkspaceModel.getDisplayName() == null
-        ? ""
-        : terraWorkspaceModel.getDisplayName();
+  public Optional<String> getWorkspaceDisplayName() {
+    return terraWorkspaceModel == null
+        ? Optional.empty()
+        : Optional.ofNullable(terraWorkspaceModel.getDisplayName());
   }
 
   /**
-   * Getter for the Terra workspace description. Returns empty string if the description is not
+   * Getter for the Terra workspace description. Returns empty Optional if the description is not
    * defined.
    *
    * @return the Terra workspace description
    */
   @JsonIgnore
-  public String getWorkspaceDescription() {
-    return terraWorkspaceModel == null || terraWorkspaceModel.getDescription() == null
-        ? ""
-        : terraWorkspaceModel.getDescription();
+  public Optional<String> getWorkspaceDescription() {
+    return terraWorkspaceModel == null
+        ? Optional.empty()
+        : Optional.ofNullable(terraWorkspaceModel.getDescription());
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -133,6 +133,33 @@ public class WorkspaceManager {
   }
 
   /**
+   * Update the mutable properties of the workspace that is mounted to the current directory.
+   *
+   * @param displayName optional display name
+   * @param description optional description
+   * @throws UserActionableException if there is no workspace currently mounted
+   */
+  public void updateWorkspace(String displayName, String description) {
+    // check that there is a workspace currently mounted
+    workspaceContext.requireCurrentWorkspace();
+
+    // check that there is a current user, we will use their credentials to communicate with WSM
+    TerraUser currentUser = globalContext.requireCurrentTerraUser();
+
+    // call WSM to update the existing workspace object
+    WorkspaceDescription workspace = workspaceContext.terraWorkspaceModel;
+    WorkspaceDescription updatedWorkspace =
+        new WorkspaceManagerService(globalContext.server, currentUser)
+            .updateWorkspace(workspaceContext.getWorkspaceId(), displayName, description);
+    logger.info("Updated workspace: id={}, {}", workspace.getId(), workspace);
+
+    // update the workspace in the current context
+    // note that this state is persisted to disk. it will be useful for code called in the same or a
+    // later CLI command/process
+    workspaceContext.updateWorkspace(updatedWorkspace);
+  }
+
+  /**
    * Add a user to the workspace that is mounted to the current directory. Possible roles are
    * defined by the WSM client library.
    *

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -46,8 +46,13 @@ public class WorkspaceManager {
         .getWorkspaces();
   }
 
-  /** Create a new workspace. */
-  public void createWorkspace() {
+  /**
+   * Create a new workspace.
+   *
+   * @param displayName optional display name
+   * @param description optional description
+   */
+  public void createWorkspace(String displayName, String description) {
     // check that there is no existing workspace already mounted
     if (!workspaceContext.isEmpty()) {
       throw new UserActionableException("There is already a workspace mounted to this directory.");
@@ -58,7 +63,8 @@ public class WorkspaceManager {
 
     // call WSM to create the workspace object and backing Google context
     WorkspaceDescription createdWorkspace =
-        new WorkspaceManagerService(globalContext.server, currentUser).createWorkspace();
+        new WorkspaceManagerService(globalContext.server, currentUser)
+            .createWorkspace(displayName, description);
     logger.info("Created workspace: id={}, {}", createdWorkspace.getId(), createdWorkspace);
 
     // update the workspace context with the current workspace

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -25,6 +25,7 @@ import bio.terra.workspace.model.WorkspaceStageModel;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,7 +140,8 @@ public class WorkspaceManagerService {
    * @param description optional description
    * @return the Workspace Manager workspace description object
    */
-  public WorkspaceDescription createWorkspace(String displayName, String description) {
+  public WorkspaceDescription createWorkspace(
+      @Nullable String displayName, @Nullable String description) {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
       // create the Terra workspace object
@@ -243,7 +245,7 @@ public class WorkspaceManagerService {
    * @return the Workspace Manager workspace description object
    */
   public WorkspaceDescription updateWorkspace(
-      UUID workspaceId, String displayName, String description) {
+      UUID workspaceId, @Nullable String displayName, @Nullable String description) {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
       // update the Terra workspace object

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -18,6 +18,7 @@ import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.RoleBindingList;
 import bio.terra.workspace.model.SystemStatus;
 import bio.terra.workspace.model.SystemVersion;
+import bio.terra.workspace.model.UpdateWorkspaceRequestBody;
 import bio.terra.workspace.model.WorkspaceDescription;
 import bio.terra.workspace.model.WorkspaceDescriptionList;
 import bio.terra.workspace.model.WorkspaceStageModel;
@@ -231,6 +232,26 @@ public class WorkspaceManagerService {
       workspaceApi.deleteWorkspace(workspaceId);
     } catch (ApiException ex) {
       throw new SystemException("Error deleting workspace", ex);
+    }
+  }
+
+  /**
+   * Call the Workspace Manager PATCH "/api/workspaces/v1/{id}" endpoint to update an existing
+   * workspace.
+   *
+   * @param workspaceId the id of the workspace to update
+   * @return the Workspace Manager workspace description object
+   */
+  public WorkspaceDescription updateWorkspace(
+      UUID workspaceId, String displayName, String description) {
+    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
+    try {
+      // update the Terra workspace object
+      UpdateWorkspaceRequestBody updateRequest =
+          new UpdateWorkspaceRequestBody().displayName(displayName).description(description);
+      return workspaceApi.updateWorkspace(updateRequest, workspaceId);
+    } catch (ApiException ex) {
+      throw new SystemException("Error updating workspace", ex);
     }
   }
 

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -134,9 +134,11 @@ public class WorkspaceManagerService {
    * Google context. Poll the "/api/workspaces/v1/{workspaceId}/cloudcontexts/results/{jobId}"
    * endpoint to wait for the job to finish.
    *
+   * @param displayName optional display name
+   * @param description optional description
    * @return the Workspace Manager workspace description object
    */
-  public WorkspaceDescription createWorkspace() {
+  public WorkspaceDescription createWorkspace(String displayName, String description) {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
       // create the Terra workspace object
@@ -145,6 +147,8 @@ public class WorkspaceManagerService {
       workspaceRequestBody.setId(workspaceId);
       workspaceRequestBody.setStage(WorkspaceStageModel.MC_WORKSPACE);
       workspaceRequestBody.setSpendProfile("wm-default-spend-profile");
+      workspaceRequestBody.setDisplayName(displayName);
+      workspaceRequestBody.setDescription(description);
       workspaceApi.createWorkspace(workspaceRequestBody);
 
       // create the Google project that backs the Terra workspace object


### PR DESCRIPTION
- Bump the WSM client library to the latest version.
- Include the workspace display name and description in the output of `terra status` and `terra workspace list`.
- Added optional flags to specify the display name and description in `terra workspace create`.
- Added a new `terra workspace update` command to allow modifying these mutable properties.

TODO: The `terra workspace update` command always prints out these `WARNING` messages. I'm not sure the cause -- but it seems to be triggered by the client library call `workspaceApi.updateWorkspace` in `WorkspaceManagerService`.

```
> terra workspace create --name="ws_name" --description="ws_description"
Workspace successfully created: dbed98b9-180f-4ee3-b141-8858f6472942

> terra status
Terra server: terra-dev
Terra workspace id: dbed98b9-180f-4ee3-b141-8858f6472942
Display name: ws_name
Description: ws_description
Google project: terra-wsm-dev-31106d3e

> terra workspace update --name="ws_name_updated"
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.glassfish.jersey.client.internal.HttpUrlConnector$3 (file:/Users/marikomedlock/Workspaces/terra-cli/build/install/terra-cli/lib/jersey-client-2.32.jar) to field sun.net.www.protocol.https.HttpsURLConnectionImpl.delegate
WARNING: Please consider reporting this to the maintainers of org.glassfish.jersey.client.internal.HttpUrlConnector$3
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Workspace successfully updated: dbed98b9-180f-4ee3-b141-8858f6472942

> terra workspace list
   8b120c98-8d99-44af-99d9-7fedaf5c3865
   c8c7b4b1-d7ce-4bce-b20c-b480b20b959e
 * dbed98b9-180f-4ee3-b141-8858f6472942
     Name: ws_name_updated
     Description: ws_description
```