### PR TITLE
PF-598: Update server specification on install

### DIFF
--- a/src/main/java/bio/terra/cli/command/Server.java
+++ b/src/main/java/bio/terra/cli/command/Server.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command;
 
 import bio.terra.cli.command.server.List;
-import bio.terra.cli.command.server.Set;
 import bio.terra.cli.command.server.Status;
 import picocli.CommandLine.Command;
 
@@ -12,5 +11,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "server",
     description = "Connect to a Terra server.",
-    subcommands = {Status.class, List.class, Set.class})
+    subcommands = {Status.class, List.class})
 public class Server {}

--- a/src/main/java/bio/terra/cli/command/Server.java
+++ b/src/main/java/bio/terra/cli/command/Server.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.command;
 
 import bio.terra.cli.command.server.List;
+import bio.terra.cli.command.server.Set;
 import bio.terra.cli.command.server.Status;
 import picocli.CommandLine.Command;
 
@@ -11,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "server",
     description = "Connect to a Terra server.",
-    subcommands = {Status.class, List.class})
+    subcommands = {Status.class, List.class, Set.class})
 public class Server {}

--- a/src/main/java/bio/terra/cli/command/config/GetValue.java
+++ b/src/main/java/bio/terra/cli/command/config/GetValue.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.config;
 import bio.terra.cli.command.config.getvalue.Browser;
 import bio.terra.cli.command.config.getvalue.Image;
 import bio.terra.cli.command.config.getvalue.Logging;
+import bio.terra.cli.command.config.getvalue.Server;
 import picocli.CommandLine.Command;
 
 /**
@@ -12,5 +13,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "get-value",
     description = "Get a configuration property value.",
-    subcommands = {Browser.class, Image.class, Logging.class})
+    subcommands = {Browser.class, Image.class, Logging.class, Server.class})
 public class GetValue {}

--- a/src/main/java/bio/terra/cli/command/config/List.java
+++ b/src/main/java/bio/terra/cli/command/config/List.java
@@ -6,6 +6,7 @@ import bio.terra.cli.auth.AuthenticationManager;
 import bio.terra.cli.command.config.getvalue.Logging;
 import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.command.helperclasses.FormatOption;
+import bio.terra.cli.context.ServerSpecification;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra config list" command. */
@@ -23,7 +24,10 @@ public class List extends BaseCommand {
         new LoggingReturnValue(globalContext.consoleLoggingLevel, globalContext.fileLoggingLevel);
     ConfigListReturnValue configList =
         new ConfigListReturnValue(
-            globalContext.browserLaunchOption, globalContext.dockerImageId, loggingLevels);
+            globalContext.browserLaunchOption,
+            globalContext.dockerImageId,
+            loggingLevels,
+            globalContext.server);
 
     formatOption.printReturnValue(configList, List::printText);
   }
@@ -33,14 +37,17 @@ public class List extends BaseCommand {
     public AuthenticationManager.BrowserLaunchOption browser;
     public String image;
     public LoggingReturnValue logging;
+    public ServerSpecification server;
 
     public ConfigListReturnValue(
         AuthenticationManager.BrowserLaunchOption browser,
         String image,
-        LoggingReturnValue logging) {
+        LoggingReturnValue logging,
+        ServerSpecification server) {
       this.browser = browser;
       this.image = image;
       this.logging = logging;
+      this.server = server;
     }
   }
 
@@ -50,6 +57,8 @@ public class List extends BaseCommand {
     OUT.println("[image] docker image id = " + returnValue.image);
     OUT.println();
     Logging.printText(returnValue.logging);
+    OUT.println();
+    OUT.println("[server] server = " + returnValue.server.name);
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/Set.java
+++ b/src/main/java/bio/terra/cli/command/config/Set.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.config;
 import bio.terra.cli.command.config.set.Browser;
 import bio.terra.cli.command.config.set.Image;
 import bio.terra.cli.command.config.set.Logging;
+import bio.terra.cli.command.config.set.Server;
 import picocli.CommandLine.Command;
 
 /**
@@ -12,5 +13,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "set",
     description = "Set a configuration property value.",
-    subcommands = {Browser.class, Image.class, Logging.class})
+    subcommands = {Browser.class, Image.class, Logging.class, Server.class})
 public class Set {}

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
@@ -6,7 +6,7 @@ import bio.terra.cli.context.ServerSpecification;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-/** This class corresponds to the fourth-level "terra config get-value browser" command. */
+/** This class corresponds to the fourth-level "terra config get-value server" command. */
 @Command(name = "server", description = "Get the Terra server the CLI connects to.")
 public class Server extends BaseCommand {
 

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
@@ -12,7 +12,7 @@ public class Server extends BaseCommand {
 
   @CommandLine.Mixin FormatOption formatOption;
 
-  /** Return the browser launch option property of the global context. */
+  /** Return the server property of the global context. */
   @Override
   protected void execute() {
     formatOption.printReturnValue(globalContext.server, Server::printText);

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Server.java
@@ -1,0 +1,31 @@
+package bio.terra.cli.command.config.getvalue;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.FormatOption;
+import bio.terra.cli.context.ServerSpecification;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the fourth-level "terra config get-value browser" command. */
+@Command(name = "server", description = "Get the Terra server the CLI connects to.")
+public class Server extends BaseCommand {
+
+  @CommandLine.Mixin FormatOption formatOption;
+
+  /** Return the browser launch option property of the global context. */
+  @Override
+  protected void execute() {
+    formatOption.printReturnValue(globalContext.server, Server::printText);
+  }
+
+  /** Print this command's output in text format. */
+  public static void printText(ServerSpecification returnValue) {
+    OUT.println(returnValue.name);
+  }
+
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/config/set/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Server.java
@@ -1,4 +1,4 @@
-package bio.terra.cli.command.server;
+package bio.terra.cli.command.config.set;
 
 import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.service.ServerManager;
@@ -6,8 +6,11 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra server set" command. */
-@Command(name = "set", description = "Set the Terra server to connect to.")
-public class Set extends BaseCommand {
+@Command(
+    name = "server",
+    description =
+        "Set the Terra server to connect to. Run `terra server list` to see the available servers.")
+public class Server extends BaseCommand {
 
   @CommandLine.Parameters(index = "0", description = "server name")
   private String serverName;
@@ -15,7 +18,15 @@ public class Set extends BaseCommand {
   /** Update the Terra environment to which the CLI is pointing. */
   @Override
   protected void execute() {
+    String prevServerName = globalContext.server.name;
     new ServerManager(globalContext).updateServer(serverName);
+
+    OUT.println(
+        "Terra server is set to "
+            + globalContext.server.name
+            + " ("
+            + (globalContext.server.name.equals(prevServerName) ? "UNCHANGED" : "CHANGED")
+            + ").");
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/set/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Server.java
@@ -7,8 +7,5 @@ import picocli.CommandLine.Command;
  * This class corresponds to the fourth-level "terra config set server" command. It is exactly the
  * same command as "terra server set".
  */
-@Command(
-    name = "server",
-    description =
-        "Set the Terra server to connect to. Run `terra server list` to see the available servers.")
+@Command(name = "server", description = "Set the Terra server to connect to.")
 public class Server extends Set {}

--- a/src/main/java/bio/terra/cli/command/config/set/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Server.java
@@ -1,37 +1,14 @@
 package bio.terra.cli.command.config.set;
 
-import bio.terra.cli.command.helperclasses.BaseCommand;
-import bio.terra.cli.service.ServerManager;
-import picocli.CommandLine;
+import bio.terra.cli.command.server.Set;
 import picocli.CommandLine.Command;
 
-/** This class corresponds to the third-level "terra config set server" command. */
+/**
+ * This class corresponds to the fourth-level "terra config set server" command. It is exactly the
+ * same command as "terra server set".
+ */
 @Command(
     name = "server",
     description =
         "Set the Terra server to connect to. Run `terra server list` to see the available servers.")
-public class Server extends BaseCommand {
-
-  @CommandLine.Parameters(index = "0", description = "server name")
-  private String serverName;
-
-  /** Update the Terra environment to which the CLI is pointing. */
-  @Override
-  protected void execute() {
-    String prevServerName = globalContext.server.name;
-    new ServerManager(globalContext).updateServer(serverName);
-
-    OUT.println(
-        "Terra server is set to "
-            + globalContext.server.name
-            + " ("
-            + (globalContext.server.name.equals(prevServerName) ? "UNCHANGED" : "CHANGED")
-            + ").");
-  }
-
-  /** This command never requires login. */
-  @Override
-  protected boolean requiresLogin() {
-    return false;
-  }
-}
+public class Server extends Set {}

--- a/src/main/java/bio/terra/cli/command/config/set/Server.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Server.java
@@ -5,7 +5,7 @@ import bio.terra.cli.service.ServerManager;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-/** This class corresponds to the third-level "terra server set" command. */
+/** This class corresponds to the third-level "terra config set server" command. */
 @Command(
     name = "server",
     description =

--- a/src/main/java/bio/terra/cli/command/server/Set.java
+++ b/src/main/java/bio/terra/cli/command/server/Set.java
@@ -1,0 +1,37 @@
+package bio.terra.cli.command.server;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.service.ServerManager;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra server set" command. */
+@Command(
+    name = "set",
+    description =
+        "Set the Terra server to connect to. Run `terra server list` to see the available servers.")
+public class Set extends BaseCommand {
+
+  @CommandLine.Parameters(index = "0", description = "server name")
+  private String serverName;
+
+  /** Update the Terra environment to which the CLI is pointing. */
+  @Override
+  protected void execute() {
+    String prevServerName = globalContext.server.name;
+    new ServerManager(globalContext).updateServer(serverName);
+
+    OUT.println(
+        "Terra server is set to "
+            + globalContext.server.name
+            + " ("
+            + (globalContext.server.name.equals(prevServerName) ? "UNCHANGED" : "CHANGED")
+            + ").");
+  }
+
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/server/Set.java
+++ b/src/main/java/bio/terra/cli/command/server/Set.java
@@ -6,13 +6,12 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra server set" command. */
-@Command(
-    name = "set",
-    description =
-        "Set the Terra server to connect to. Run `terra server list` to see the available servers.")
+@Command(name = "set", description = "Set the Terra server to connect to.")
 public class Set extends BaseCommand {
 
-  @CommandLine.Parameters(index = "0", description = "server name")
+  @CommandLine.Parameters(
+      index = "0",
+      description = "Server name. Run `terra server list` to see the available servers.")
   private String serverName;
 
   /** Update the Terra environment to which the CLI is pointing. */

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -40,6 +40,10 @@ echo "--  Pulling the default Docker image"
 defaultDockerImage=$(./terra config get-value image)
 docker pull $defaultDockerImage
 
+echo "-- Setting the server to its current value, to pull any changes"
+currentServer=$(./terra config get-value server)
+./terra config set server $currentServer
+
 echo "--  Install complete"
 echo "You can add the ./terra executable to your \$PATH"
 echo "Run \"./terra\" to see usage"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -23,7 +23,7 @@ echo "Pulling the default Docker image"
 defaultDockerImage=$(terra config get-value image)
 docker pull $defaultDockerImage
 
-echo "-- Setting the server to its current value, to pull any changes"
+echo "Setting the server to its current value, to pull any changes"
 currentServer=$(terra config get-value server)
 terra config set server $currentServer
 

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -23,6 +23,10 @@ echo "Pulling the default Docker image"
 defaultDockerImage=$(terra config get-value image)
 docker pull $defaultDockerImage
 
+echo "-- Setting the server to its current value, to pull any changes"
+currentServer=$(terra config get-value server)
+terra config set server $currentServer
+
 echo "Making all 'tools' scripts executable"
 chmod a+x tools/*
 


### PR DESCRIPTION
- Included the server setting into the `terra config` group of commands.
  - `terra config server set` duplicates the existing `terra server set`. So the server setting can now be changed in the general `config` group of commands, or in the `server` group of commands.
  - `terra config get-value server` is a new command to fetch the current server name.
  - `terra config list` includes the current server name.
- Updated the server specification in the install and local-dev scripts.
  - The scripts now look up the current server, and call `terra config server set` with that value.
  - This will not change the server, but will pick up any changes to the server specification files in the code (i.e. in the `resources/server/*.json` files).