### PR TITLE
PF-662 add a 'resources resolve' command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Commands:
   delete    Delete an existing controlled resource.
   describe  Describe an existing controlled resource.
   list      List all controlled resources.
+  resolve   Resolve a resource to its cloud id or path.
 ```
 
 A controlled resource is a cloud resource managed by the Terra workspace on behalf of the user.

--- a/src/main/java/bio/terra/cli/command/Resources.java
+++ b/src/main/java/bio/terra/cli/command/Resources.java
@@ -4,6 +4,7 @@ import bio.terra.cli.command.resources.Create;
 import bio.terra.cli.command.resources.Delete;
 import bio.terra.cli.command.resources.Describe;
 import bio.terra.cli.command.resources.List;
+import bio.terra.cli.command.resources.Resolve;
 import picocli.CommandLine;
 
 /**
@@ -13,5 +14,5 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "resources",
     description = "Manage controlled resources in the workspace.",
-    subcommands = {Create.class, Delete.class, Describe.class, List.class})
+    subcommands = {Create.class, Delete.class, Describe.class, List.class, Resolve.class})
 public class Resources {}

--- a/src/main/java/bio/terra/cli/command/resources/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resources/Resolve.java
@@ -1,0 +1,28 @@
+package bio.terra.cli.command.resources;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import bio.terra.cli.context.CloudResource;
+import bio.terra.cli.service.WorkspaceManager;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra resources resolve" command. */
+@CommandLine.Command(name = "resolve", description = "Resolve a resource to its cloud id or path.")
+public class Resolve extends BaseCommand {
+
+  @CommandLine.Option(
+      names = "--name",
+      required = true,
+      description = "The name of the resource, scoped to the workspace.")
+  private String name;
+
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Resolve a resource in the workspace to its cloud identifier. */
+  @Override
+  protected void execute() {
+    CloudResource resource =
+        new WorkspaceManager(globalContext, workspaceContext).getControlledResource(name);
+    formatOption.printReturnValue(resource.cloudId);
+  }
+}


### PR DESCRIPTION
This is a convenience command for getting the cloud id of a controlled resource. It parallels the 'data-refs resolve' command.