### PR TITLE
PF-713 Add a --post-startup-script option for notebooks create.

### DIFF
--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -2,6 +2,8 @@
 
 echo "Setting up Terra app environment..."
 
+echo "hello world" > /tmp/hello.txt
+
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud config set project ${GOOGLE_CLOUD_PROJECT}
 

--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -5,5 +5,8 @@ echo "Setting up Terra app environment..."
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud config set project ${GOOGLE_CLOUD_PROJECT}
 
+# DO NOT SUBMIT revert me.
+touch hello.txt
+
 echo "Done setting up Terra app environment..."
 echo

--- a/docker/scripts/terra_init.sh
+++ b/docker/scripts/terra_init.sh
@@ -2,13 +2,8 @@
 
 echo "Setting up Terra app environment..."
 
-echo "hello world" > /tmp/hello.txt
-
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud config set project ${GOOGLE_CLOUD_PROJECT}
-
-# DO NOT SUBMIT revert me.
-touch hello.txt
 
 echo "Done setting up Terra app environment..."
 echo

--- a/src/main/java/bio/terra/cli/command/notebooks/Create.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Create.java
@@ -58,6 +58,13 @@ public class Create extends BaseCommand {
           "Use this VM image family to find the image; the newest image in this family will be used.")
   private String vmImageFamily;
 
+  @CommandLine.Option(
+      names = "--post-startup-script",
+      description =
+          "Path to a Bash script that automatically runs after a notebook instance fully boots up. "
+              + "The path must be a URL or Cloud Storage path, e.g. 'gs://path-to-file/file-name'")
+  private String postStartupScript;
+
   // TODO: Add boot disk types & gpu size configs.
 
   @Override
@@ -102,6 +109,10 @@ public class Create extends BaseCommand {
     // each zone.
     envVars.put("SUBNET", "projects/" + projectId + "/regions/" + zone + "/subnetworks/subnetwork");
     envVars.put("TERRA_WORKSPACE_ID", workspaceContext.getWorkspaceId().toString());
+    if (postStartupScript != null) {
+      command = command + " --post-startup-script=$POST_STARTUP_SCRIPT";
+      envVars.put("POST_STARTUP_SCRIPT", postStartupScript);
+    }
 
     OUT.println(
         String.format(


### PR DESCRIPTION
Allow the solutions team to iterate on a post-startup-script in the short term. Long term, this will be a parameter on the WM create notebook instance api.