### PR TITLE
PF-663 Add support for big query datasets as another resource type.

### DIFF
--- a/src/main/java/bio/terra/cli/command/datarefs/Add.java
+++ b/src/main/java/bio/terra/cli/command/datarefs/Add.java
@@ -26,7 +26,8 @@ public class Add extends BaseCommand {
   @CommandLine.Option(
       names = "--uri",
       required = true,
-      description = "The bucket path (e.g. gs://my-bucket)")
+      description =
+          "The cloud id of the data reference. (e.g. for buckets gs://my-bucket', for BigQuery datasets 'projectId.datasetId')")
   private String uri;
 
   @CommandLine.Mixin FormatOption formatOption;

--- a/src/main/java/bio/terra/cli/context/CloudResource.java
+++ b/src/main/java/bio/terra/cli/context/CloudResource.java
@@ -1,9 +1,21 @@
 package bio.terra.cli.context;
 
+import bio.terra.cli.command.exception.UserActionableException;
+import bio.terra.cli.service.utils.GoogleBigQuery;
 import bio.terra.cli.service.utils.GoogleCloudStorage;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.bigquery.DatasetId;
 
 /** This POJO class represents a Terra workspace cloud resource (controlled or external). */
 public class CloudResource {
+  /**
+   * Delimiter between the project id and dataset id for a bigQueryDataset {@link #cloudId}.
+   *
+   * <p>The choice is somewhat arbitrary. BigQuery Datatsets do not have true URIs. The '.'
+   * delimiter allows the cloudId to be used directly in SQL calls with a bigquery extension.
+   */
+  private static final char DATASET_CLOUD_ID_DELIMITER = '.';
+
   // name of the cloud resource. names are unique within a workspace
   public String name;
 
@@ -29,7 +41,9 @@ public class CloudResource {
 
   /** Type of cloud resource. */
   public enum Type {
-    bucket(true);
+    bucket(true),
+    // cloudId format is 'projectId.datasetId'.
+    bigQueryDataset(true);
 
     // true means this cloud resource will be included in the list of data references for a
     // workspace
@@ -47,8 +61,22 @@ public class CloudResource {
    * @return true if the user has access
    */
   public boolean checkAccessForUser(TerraUser terraUser, WorkspaceContext workspaceContext) {
-    return new GoogleCloudStorage(terraUser.userCredentials, workspaceContext.getGoogleProject())
-        .checkObjectsListAccess(cloudId);
+    return checkAccess(terraUser.userCredentials, workspaceContext);
+  }
+
+  public static DatasetId cloudIdToDatasetId(String cloudId) {
+    int delimiterIndex = cloudId.indexOf(DATASET_CLOUD_ID_DELIMITER);
+    if (delimiterIndex == -1) {
+      throw new UserActionableException(
+          "Expected the cloudId for a dataset to be of the form 'projectId.datasetId', but was "
+              + cloudId);
+    }
+    return DatasetId.of(
+        cloudId.substring(0, delimiterIndex), cloudId.substring(delimiterIndex + 1));
+  }
+
+  public static String toCloudId(DatasetId datasetId) {
+    return datasetId.getProject() + DATASET_CLOUD_ID_DELIMITER + datasetId.getDataset();
   }
 
   /**
@@ -58,7 +86,18 @@ public class CloudResource {
    * @return true if the user's pet SA has access
    */
   public boolean checkAccessForPetSa(TerraUser terraUser, WorkspaceContext workspaceContext) {
-    return new GoogleCloudStorage(terraUser.petSACredentials, workspaceContext.getGoogleProject())
-        .checkObjectsListAccess(cloudId);
+    return checkAccess(terraUser.petSACredentials, workspaceContext);
+  }
+
+  private boolean checkAccess(GoogleCredentials credentials, WorkspaceContext workspaceContext) {
+    switch (type) {
+      case bucket:
+        return new GoogleCloudStorage(credentials, workspaceContext.getGoogleProject())
+            .checkObjectsListAccess(cloudId);
+      case bigQueryDataset:
+        return new GoogleBigQuery(credentials, workspaceContext.getGoogleProject())
+            .checkListTablesAccess(CloudResource.cloudIdToDatasetId(cloudId));
+    }
+    throw new IllegalArgumentException("Unhandled CloudResource type.");
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/GoogleBigQuery.java
+++ b/src/main/java/bio/terra/cli/service/utils/GoogleBigQuery.java
@@ -1,0 +1,57 @@
+package bio.terra.cli.service.utils;
+
+import bio.terra.cli.command.exception.SystemException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.bigquery.DatasetId;
+import com.google.cloud.bigquery.DatasetInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Utility methods for calling Google Cloud BigQuery endpoints. */
+public class GoogleBigQuery {
+  private static final Logger logger = LoggerFactory.getLogger(GoogleCloudStorage.class);
+
+  private final BigQuery bigQuery;
+
+  public GoogleBigQuery(GoogleCredentials credentials, String projectId) {
+    bigQuery =
+        BigQueryOptions.newBuilder()
+            .setCredentials(credentials)
+            .setProjectId(projectId)
+            .build()
+            .getService();
+  }
+
+  public Dataset create(DatasetId datasetId) {
+    logger.info("Creating dataset: {}", datasetId);
+    return bigQuery.create(DatasetInfo.newBuilder(datasetId.getDataset()).build());
+  }
+
+  public void delete(DatasetId datasetId) {
+    logger.info("Deleting dataset: {}", datasetId);
+    boolean deleted = bigQuery.delete(datasetId);
+    if (!deleted) {
+      throw new SystemException("BigQuery dataset not found for deletion.");
+    }
+  }
+
+  /** Returns whether we have permission to list tables in the dataset. */
+  public boolean checkListTablesAccess(DatasetId datasetId) {
+    try {
+      bigQuery.listTables(datasetId);
+      return true;
+    } catch (BigQueryException e) {
+      logger.debug("BigQuery exception = {}", e);
+      if (e.getCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND
+          || e.getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
+        return false;
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
This add support for using BigQuery datasets in both the `resources` and `data-refs` commands.

This is our second resource type. I'm not really sold on our interfaces with the `WorkspaceManager` class and the switch statements everywhere. On the other hand, this is likely to get a major revision once we switch to using WM APIs instead of direct cloud access for create/delete/list, so I'm not sure how much investment to put in at this point.  