### PR TITLE
PF-704: Update README with exit codes, un-hide pass-through app commands.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,8 @@ terra
 ```
 
 #### Logging
-Logging is turned off by default. Modify the root level in the `src/main/resources/logback.xml` file to turn it on (e.g. `INFO`).
+Logging is turned off by default. Modify the level with the `terra config set logging` command. Available levels are
+listed in the command usage.
 
 #### Troubleshooting
 - Wipe the global context directory. `rm -R $HOME/.terra`.
@@ -35,6 +36,10 @@ Logging is turned off by default. Modify the root level in the `src/main/resourc
 
 ### Publish a release
 A release includes a GitHub release of the `terra-cli` repository and a corresponding Docker image pushed to GCR.
+
+The GitHub action that runs on-merge to the `main` branch automatically builds the code and creates a GitHub release.
+So, this section about publishing a release manually is only intended for testing the release process, releasing a fix
+before code is merged (e.g. as a GitHub pre-release), or debugging errors in the GitHub action.
 
 To publish a release manually, from the current local code:
 1. Create a tag (e.g. `test123`) and push it to the remote repository. The tag should not include any uppercase letters.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     * [Reference in a CLI command](#reference-in-a-cli-command)
     * [Reference in file](#reference-in-file)
     * [See all environment variables](#see-all-environment-variables)
+5. [Exit codes](#exit-codes)
 
 -----
 
@@ -202,7 +203,7 @@ See the list of supported (external) tools.
 The CLI runs these tools in a Docker image. Print the image tag that the CLI is currently using.
 ```
 terra app list
-terra config get image
+terra config get-value image
 ```
 
 ### Commands description
@@ -417,9 +418,13 @@ Commands:
 These commands are property getters and setters for configuring the Terra CLI. Currently the available
 configuration properties are:
 ```
-  browser  Check whether a browser is launched automatically during the login
-             process.
-  image    Get the Docker image used for launching applications.
+[browser] browser launch for login = auto
+[image] docker image id = gcr.io/terra-cli-dev/terra-cli/0.33.0:stable
+
+[logging, console] logging level for printing directly to the terminal = OFF
+[logging, file] logging level for writing to files in /Users/marikomedlock/.terra/logs = INFO
+
+[server] server = verily-cli
 ```
 
 ### Workspace context for applications
@@ -495,3 +500,11 @@ are run.
 
 The `terra app execute ...` command is intended for debugging and lets you execute any command in the Docker
 container, not just the ones we've officially "supported" (i.e. gsutil, bq, gcloud, nextflow).
+
+### Exit codes
+The CLI sets the process exit code as follows.
+
+- 0 = Successful program execution
+- 1 = User-actionable error (e.g. missing parameter, workspace not defined in the current context)
+- 2 = System or internal error (e.g. error making a request to a Terra service)
+- 3 = Unexpected error (e.g. null pointer exception)

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -29,14 +29,14 @@ import picocli.CommandLine.ParseResult;
       Resources.class,
       DataRefs.class,
       App.class,
-      Gcloud.class,
-      Gsutil.class,
-      Bq.class,
-      Nextflow.class,
       Notebooks.class,
       Groups.class,
       Spend.class,
-      Config.class
+      Config.class,
+      Gcloud.class,
+      Gsutil.class,
+      Bq.class,
+      Nextflow.class
     },
     description = "Terra CLI")
 class Main implements Runnable {

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Bq.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Bq.java
@@ -7,7 +7,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the second-level "terra bq" command. */
-@Command(name = "bq", description = "Use the bq tool in the Terra workspace.", hidden = true)
+@Command(name = "bq", description = "Call bq in the Terra workspace.")
 public class Bq extends BaseCommand {
 
   @CommandLine.Unmatched private List<String> cmdArgs;

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Gcloud.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Gcloud.java
@@ -7,10 +7,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the second-level "terra gcloud" command. */
-@Command(
-    name = "gcloud",
-    description = "Use the gcloud tool in the Terra workspace.",
-    hidden = true)
+@Command(name = "gcloud", description = "Call gcloud in the Terra workspace.")
 public class Gcloud extends BaseCommand {
 
   @CommandLine.Unmatched private List<String> cmdArgs;

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Gsutil.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Gsutil.java
@@ -7,10 +7,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the second-level "terra gsutil" command. */
-@Command(
-    name = "gsutil",
-    description = "Use the gsutil tool in the Terra workspace.",
-    hidden = true)
+@Command(name = "gsutil", description = "Call gsutil in the Terra workspace.")
 public class Gsutil extends BaseCommand {
 
   @CommandLine.Unmatched private List<String> cmdArgs;

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
@@ -9,10 +9,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the second-level "terra nextflow" command. */
-@Command(
-    name = "nextflow",
-    description = "Use the nextflow tool in the Terra workspace.",
-    hidden = true)
+@Command(name = "nextflow", description = "Call nextflow in the Terra workspace.")
 public class Nextflow extends BaseCommand {
 
   @CommandLine.Unmatched private List<String> cmdArgs;


### PR DESCRIPTION
- Updated the README to include descriptions of the exit codes. This is a follow-on task from https://github.com/DataBiosphere/terra-cli/pull/56, specifically a request from John.
- Changed the main usage to include the pass-through app commands (i.e. `gsutil`, `gcloud`, `bq`, `nextflow`). Previously these were hidden and you could only list them with `terra app list`. Un-hiding them per a request from Nicole.
- Also fixed a few other out-of-date sections of the README and CONTRIBUTING docs.