### PR TITLE
PF-665: Install gcloud SDK from versioned archive.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,20 +4,23 @@ FROM openjdk:11.0-jre-slim
 # working directory when the docker is run
 WORKDIR /usr
 
-# install curl
+# install curl (to download install packages) and python (for gcloud sdk)
 RUN apt-get update \
-    && apt-get install -y curl
+    && apt-get install -y curl \
+    && apt-get install -y python
 
 # install Google Cloud SDK (gcloud, gsutil, bq)
-# these commands come from https://cloud.google.com/sdk/docs/install
+# these commands come from https://cloud.google.com/sdk/docs/downloads-versioned-archives
 # other examples of installing gcloud in a docker image:
 #   - AoU (https://github.com/all-of-us/workbench/blob/master/api/src/dev/server/Dockerfile#L34)
 #   - Terra Jupyter (https://github.com/DataBiosphere/terra-docker/blob/master/terra-jupyter-base/Dockerfile#L74)
-ENV CLOUD_SDK_VERSION 335.0.0-0
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-    && apt-get install apt-transport-https ca-certificates gnupg -y \
-    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - \
-    && apt-get update -y && apt-get install google-cloud-sdk=${CLOUD_SDK_VERSION} -y
+ENV CLOUD_SDK_VERSION 337.0.0
+ENV PATH /usr/local/google-cloud-sdk/bin:$PATH
+RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    mv google-cloud-sdk/ /usr/local/ && \
+    gcloud config set component_manager/disable_update_check true
 
 # install Nextflow
 ENV NXF_VER 20.10.0


### PR DESCRIPTION
Install the gcloud SDK in the Docker image by downloading a versioned archive, instead of using `apt-get`. Gcloud SDK [documentation](https://cloud.google.com/sdk/docs/install) says that the last 10 releases will be available via `apt-get`. This change allows us to pin the version indefinitely, instead of getting errors every ~10 weeks when the version we pinned is no longer available via `apt-get`. We should still try to keep this up to date, but don't want to cause breakages in case we forget.

I considered always using the latest version of gcloud sdk, but decided against it because that's inconsistent with how we handle most other dependencies (e.g. in `build.gradle` and `nextflow` in the Docker image). As Will pointed out, it's also clunkier to track which CLI release uses which version of the gcloud sdk. Not impossible, since the Docker image for each CLI release is preserved in GCR, so we could execute `gcloud version` in a container that uses that image, but it's not in GitHub history like other dependencies.

Also bumped the gcloud sdk version to the latest as part of this PR (335 -> 337).