### PR TITLE
PF-665 bump gcloud sdk version to temporarily unbreak Dockerfile.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 # other examples of installing gcloud in a docker image:
 #   - AoU (https://github.com/all-of-us/workbench/blob/master/api/src/dev/server/Dockerfile#L34)
 #   - Terra Jupyter (https://github.com/DataBiosphere/terra-docker/blob/master/terra-jupyter-base/Dockerfile#L74)
-ENV CLOUD_SDK_VERSION 326.0.0-0
+ENV CLOUD_SDK_VERSION 335.0.0-0
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && apt-get install apt-transport-https ca-certificates gnupg -y \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \

--- a/tools/build-docker.sh
+++ b/tools/build-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script builds the Docker image that the CLI uses to run applications.
 ## Dependencies: docker, git
 ## Inputs: localImageTag (arg, optional) tag of the local image, default is Git commit hash

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script downloads a release archive of the Terra CLI and calls its install script.
 ## Dependencies: curl, tar
 ## Inputs: TERRA_CLI_VERSION (env var, optional) specific version requested, default is latest

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script installs the Terra CLI from an unarchived release directory.
 ## Dependencies: docker, gcloud
 ## Usage: ./install.sh

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script sets up the environment for local development.
 ## Dependencies: docker, chmod
 ## Usage: source tools/local-dev.sh

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script builds the Docker image that the CLI uses to run applications.
 ## Dependencies: docker, gcloud
 ## Inputs: remoteImageTag (arg, required) tag of the image in GCR

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+set -e
 ## This script builds a new GitHub release for the Terra CLI, and uploads a new Docker container.
 ## The GitHub release includes an install package and a download + install script.
 ## Note that a pre-release does not affect the "Latest release" tag, but a regular release does.


### PR DESCRIPTION
Google doesn't support versions indefinitely on apt-get install. Bump to the latest gcloud sdk version as a fix to stop docker image builds from failing.
Filed PF-665 for consideration of a longer term fix that won't break in ~2 months after there have been 10 more weekly releases from Google.

https://github.com/DataBiosphere/terra-cli/runs/2238110791
```
E: Version '326.0.0-0' for 'google-cloud-sdk' was not found
The command '/bin/sh -c echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list     && apt-get install apt-transport-https ca-certificates gnupg -y     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add -     && apt-get update -y && apt-get install google-cloud-sdk=$***CLOUD_SDK_VERSION*** -y' returned a non-zero code: 100
```

Add `set -e` to tools scripts so that they fail early on subcommands instead of blithely proceeding. This should help us find breakages earlier and users identify problems.