### PR TITLE
[PF-634] Add verily-cli environment

### DIFF
--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,1 +1,1 @@
-[ "terra-dev.json", "terra-verily-dev.json", "mm-dev.json", "wchamber-dev.json" ]
+[ "terra-dev.json", "terra-verily-dev.json", "mm-dev.json", "verily-cli.json", "wchamber-dev.json" ]

--- a/src/main/resources/servers/verily-cli.json
+++ b/src/main/resources/servers/verily-cli.json
@@ -1,0 +1,8 @@
+{
+  "name": "verily-cli",
+  "description": "A more stable dev-like environment for development with the CLI.",
+
+  "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.verilycli.integ.envs.broadinstitute.org"
+}


### PR DESCRIPTION
This adds configuration for the newly created `verilycli` personal environment. Unlike other personal environments, this WSM instance points to dev RBS, so projects will not be cleaned up by Janitor. This is intended to be similar to dev, but will be manually synced instead of automatically updated every time WSM head is changed. This should give us more stability for development without blocking backwards-incompatible WSM changes.

In the near-future, this will be set as the default WSM server. I'm not doing that yet so we have some time to transition existing workspaces.

From CONTRIBUTING.md it seems like I don't need to do any manual publishing, it should all be handled by GHA. Is that true?