### PR TITLE
PF-620: Invite user if `terra spend enable` fails with user not found in SAM.

### DIFF
--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -350,7 +350,7 @@ public class SamService {
    * "/api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/memberEmails/{email}"
    * PUT endpoint to add an email address to a resource + policy.
    *
-   * <p>If that returns a Not Found error, then call the SAM "/api/users/v1/invite/{inviteeEmail}"
+   * <p>If that returns a Bad Request error, then call the SAM "/api/users/v1/invite/{inviteeEmail}"
    * endpoint to invite the user.
    *
    * @param resourceType type of resource
@@ -376,7 +376,7 @@ public class SamService {
       logger.info("User not found in SAM. Trying to invite a new user.");
 
       try {
-        // add to resource failed with Not Found error, now try to invite the user and add them to
+        // add to resource failed with Bad Request error, now try to invite the user and add them to
         // the resource again
         logger.info("Inviting new user: {}", userEmail);
         UserStatusDetails userStatusDetails = inviteUser(userEmail);

--- a/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SpendProfileManagerService.java
@@ -57,7 +57,7 @@ public class SpendProfileManagerService {
    * @param email email of the user or group to add
    */
   public void enableUserForDefaultSpendProfile(SpendProfilePolicy policy, String email) {
-    samService.addUserToResource(
+    samService.addUserToResourceOrInviteUser(
         SPEND_PROFILE_RESOURCE_TYPE, WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID, policy.name(), email);
   }
 


### PR DESCRIPTION
If `terra spend enable` fails with a user not found in SAM error, then try to invite the user before enabling spend.

This is similar behavior to when:
  - `terra workspace add-user` fails with a user not found in SAM error. In this case, we also try to invite the user before adding them to the workspace.
  - `terra auth login` or any command requiring an active login fails with a user not found in SAM error. In this case, we try to register the user before executing the command.