### PR TITLE
PF-714: Handle one-time error pattern.

### DIFF
--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -200,7 +200,6 @@ public class HttpUtils {
    * @param makeRequest function to perform the request
    * @param isOneTimeError function to test whether the exception is the expected one-time error
    * @param handleOneTimeError function to handle the one-time error before retrying the request
-   *     once
    * @param <T> type of the Http response (i.e. return type of the makeRequest function)
    * @return the Http response
    * @throws E if makeRequest throws an exception that is not the expected one-time error

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -134,7 +134,7 @@ public class HttpUtils {
    *     number of retries was exhausted
    */
   public static <T, E extends Exception> T callWithRetries(
-      HttpRequestOperator<T, E> makeRequest, Predicate<Exception> isRetryable)
+      SupplierWithCheckedException<T, E> makeRequest, Predicate<Exception> isRetryable)
       throws E, InterruptedException {
     return callWithRetries(
         DEFAULT_MAXIMUM_RETRIES, DEFAULT_MILLISECONDS_SLEEP_FOR_RETRY, makeRequest, isRetryable);
@@ -155,7 +155,7 @@ public class HttpUtils {
   public static <T, E extends Exception> T callWithRetries(
       int maxRetries,
       Duration sleepDuration,
-      HttpRequestOperator<T, E> makeRequest,
+      SupplierWithCheckedException<T, E> makeRequest,
       Predicate<Exception> isRetryable)
       throws E, InterruptedException {
     int numTries = 0;
@@ -202,14 +202,14 @@ public class HttpUtils {
    * @param handleOneTimeError function to handle the one-time error before retrying the request
    * @param <T> type of the Http response (i.e. return type of the makeRequest function)
    * @return the Http response
-   * @throws E if makeRequest throws an exception that is not the expected one-time error
+   * @throws E1 if makeRequest throws an exception that is not the expected one-time error
    * @throws E2 if handleOneTimeError throws an exception
    */
-  public static <T, E extends Exception, E2 extends Exception> T callAndHandleOneTimeError(
-      HttpRequestOperator<T, E> makeRequest,
+  public static <T, E1 extends Exception, E2 extends Exception> T callAndHandleOneTimeError(
+      SupplierWithCheckedException<T, E1> makeRequest,
       Predicate<Exception> isOneTimeError,
-      HttpRequestOperator<Void, E2> handleOneTimeError)
-      throws E, E2, InterruptedException {
+      SupplierWithCheckedException<Void, E2> handleOneTimeError)
+      throws E1, E2, InterruptedException {
     try {
       // make the initial request
       return makeRequest.makeRequest();
@@ -237,7 +237,7 @@ public class HttpUtils {
    * @param <T> type of the Http response (i.e. return type of the makeRequest method)
    */
   @FunctionalInterface
-  public interface HttpRequestOperator<T, E extends Exception> {
+  public interface SupplierWithCheckedException<T, E extends Exception> {
     T makeRequest() throws E;
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -408,7 +408,7 @@ public class SamService {
   }
 
   /**
-   * Utility method that checks if an exception thrown by the WSM client is a bad request.
+   * Utility method that checks if an exception thrown by the SAM client is a bad request.
    *
    * @param ex exception to test
    * @return true if the exception is a bad request
@@ -422,7 +422,7 @@ public class SamService {
   }
 
   /**
-   * Utility method that checks if an exception thrown by the WSM client is a not found.
+   * Utility method that checks if an exception thrown by the SAM client is a not found.
    *
    * @param ex exception to test
    * @return true if the exception is a not found

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -103,8 +103,12 @@ public class SamService {
   public UserStatusDetails inviteUser(String userEmail) {
     UsersApi samUsersApi = new UsersApi(apiClient);
     try {
-      return HttpUtils.callWithRetries(
-          () -> samUsersApi.inviteUser(userEmail), SamService::isRetryable);
+      logger.info("Inviting new user: {}", userEmail);
+      UserStatusDetails userStatusDetails =
+          HttpUtils.callWithRetries(
+              () -> samUsersApi.inviteUser(userEmail), SamService::isRetryable);
+      logger.info("Invited new user: {}", userStatusDetails);
+      return userStatusDetails;
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error inviting user in SAM.", ex);
     } finally {
@@ -140,31 +144,25 @@ public class SamService {
    * @return SAM object with details about the user
    */
   public UserStatusInfo getUserInfoOrRegisterUser() {
-    UsersApi samUsersApi = new UsersApi(apiClient);
     try {
-      // first try to lookup the user
-      return HttpUtils.callWithRetries(
-          () -> samUsersApi.getUserStatusInfo(), SamService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      if (!(ex instanceof ApiException)
-          || (((ApiException) ex).getCode() != HttpStatusCodes.STATUS_CODE_NOT_FOUND)) {
-        throw new SystemException("Error reading user information from SAM.", ex);
-      }
-      logger.info("User not found in SAM. Trying to register a new user.");
-
-      try {
-        // lookup failed with Not Found error, now try to register the user and look them up again
-        UserStatus userStatus =
-            HttpUtils.callWithRetries(() -> samUsersApi.createUserV2(), SamService::isRetryable);
-        logger.info(
-            "User registered in SAM: {}, {}",
-            userStatus.getUserInfo().getUserSubjectId(),
-            userStatus.getUserInfo().getUserEmail());
-        return HttpUtils.callWithRetries(
-            () -> samUsersApi.getUserStatusInfo(), SamService::isRetryable);
-      } catch (ApiException | InterruptedException secondEx) {
-        throw new SystemException("Error reading user information from SAM.", secondEx);
-      }
+      // - try to lookup the user
+      // - if the user lookup failed with a Not Found error, it means the email is not found
+      // - so try to register the user first, then retry looking them up
+      return HttpUtils.callAndHandleOneTimeError(
+          () -> getUserInfo(),
+          SamService::isNotFound,
+          () -> {
+            UserStatus userStatus =
+                HttpUtils.callWithRetries(
+                    () -> new UsersApi(apiClient).createUserV2(), SamService::isRetryable);
+            logger.info(
+                "User registered in SAM: {}, {}",
+                userStatus.getUserInfo().getUserSubjectId(),
+                userStatus.getUserInfo().getUserEmail());
+            return null;
+          });
+    } catch (Exception secondEx) {
+      throw new SystemException("Error reading user information from SAM.", secondEx);
     } finally {
       closeConnectionPool();
     }
@@ -350,15 +348,12 @@ public class SamService {
    * "/api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/memberEmails/{email}"
    * PUT endpoint to add an email address to a resource + policy.
    *
-   * <p>If that returns a Bad Request error, then call the SAM "/api/users/v1/invite/{inviteeEmail}"
-   * endpoint to invite the user.
-   *
    * @param resourceType type of resource
    * @param resourceId id of resource
    * @param resourcePolicyName name of resource policy
    * @param userEmail email of the user or group to add
    */
-  public void addUserToResourceOrInviteUser(
+  public void addUserToResource(
       String resourceType, String resourceId, String resourcePolicyName, String userEmail) {
     ResourcesApi resourcesApi = new ResourcesApi(apiClient);
     try {
@@ -369,31 +364,75 @@ public class SamService {
           },
           SamService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
-      if (!(ex instanceof ApiException)
-          || (((ApiException) ex).getCode() != HttpStatusCodes.STATUS_CODE_BAD_REQUEST)) {
-        throw new SystemException("Error adding user to SAM resource.", ex);
-      }
-      logger.info("User not found in SAM. Trying to invite a new user.");
-
-      try {
-        // add to resource failed with Bad Request error, now try to invite the user and add them to
-        // the resource again
-        logger.info("Inviting new user: {}", userEmail);
-        UserStatusDetails userStatusDetails = inviteUser(userEmail);
-        logger.info("Invited new user: {}", userStatusDetails);
-
-        HttpUtils.callWithRetries(
-            () -> {
-              resourcesApi.addUserToPolicy(resourceType, resourceId, resourcePolicyName, userEmail);
-              return null;
-            },
-            SamService::isRetryable);
-      } catch (ApiException | InterruptedException secondEx) {
-        throw new SystemException("Error adding user to SAM resource.", secondEx);
-      }
+      throw new SystemException("Error adding user to SAM resource.", ex);
     } finally {
       closeConnectionPool();
     }
+  }
+
+  /**
+   * Call the SAM
+   * "/api/resources/v1/{resourceTypeName}/{resourceId}/policies/{policyName}/memberEmails/{email}"
+   * PUT endpoint to add an email address to a resource + policy.
+   *
+   * <p>If that returns a Not Found error, then call the SAM "/api/users/v1/invite/{inviteeEmail}"
+   * endpoint to invite the user.
+   *
+   * @param resourceType type of resource
+   * @param resourceId id of resource
+   * @param resourcePolicyName name of resource policy
+   * @param userEmail email of the user or group to add
+   */
+  public void addUserToResourceOrInviteUser(
+      String resourceType, String resourceId, String resourcePolicyName, String userEmail) {
+    try {
+      // - try to add user to the policy
+      // - if the add user to policy failed with a Bad Request error, it means the email is not
+      // found
+      // - so try to invite the user first, then retry adding them to the policy
+      HttpUtils.callAndHandleOneTimeError(
+          () -> {
+            addUserToResource(resourceType, resourceId, resourcePolicyName, userEmail);
+            return null;
+          },
+          SamService::isBadRequest,
+          () -> {
+            inviteUser(userEmail);
+            return null;
+          });
+    } catch (Exception secondEx) {
+      throw new SystemException("Error adding user to SAM resource.", secondEx);
+    } finally {
+      closeConnectionPool();
+    }
+  }
+
+  /**
+   * Utility method that checks if an exception thrown by the WSM client is a bad request.
+   *
+   * @param ex exception to test
+   * @return true if the exception is a bad request
+   */
+  private static boolean isBadRequest(Exception ex) {
+    if (!(ex instanceof ApiException)) {
+      return false;
+    }
+    int statusCode = ((ApiException) ex).getCode();
+    return statusCode == HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
+  }
+
+  /**
+   * Utility method that checks if an exception thrown by the WSM client is a not found.
+   *
+   * @param ex exception to test
+   * @return true if the exception is a not found
+   */
+  private static boolean isNotFound(Exception ex) {
+    if (!(ex instanceof ApiException)) {
+      return false;
+    }
+    int statusCode = ((ApiException) ex).getCode();
+    return statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND;
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/utils/SamService.java
+++ b/src/main/java/bio/terra/cli/service/utils/SamService.java
@@ -353,7 +353,7 @@ public class SamService {
    * @param resourcePolicyName name of resource policy
    * @param userEmail email of the user or group to add
    */
-  public void addUserToResource(
+  private void addUserToResource(
       String resourceType, String resourceId, String resourcePolicyName, String userEmail) {
     ResourcesApi resourcesApi = new ResourcesApi(apiClient);
     try {

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -26,7 +26,6 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import java.util.UUID;
 import javax.annotation.Nullable;
-import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,33 +268,21 @@ public class WorkspaceManagerService {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     GrantRoleRequestBody grantRoleRequestBody = new GrantRoleRequestBody().memberEmail(userEmail);
     try {
-      workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole);
-    } catch (ApiException ex) {
-      // a bad request is the only type of exception that inviting the user might fix
-      if (!isBadRequest(ex)) {
-        throw new SystemException("Error granting IAM role on workspace", ex);
-      }
-
-      try {
-        // try to invite the user first, in case they are not already registered
-        // if they are already registered, this will throw an exception
-        logger.info("Inviting new user: {}", userEmail);
-        UserStatusDetails userStatusDetails =
+      // - try to grant the user an iam role
+      // - if this fails with a Bad Request error, it means the email is not found
+      // - so try to invite the user first, then retry granting them an iam role
+      HttpUtils.callAndHandleOneTimeError(
+          () -> {
+            workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole);
+            return null;
+          },
+          WorkspaceManagerService::isBadRequest,
+          () -> {
             new SamService(server, terraUser).inviteUser(userEmail);
-        logger.info("Invited new user: {}", userStatusDetails);
-
-        // now try to add the user to the workspace role
-        // retry if it returns with a bad request (because the invite sometimes takes a few seconds
-        // to propagate -- not sure why)
-        HttpUtils.callWithRetries(
-            () -> {
-              workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole);
-              return null;
-            },
-            WorkspaceManagerService::isBadRequest);
-      } catch (ApiException | InterruptedException inviteEx) {
-        throw new SystemException("Error granting IAM role on workspace", inviteEx);
-      }
+            return null;
+          });
+    } catch (Exception secondEx) {
+      throw new SystemException("Error granting IAM role on workspace.", secondEx);
     }
   }
 


### PR DESCRIPTION
- Added a new utility method `HttpUtils#callAndHandleOneTimeError` for the pattern: try something/handle a one-time error/try again.
- Updated the three places in the CLI that follow this pattern to use the new utility method:
  - Add a user to a workspace (try to add, invite the user if they're not found, try adding again)
  - Enable a user on spend profile (try to enable, invite the user if they're not found, try enabling again)
  - Fetch user info (try to fetch, register the user if they're not found, try fetching again)

This is a follow-on ticket from [PF-620](https://github.com/DataBiosphere/terra-cli/pull/59), specifically from one of Will's comments. This code may not be merged -- it is a tech debt/code cleanup ticket with no effect on the behavior of the CLI, so it should only go in if it makes things cleaner. I am not sure whether this is the case, but think it's worth a shot and will be good to hear other's opinions.