### PR TITLE
PF-486: Expose bucket lifecycle rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ A controlled resource is a cloud resource managed by the Terra workspace on beha
 Currently, the only supported controlled resource is a bucket.
 
 ##### GCS bucket lifecycle rules
-GCS bucket lifecycle rules are specified by passing a JSON-formatted file to the `terra resources create gcs-bucket`
-command. The expected JSON structure matches the one used by the `gsutil lifecycle` 
+GCS bucket lifecycle rules are specified by passing a JSON-formatted file path to the
+`terra resources create gcs-bucket` command. The expected JSON structure matches the one used by the `gsutil lifecycle` 
 [command](https://cloud.google.com/storage/docs/gsutil/commands/lifecycle). This structure is a subset of the GCS
 resource [specification](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle). Below are some
 example file contents for specifying a lifecycle rule.

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ resource [specification](https://cloud.google.com/storage/docs/json_api/v1/bucke
 example file contents for specifying a lifecycle rule.
 
 (1) Changes the storage class from `STANDARD` to `ARCHIVE` after 10 days.
-```
+```json
 {
     "rule": [
       {
@@ -353,7 +353,7 @@ example file contents for specifying a lifecycle rule.
 ```
 
 (2) Deletes any objects with storage class `STANDARD` that were created before December 3, 2007.
-```
+```json
 {
     "rule": [
       {
@@ -370,7 +370,7 @@ example file contents for specifying a lifecycle rule.
 ```
 
 (3) Deletes any objects with storage class `STANDARD` that are more than 365 days old.
-```
+```json
 {
   "rule":
   [

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     * [Server](#server)
     * [Workspace](#workspace)
     * [Resources](#resources)
+        * [GCS bucket lifecycle rules](#gcs-bucket-lifecycle-rules)
     * [Data References](#data-references)
     * [Applications](#applications)
     * [Notebooks](#notebooks)
@@ -323,6 +324,70 @@ Commands:
 
 A controlled resource is a cloud resource managed by the Terra workspace on behalf of the user.
 Currently, the only supported controlled resource is a bucket.
+
+##### GCS bucket lifecycle rules
+GCS bucket lifecycle rules are specified by passing a JSON-formatted file to the `terra resources create gcs-bucket`
+command. The expected JSON structure matches the one used by the `gsutil lifecycle` 
+[command](https://cloud.google.com/storage/docs/gsutil/commands/lifecycle). This structure is a subset of the GCS
+resource [specification](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle). Below are some
+example file contents for specifying a lifecycle rule.
+
+(1) Changes the storage class from `STANDARD` to `ARCHIVE` after 10 days.
+```
+{
+    "rule": [
+      {
+        "action": {
+          "type": "SetStorageClass",
+          "storageClass": "ARCHIVE"
+        },
+        "condition": {
+          "age": 10,
+          "matchesStorageClass": [
+            "STANDARD"
+          ]
+        }
+      }
+    ]
+  }
+```
+
+(2) Deletes any objects with storage class `STANDARD` that were created before December 3, 2007.
+```
+{
+    "rule": [
+      {
+        "action": {"type": "Delete"},
+        "condition": {
+          "createdBefore": "2007-12-03",
+          "matchesStorageClass": [
+            "STANDARD"
+          ]
+        }
+      }
+    ]
+  }
+```
+
+(3) Deletes any objects with storage class `STANDARD` that are more than 365 days old.
+```
+{
+  "rule":
+  [
+    {
+      "action": {"type": "Delete"},
+      "condition": {
+      	"age": 365,
+      	"matchesStorageClass": ["STANDARD"]
+      }
+    }
+  ]
+}
+```
+There is also a command shortcut for specifying this type of lifecycle rule (3).
+```
+terra resources create gcs-bucket --name=mybucket --bucket-name=mybucket --auto-delete=365
+```
 
 #### Data References
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         slf4j = '1.7.30'
 
         // serialization
-        jackson = '2.10.2'
+        jackson = '2.12.3'
 
         // GCP
         googleOauth2 = '0.22.0'

--- a/src/main/java/bio/terra/cli/command/helperclasses/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/options/Format.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.command.helperclasses.options;
 
 import bio.terra.cli.command.exception.SystemException;
+import bio.terra.cli.context.utils.JacksonMapper;
 import bio.terra.cli.context.utils.Printer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,7 +79,7 @@ public class Format {
    */
   public static <T> void printJson(T returnValue) {
     // use Jackson to map the object to a JSON-formatted text block
-    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+    ObjectMapper objectMapper = JacksonMapper.getMapper();
     ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
     try {
       Printer.getOut().println(objectWriter.writeValueAsString(returnValue));

--- a/src/main/java/bio/terra/cli/command/helperclasses/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/helperclasses/options/Format.java
@@ -78,7 +78,7 @@ public class Format {
    */
   public static <T> void printJson(T returnValue) {
     // use Jackson to map the object to a JSON-formatted text block
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
     try {
       Printer.getOut().println(objectWriter.writeValueAsString(returnValue));

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -55,7 +55,7 @@ public class GcsBucket extends BaseCommand {
     @CommandLine.Option(
         names = "--lifecycle",
         description =
-            "Lifecycle rules (https://cloud.google.com/storage/docs/lifecycle) specified in a JSON-formatted file. Use --print-json-format option to see expected JSON format.")
+            "Lifecycle rules (https://cloud.google.com/storage/docs/lifecycle) specified in a JSON-formatted file. See the README for the expected JSON format.")
     private Path pathToLifecycleFile;
 
     @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -6,7 +6,7 @@ import bio.terra.cli.command.helperclasses.PrintingUtils;
 import bio.terra.cli.command.helperclasses.options.CreateControlledResource;
 import bio.terra.cli.command.helperclasses.options.Format;
 import bio.terra.cli.context.resources.GcsBucketLifecycle;
-import bio.terra.cli.context.utils.FileUtils;
+import bio.terra.cli.context.utils.JacksonMapper;
 import bio.terra.cli.service.WorkspaceManager;
 import bio.terra.workspace.model.ControlledResourceMetadata;
 import bio.terra.workspace.model.GcpGcsBucketAttributes;
@@ -84,7 +84,7 @@ public class GcsBucket extends BaseCommand {
       // read in the lifecycle rules from a file
       try {
         lifecycle =
-            FileUtils.readFileIntoJavaObject(
+            JacksonMapper.readFileIntoJavaObject(
                 lifecycleArgGroup.pathToLifecycleFile.toFile(),
                 GcsBucketLifecycle.class,
                 Collections.singletonList(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS));

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -1,9 +1,12 @@
 package bio.terra.cli.command.resources.create;
 
+import bio.terra.cli.command.exception.UserActionableException;
 import bio.terra.cli.command.helperclasses.BaseCommand;
 import bio.terra.cli.command.helperclasses.PrintingUtils;
 import bio.terra.cli.command.helperclasses.options.CreateControlledResource;
 import bio.terra.cli.command.helperclasses.options.Format;
+import bio.terra.cli.context.resources.GcsBucketLifecycle;
+import bio.terra.cli.context.utils.FileUtils;
 import bio.terra.cli.service.WorkspaceManager;
 import bio.terra.workspace.model.ControlledResourceMetadata;
 import bio.terra.workspace.model.GcpGcsBucketAttributes;
@@ -13,6 +16,9 @@ import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ResourceAttributesUnion;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceMetadata;
+import com.fasterxml.jackson.databind.MapperFeature;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import picocli.CommandLine;
 
@@ -42,12 +48,30 @@ public class GcsBucket extends BaseCommand {
       description = "Bucket location (https://cloud.google.com/storage/docs/locations)")
   private String location;
 
+  @CommandLine.Option(
+      names = "--lifecycle",
+      description =
+          "Lifecycle rules (https://cloud.google.com/storage/docs/lifecycle) specified in a JSON-formatted file")
+  private Path pathToLifecycleFile;
+
   @CommandLine.Mixin Format formatOption;
 
   /** Add a controlled GCS bucket to the workspace. */
   @Override
   protected void execute() {
     createControlledResourceOptions.validateAccessOptions();
+
+    // read in the lifecycle rules from a file
+    GcsBucketLifecycle lifecycle;
+    try {
+      lifecycle =
+          FileUtils.readFileIntoJavaObject(
+              pathToLifecycleFile.toFile(),
+              GcsBucketLifecycle.class,
+              Collections.singletonList(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS));
+    } catch (IOException ioEx) {
+      throw new UserActionableException("Error reading lifecycle rules from file.", ioEx);
+    }
 
     // build the resource object to create
     PrivateResourceIamRoles privateResourceIamRoles = new PrivateResourceIamRoles();
@@ -73,11 +97,9 @@ public class GcsBucket extends BaseCommand {
                 new ResourceAttributesUnion()
                     .gcpGcsBucket(new GcpGcsBucketAttributes().bucketName(bucketName)));
 
-    // TODO (PF-486): allow the user to specify lifecycle rules on the bucket
     ResourceDescription resourceCreated =
         new WorkspaceManager(globalContext, workspaceContext)
-            .createControlledGcsBucket(
-                resourceToCreate, storageClass, Collections.emptyList(), location);
+            .createControlledGcsBucket(resourceToCreate, storageClass, lifecycle, location);
     formatOption.printReturnValue(resourceCreated, GcsBucket::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -61,7 +61,7 @@ public class GcsBucket extends BaseCommand {
     @CommandLine.Option(
         names = "--auto-delete",
         description =
-            "Number of days after which to auto-delete the bucket. This option is a shortcut for specifying a lifecycle rule that auto-deletes objects in the bucket after some number of days.")
+            "Number of days after which to auto-delete the objects in the bucket. This option is a shortcut for specifying a lifecycle rule that auto-deletes objects in the bucket after some number of days.")
     private Integer autoDelete;
   }
 

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -5,7 +5,7 @@ import static bio.terra.cli.context.utils.Logger.LogLevel;
 import bio.terra.cli.apps.DockerCommandRunner;
 import bio.terra.cli.auth.AuthenticationManager.BrowserLaunchOption;
 import bio.terra.cli.command.exception.UserActionableException;
-import bio.terra.cli.context.utils.FileUtils;
+import bio.terra.cli.context.utils.JacksonMapper;
 import bio.terra.cli.service.ServerManager;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.IOException;
@@ -73,7 +73,8 @@ public class GlobalContext {
   public static GlobalContext readFromFile() {
     // try to read in an instance of the global context file
     try {
-      return FileUtils.readFileIntoJavaObject(getGlobalContextFile().toFile(), GlobalContext.class);
+      return JacksonMapper.readFileIntoJavaObject(
+          getGlobalContextFile().toFile(), GlobalContext.class);
     } catch (IOException ioEx) {
       // file not found is a common error here (e.g. first time running the CLI, there will be no
       // pre-existing global context file). we handle this by returning an object populated with
@@ -88,7 +89,7 @@ public class GlobalContext {
   /** Write an instance of this class to a JSON-formatted file in the global context directory. */
   private void writeToFile() {
     try {
-      FileUtils.writeJavaObjectToFile(getGlobalContextFile().toFile(), this);
+      JacksonMapper.writeJavaObjectToFile(getGlobalContextFile().toFile(), this);
     } catch (IOException ioEx) {
       logger.error("Error persisting global context.", ioEx);
     }

--- a/src/main/java/bio/terra/cli/context/ServerSpecification.java
+++ b/src/main/java/bio/terra/cli/context/ServerSpecification.java
@@ -2,6 +2,7 @@ package bio.terra.cli.context;
 
 import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.context.utils.FileUtils;
+import bio.terra.cli.context.utils.JacksonMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -46,7 +47,7 @@ public class ServerSpecification {
    */
   public static ServerSpecification fromJSONFile(String fileName) throws IOException {
     // use Jackson to map the stream contents to a ServerSpecification object
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = JacksonMapper.getMapper();
 
     // read in the server file
     ServerSpecification server;
@@ -60,7 +61,7 @@ public class ServerSpecification {
       logger.debug(
           "Server file ({}) not found in resource directory, now trying as absolute path.",
           fileName);
-      server = FileUtils.readFileIntoJavaObject(new File(fileName), ServerSpecification.class);
+      server = JacksonMapper.readFileIntoJavaObject(new File(fileName), ServerSpecification.class);
     }
 
     if (server != null) {

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.context;
 
 import bio.terra.cli.command.exception.UserActionableException;
-import bio.terra.cli.context.utils.FileUtils;
+import bio.terra.cli.context.utils.JacksonMapper;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.WorkspaceDescription;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -54,7 +54,7 @@ public class WorkspaceContext {
   public static WorkspaceContext readFromFile() {
     // try to read in an instance of the workspace context file
     try {
-      return FileUtils.readFileIntoJavaObject(
+      return JacksonMapper.readFileIntoJavaObject(
           getWorkspaceContextFile().toFile(), WorkspaceContext.class);
     } catch (IOException ioEx) {
       logger.debug("Workspace context file not found or error reading it.", ioEx);
@@ -70,7 +70,7 @@ public class WorkspaceContext {
    */
   private void writeToFile() {
     try {
-      FileUtils.writeJavaObjectToFile(getWorkspaceContextFile().toFile(), this);
+      JacksonMapper.writeJavaObjectToFile(getWorkspaceContextFile().toFile(), this);
     } catch (IOException ioEx) {
       logger.error("Error persisting workspace context.", ioEx);
     }

--- a/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
@@ -1,0 +1,142 @@
+package bio.terra.cli.context.resources;
+
+import bio.terra.workspace.model.GcpGcsBucketLifecycleRule;
+import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleAction;
+import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleActionType;
+import bio.terra.workspace.model.GcpGcsBucketLifecycleRuleCondition;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This POJO class specifies a list of GCS bucket lifecycle rules. Its structure mimics the one used
+ * by the `gsutil lifecycle` command.
+ *
+ * <p>Command ref: https://cloud.google.com/storage/docs/gsutil/commands/lifecycle
+ *
+ * <p>GCS bucket JSON format ref: https://cloud.google.com/storage/docs/json_api/v1/buckets#resource
+ *
+ * <p>This class is intended for passing throughout the CLI codebase, and also for exposing to users
+ * so that they can specify the lifecycle rules in a JSON file and pass that to the CLI.
+ */
+@SuppressFBWarnings(
+    value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "NP_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD"},
+    justification = "This POJO class is used for easy serialization to JSON using Jackson.")
+public class GcsBucketLifecycle {
+  public List<Rule> rule = new ArrayList<>();
+
+  public static class Rule {
+    public Action action;
+    public Condition condition;
+  }
+
+  public static class Action {
+    public ActionType type;
+    public GcsStorageClass storageClass;
+  }
+
+  public static class Condition {
+    public Integer age;
+    public LocalDate createdBefore;
+    public LocalDate customTimeBefore;
+    public Integer daysSinceCustomTime;
+    public Integer daysSinceNoncurrentTime;
+    public Boolean isLive;
+    public List<GcsStorageClass> matchesStorageClass;
+    public LocalDate noncurrentTimeBefore;
+    public Integer numNewerVersions;
+  }
+
+  /**
+   * This enum defines the possible ActionTypes for bucket lifecycle rules, and maps these types to
+   * the corresponding enum in the WSM client library.
+   *
+   * <p>This class mirrors the {@link GcpGcsBucketLifecycleRuleActionType} class in the WSM client
+   * library. The CLI defines its own version of this enum instead of using the WSM client library
+   * version so that:
+   *
+   * <p>- The CLI can use different enum names. In this case, the publicly documented GCS resource
+   * definition uses a slightly different casing of the enum values. In an effort to mimic the
+   * similar `gsutil lifecycle` command as closely as possible, the CLI will use the GCS version,
+   * instead of the WSM client library version.
+   * (https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle)
+   *
+   * <p>- The CLI syntax does not change when WSM API changes. In this case, the syntax affected is
+   * the structure of the user-provided JSON file to specify a lifecycle rule.
+   *
+   * <p>- The CLI can more easily control the JSON mapping behavior of the enum. In this case, the
+   * WSM client library version of the enum provides a @JsonCreator fromValue method that is case
+   * sensitive, and the CLI wants to allow case insensitive deserialization.
+   */
+  public enum ActionType {
+    Delete(GcpGcsBucketLifecycleRuleActionType.DELETE),
+    SetStorageClass(GcpGcsBucketLifecycleRuleActionType.SET_STORAGE_CLASS);
+
+    private GcpGcsBucketLifecycleRuleActionType wsmEnumVal;
+
+    ActionType(GcpGcsBucketLifecycleRuleActionType wsmEnumVal) {
+      this.wsmEnumVal = wsmEnumVal;
+    }
+
+    public GcpGcsBucketLifecycleRuleActionType toWSMEnum() {
+      return this.wsmEnumVal;
+    }
+  }
+
+  /**
+   * Helper method to convert a local date (e.g. 2014-01-02) into an object that includes time and
+   * zone. The time is set to midnight, the zone to UTC.
+   *
+   * @param localDate date object with no time or zone/offset information included
+   * @return object that specifies the date, time and zone/offest
+   */
+  public static OffsetDateTime dateAtMidnightAndUTC(LocalDate localDate) {
+    return localDate == null
+        ? null
+        : OffsetDateTime.of(localDate.atTime(LocalTime.MIDNIGHT), ZoneOffset.UTC);
+  }
+
+  /**
+   * This method converts this CLI-defined POJO class into a list of WSM client library-defined
+   * request objects.
+   *
+   * @return list of lifecycle rules in the format expected by the WSM client library
+   */
+  public List<GcpGcsBucketLifecycleRule> toWsmLifecycleRules() {
+    List<GcpGcsBucketLifecycleRule> wsmLifecycleRules = new ArrayList<>();
+    for (GcsBucketLifecycle.Rule rule : rule) {
+      GcpGcsBucketLifecycleRuleAction action =
+          new GcpGcsBucketLifecycleRuleAction().type(rule.action.type.toWSMEnum());
+      if (rule.action.storageClass != null) {
+        action.storageClass(rule.action.storageClass.toWSMEnum());
+      }
+
+      GcpGcsBucketLifecycleRuleCondition condition =
+          new GcpGcsBucketLifecycleRuleCondition()
+              .age(rule.condition.age)
+              .createdBefore(GcsBucketLifecycle.dateAtMidnightAndUTC(rule.condition.createdBefore))
+              .customTimeBefore(
+                  GcsBucketLifecycle.dateAtMidnightAndUTC(rule.condition.customTimeBefore))
+              .daysSinceCustomTime(rule.condition.daysSinceCustomTime)
+              .daysSinceNoncurrentTime(rule.condition.daysSinceNoncurrentTime)
+              .live(rule.condition.isLive)
+              .matchesStorageClass(
+                  rule.condition.matchesStorageClass.stream()
+                      .map(gcsStorageClass -> gcsStorageClass.toWSMEnum())
+                      .collect(Collectors.toList()))
+              .noncurrentTimeBefore(
+                  GcsBucketLifecycle.dateAtMidnightAndUTC(rule.condition.noncurrentTimeBefore))
+              .numNewerVersions(rule.condition.numNewerVersions);
+
+      GcpGcsBucketLifecycleRule lifecycleRuleRequestObject =
+          new GcpGcsBucketLifecycleRule().action(action).condition(condition);
+      wsmLifecycleRules.add(lifecycleRuleRequestObject);
+    }
+    return wsmLifecycleRules;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
@@ -54,15 +54,12 @@ public class GcsBucketLifecycle {
 
   /**
    * This enum defines the possible ActionTypes for bucket lifecycle rules, and maps these types to
-   * the corresponding enum in the WSM client library.
-   *
-   * <p>This class mirrors the {@link GcpGcsBucketLifecycleRuleActionType} class in the WSM client
-   * library. The CLI defines its own version of this enum instead of using the WSM client library
-   * version so that:
+   * the corresponding {@link GcpGcsBucketLifecycleRuleActionType} enum in the WSM client library.
+   * The CLI defines its own version of this enum so that:
    *
    * <p>- The CLI can use different enum names. In this case, the publicly documented GCS resource
    * definition uses a slightly different casing of the enum values. In an effort to mimic the
-   * similar `gsutil lifecycle` command as closely as possible, the CLI will use the GCS version,
+   * similar `gsutil lifecycle` command as closely as possible, the CLI will use the GCS casing,
    * instead of the WSM client library version.
    * (https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle)
    *
@@ -71,7 +68,7 @@ public class GcsBucketLifecycle {
    *
    * <p>- The CLI can more easily control the JSON mapping behavior of the enum. In this case, the
    * WSM client library version of the enum provides a @JsonCreator fromValue method that is case
-   * sensitive, and the CLI wants to allow case insensitive deserialization.
+   * sensitive, and the CLI may want to allow case insensitive deserialization.
    */
   public enum ActionType {
     Delete(GcpGcsBucketLifecycleRuleActionType.DELETE),

--- a/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
@@ -47,7 +47,7 @@ public class GcsBucketLifecycle {
     public Integer daysSinceCustomTime;
     public Integer daysSinceNoncurrentTime;
     public Boolean isLive;
-    public List<GcsStorageClass> matchesStorageClass;
+    public List<GcsStorageClass> matchesStorageClass = new ArrayList<>();
     public LocalDate noncurrentTimeBefore;
     public Integer numNewerVersions;
   }
@@ -138,5 +138,29 @@ public class GcsBucketLifecycle {
       wsmLifecycleRules.add(lifecycleRuleRequestObject);
     }
     return wsmLifecycleRules;
+  }
+
+  /**
+   * Helper method to build a lifecycle rule that auto-deletes the contents of the bucket after some
+   * number of days.
+   *
+   * @param numDays number of days after which to delete an object in the bucket
+   * @return lifecycle rule definition
+   */
+  public static GcsBucketLifecycle buildAutoDeleteRule(Integer numDays) {
+    Action action = new Action();
+    action.type = ActionType.Delete;
+
+    Condition condition = new Condition();
+    condition.age = numDays;
+
+    Rule rule = new Rule();
+    rule.action = action;
+    rule.condition = condition;
+
+    GcsBucketLifecycle lifecycle = new GcsBucketLifecycle();
+    lifecycle.rule.add(rule);
+
+    return lifecycle;
   }
 }

--- a/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsBucketLifecycle.java
@@ -12,6 +12,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * This POJO class specifies a list of GCS bucket lifecycle rules. Its structure mimics the one used
@@ -92,7 +93,7 @@ public class GcsBucketLifecycle {
    * @param localDate date object with no time or zone/offset information included
    * @return object that specifies the date, time and zone/offest
    */
-  public static OffsetDateTime dateAtMidnightAndUTC(LocalDate localDate) {
+  public static OffsetDateTime dateAtMidnightAndUTC(@Nullable LocalDate localDate) {
     return localDate == null
         ? null
         : OffsetDateTime.of(localDate.atTime(LocalTime.MIDNIGHT), ZoneOffset.UTC);
@@ -124,7 +125,7 @@ public class GcsBucketLifecycle {
               .live(rule.condition.isLive)
               .matchesStorageClass(
                   rule.condition.matchesStorageClass.stream()
-                      .map(gcsStorageClass -> gcsStorageClass.toWSMEnum())
+                      .map(GcsStorageClass::toWSMEnum)
                       .collect(Collectors.toList()))
               .noncurrentTimeBefore(
                   GcsBucketLifecycle.dateAtMidnightAndUTC(rule.condition.noncurrentTimeBefore))

--- a/src/main/java/bio/terra/cli/context/resources/GcsStorageClass.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsStorageClass.java
@@ -4,18 +4,15 @@ import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
 
 /**
  * This enum defines the possible storage classes for buckets, and maps these classes to the
- * corresponding enum in the WSM client library.
- *
- * <p>This class mirrors the {@link GcpGcsBucketDefaultStorageClass} class in the WSM client
- * library. The CLI defines its own version of this enum instead of using the WSM client library
- * version so that:
+ * corresponding {@link GcpGcsBucketDefaultStorageClass} enum in the WSM client library. The CLI
+ * defines its own version of this enum so that:
  *
  * <p>- The CLI syntax does not change when WSM API changes. In this case, the syntax affected is
- * the structure of the user-provided JSON file to specify a lifecycle fule.
+ * the structure of the user-provided JSON file to specify a lifecycle rule.
  *
  * <p>- The CLI can more easily control the JSON mapping behavior of the enum. In this case, the WSM
  * client library version of the enum provides a @JsonCreator fromValue method that is case
- * sensitive, and the CLI wants to allow case insensitive deserialization.
+ * sensitive, and the CLI may want to allow case insensitive deserialization.
  */
 public enum GcsStorageClass {
   STANDARD(GcpGcsBucketDefaultStorageClass.STANDARD),

--- a/src/main/java/bio/terra/cli/context/resources/GcsStorageClass.java
+++ b/src/main/java/bio/terra/cli/context/resources/GcsStorageClass.java
@@ -1,0 +1,35 @@
+package bio.terra.cli.context.resources;
+
+import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
+
+/**
+ * This enum defines the possible storage classes for buckets, and maps these classes to the
+ * corresponding enum in the WSM client library.
+ *
+ * <p>This class mirrors the {@link GcpGcsBucketDefaultStorageClass} class in the WSM client
+ * library. The CLI defines its own version of this enum instead of using the WSM client library
+ * version so that:
+ *
+ * <p>- The CLI syntax does not change when WSM API changes. In this case, the syntax affected is
+ * the structure of the user-provided JSON file to specify a lifecycle fule.
+ *
+ * <p>- The CLI can more easily control the JSON mapping behavior of the enum. In this case, the WSM
+ * client library version of the enum provides a @JsonCreator fromValue method that is case
+ * sensitive, and the CLI wants to allow case insensitive deserialization.
+ */
+public enum GcsStorageClass {
+  STANDARD(GcpGcsBucketDefaultStorageClass.STANDARD),
+  NEARLINE(GcpGcsBucketDefaultStorageClass.NEARLINE),
+  COLDLINE(GcpGcsBucketDefaultStorageClass.COLDLINE),
+  ARCHIVE(GcpGcsBucketDefaultStorageClass.ARCHIVE);
+
+  private GcpGcsBucketDefaultStorageClass wsmEnumVal;
+
+  GcsStorageClass(GcpGcsBucketDefaultStorageClass wsmEnumVal) {
+    this.wsmEnumVal = wsmEnumVal;
+  }
+
+  public GcpGcsBucketDefaultStorageClass toWSMEnum() {
+    return this.wsmEnumVal;
+  }
+}

--- a/src/main/java/bio/terra/cli/context/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/context/utils/FileUtils.java
@@ -1,109 +1,19 @@
 package bio.terra.cli.context.utils;
 
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Utility methods for manipulating files on disk. */
 public class FileUtils {
   private static final Logger logger = LoggerFactory.getLogger(FileUtils.class);
-
-  /**
-   * Read a JSON-formatted file into a Java object using the Jackson object mapper.
-   *
-   * @param inputFile the file to read in
-   * @param javaObjectClass the Java object class
-   * @param <T> the Java object class to map the file contents to
-   * @return an instance of the Java object class
-   * @throws FileNotFoundException if the file to read in does not exist
-   */
-  public static <T> T readFileIntoJavaObject(File inputFile, Class<T> javaObjectClass)
-      throws IOException {
-    return readFileIntoJavaObject(inputFile, javaObjectClass, Collections.emptyList());
-  }
-
-  /**
-   * Read a JSON-formatted file into a Java object using the Jackson object mapper.
-   *
-   * @param inputFile the file to read in
-   * @param javaObjectClass the Java object class
-   * @param mapperFeatures list of Jackson mapper features to enable
-   * @param <T> the Java object class to map the file contents to
-   * @return an instance of the Java object class
-   * @throws FileNotFoundException if the file to read in does not exist
-   */
-  public static <T> T readFileIntoJavaObject(
-      File inputFile, Class<T> javaObjectClass, List<MapperFeature> mapperFeatures)
-      throws IOException {
-    // use Jackson to map the file contents to an instance of the specified class
-    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
-
-    // enable any Jackson features specified
-    for (MapperFeature mapperFeature : mapperFeatures) {
-      objectMapper.enable(mapperFeature);
-    }
-
-    try (FileInputStream inputStream = new FileInputStream(inputFile)) {
-      return objectMapper.readValue(inputStream, javaObjectClass);
-    }
-  }
-
-  /**
-   * Write a Java object to a JSON-formatted file using the Jackson object mapper.
-   *
-   * @param outputFile the file to write to
-   * @param javaObject the Java object to write
-   * @param <T> the Java object class to write
-   * @return an instance of the Java object class
-   */
-  @SuppressFBWarnings(
-      value = "RV_RETURN_VALUE_IGNORED",
-      justification =
-          "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
-  public static <T> void writeJavaObjectToFile(File outputFile, T javaObject) throws IOException {
-    // use Jackson to map the object to a JSON-formatted text block
-    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
-    ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
-
-    // create the file and any parent directories if they don't already exist
-    createFile(outputFile);
-
-    logger.debug("Serializing object with Jackson to file: {}", outputFile.getAbsolutePath());
-    objectWriter.writeValue(outputFile, javaObject);
-  }
-
-  /**
-   * Write a string directly to a file.
-   *
-   * @param outputFile the file to write to
-   * @param fileContents the string to write
-   * @return the file that was written to
-   */
-  @SuppressFBWarnings(
-      value = "RV_RETURN_VALUE_IGNORED",
-      justification =
-          "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
-  public static Path writeStringToFile(File outputFile, String fileContents) throws IOException {
-    logger.debug("Writing to file: {}", outputFile.getAbsolutePath());
-
-    // create the file and any parent directories if they don't already exist
-    createFile(outputFile);
-
-    return Files.write(outputFile.toPath(), fileContents.getBytes(Charset.forName("UTF-8")));
-  }
 
   /**
    * Build a stream handle to a resource file.
@@ -131,5 +41,25 @@ public class FileUtils {
       file.getParentFile().mkdirs();
       file.createNewFile();
     }
+  }
+
+  /**
+   * Write a string directly to a file.
+   *
+   * @param outputFile the file to write to
+   * @param fileContents the string to write
+   * @return the file that was written to
+   */
+  @SuppressFBWarnings(
+      value = "RV_RETURN_VALUE_IGNORED",
+      justification =
+          "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
+  public static Path writeStringToFile(File outputFile, String fileContents) throws IOException {
+    logger.debug("Writing to file: {}", outputFile.getAbsolutePath());
+
+    // create the file and any parent directories if they don't already exist
+    createFile(outputFile);
+
+    return Files.write(outputFile.toPath(), fileContents.getBytes(Charset.forName("UTF-8")));
   }
 }

--- a/src/main/java/bio/terra/cli/context/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/context/utils/FileUtils.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.context.utils;
 
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -11,6 +12,8 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,8 +32,30 @@ public class FileUtils {
    */
   public static <T> T readFileIntoJavaObject(File inputFile, Class<T> javaObjectClass)
       throws IOException {
+    return readFileIntoJavaObject(inputFile, javaObjectClass, Collections.emptyList());
+  }
+
+  /**
+   * Read a JSON-formatted file into a Java object using the Jackson object mapper.
+   *
+   * @param inputFile the file to read in
+   * @param javaObjectClass the Java object class
+   * @param mapperFeatures list of Jackson mapper features to enable
+   * @param <T> the Java object class to map the file contents to
+   * @return an instance of the Java object class
+   * @throws FileNotFoundException if the file to read in does not exist
+   */
+  public static <T> T readFileIntoJavaObject(
+      File inputFile, Class<T> javaObjectClass, List<MapperFeature> mapperFeatures)
+      throws IOException {
     // use Jackson to map the file contents to an instance of the specified class
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    // enable any Jackson features specified
+    for (MapperFeature mapperFeature : mapperFeatures) {
+      objectMapper.enable(mapperFeature);
+    }
+
     try (FileInputStream inputStream = new FileInputStream(inputFile)) {
       return objectMapper.readValue(inputStream, javaObjectClass);
     }
@@ -50,7 +75,7 @@ public class FileUtils {
           "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
   public static <T> void writeJavaObjectToFile(File outputFile, T javaObject) throws IOException {
     // use Jackson to map the object to a JSON-formatted text block
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
     ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
 
     // create the file and any parent directories if they don't already exist

--- a/src/main/java/bio/terra/cli/context/utils/JacksonMapper.java
+++ b/src/main/java/bio/terra/cli/context/utils/JacksonMapper.java
@@ -1,0 +1,113 @@
+package bio.terra.cli.context.utils;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods for using Jackson to de/serialize JSON. This class maintains a singleton instance
+ * of the Jackson {@link ObjectMapper}, to avoid re-loading the modules multiple times for a single
+ * CLI command.
+ */
+public class JacksonMapper {
+  private static final Logger logger = LoggerFactory.getLogger(JacksonMapper.class);
+
+  private static ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+  /** Getter for the singleton instance of the default Jackson {@link ObjectMapper} instance. */
+  public static ObjectMapper getMapper() {
+    return objectMapper;
+  }
+
+  /**
+   * Getter for an instance of the Jackson {@link ObjectMapper}, with the specified Jackson features
+   * enabled. If no Jackson features are specified (i.e. the list of mapper featuers is empty), then
+   * this method is equivalent to the {@link #getMapper()} method.
+   */
+  public static ObjectMapper getMapper(List<MapperFeature> mapperFeatures) {
+    // if no Jackson features are specified, just return the default mapper object
+    if (mapperFeatures.size() == 0) {
+      return getMapper();
+    }
+
+    // create a copy of the default mapper and enable any Jackson features specified
+    ObjectMapper objectMapperWithFeatures = getMapper().copy();
+    for (MapperFeature mapperFeature : mapperFeatures) {
+      objectMapperWithFeatures.enable(mapperFeature);
+    }
+    return objectMapperWithFeatures;
+  }
+
+  /**
+   * Read a JSON-formatted file into a Java object using the Jackson object mapper.
+   *
+   * @param inputFile the file to read in
+   * @param javaObjectClass the Java object class
+   * @param <T> the Java object class to map the file contents to
+   * @return an instance of the Java object class
+   * @throws FileNotFoundException if the file to read in does not exist
+   */
+  public static <T> T readFileIntoJavaObject(File inputFile, Class<T> javaObjectClass)
+      throws IOException {
+    return readFileIntoJavaObject(inputFile, javaObjectClass, Collections.emptyList());
+  }
+
+  /**
+   * Read a JSON-formatted file into a Java object using the Jackson object mapper.
+   *
+   * @param inputFile the file to read in
+   * @param javaObjectClass the Java object class
+   * @param mapperFeatures list of Jackson mapper features to enable
+   * @param <T> the Java object class to map the file contents to
+   * @return an instance of the Java object class
+   * @throws FileNotFoundException if the file to read in does not exist
+   */
+  public static <T> T readFileIntoJavaObject(
+      File inputFile, Class<T> javaObjectClass, List<MapperFeature> mapperFeatures)
+      throws IOException {
+    // use Jackson to map the file contents to an instance of the specified class
+    ObjectMapper objectMapper = getMapper(mapperFeatures);
+
+    // enable any Jackson features specified
+    for (MapperFeature mapperFeature : mapperFeatures) {
+      objectMapper.enable(mapperFeature);
+    }
+
+    try (FileInputStream inputStream = new FileInputStream(inputFile)) {
+      return objectMapper.readValue(inputStream, javaObjectClass);
+    }
+  }
+
+  /**
+   * Write a Java object to a JSON-formatted file using the Jackson object mapper.
+   *
+   * @param outputFile the file to write to
+   * @param javaObject the Java object to write
+   * @param <T> the Java object class to write
+   * @return an instance of the Java object class
+   */
+  @SuppressFBWarnings(
+      value = "RV_RETURN_VALUE_IGNORED",
+      justification =
+          "A file not found exception will be thrown anyway in this same method if the mkdirs or createNewFile calls fail.")
+  public static <T> void writeJavaObjectToFile(File outputFile, T javaObject) throws IOException {
+    // use Jackson to map the object to a JSON-formatted text block
+    ObjectMapper objectMapper = getMapper();
+    ObjectWriter objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
+
+    // create the file and any parent directories if they don't already exist
+    FileUtils.createFile(outputFile);
+
+    logger.debug("Serializing object with Jackson to file: {}", outputFile.getAbsolutePath());
+    objectWriter.writeValue(outputFile, javaObject);
+  }
+}

--- a/src/main/java/bio/terra/cli/service/ServerManager.java
+++ b/src/main/java/bio/terra/cli/service/ServerManager.java
@@ -4,6 +4,7 @@ import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.ServerSpecification;
 import bio.terra.cli.context.utils.FileUtils;
+import bio.terra.cli.context.utils.JacksonMapper;
 import bio.terra.cli.service.utils.DataRepoService;
 import bio.terra.cli.service.utils.SamService;
 import bio.terra.cli.service.utils.WorkspaceManagerService;
@@ -111,7 +112,7 @@ public class ServerManager {
   /** List all server specifications found on the classpath. */
   public static List<ServerSpecification> allPossibleServers() {
     // use Jackson to map the stream contents to a list of strings
-    ObjectMapper objectMapper = new ObjectMapper();
+    ObjectMapper objectMapper = JacksonMapper.getMapper();
 
     try {
       // read in the list of servers file

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -4,12 +4,12 @@ import bio.terra.cli.command.exception.UserActionableException;
 import bio.terra.cli.context.GlobalContext;
 import bio.terra.cli.context.TerraUser;
 import bio.terra.cli.context.WorkspaceContext;
+import bio.terra.cli.context.resources.GcsBucketLifecycle;
 import bio.terra.cli.service.utils.GoogleBigQuery;
 import bio.terra.cli.service.utils.GoogleCloudStorage;
 import bio.terra.cli.service.utils.WorkspaceManagerService;
 import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
-import bio.terra.workspace.model.GcpGcsBucketLifecycleRule;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceList;
@@ -333,7 +333,7 @@ public class WorkspaceManager {
    * @param resourceToCreate resource definition to create
    * @param defaultStorageClass GCS storage class
    *     (https://cloud.google.com/storage/docs/storage-classes)
-   * @param lifecycleRules list of lifecycle rules for the bucket
+   * @param lifecycle list of lifecycle rules for the bucket
    *     (https://cloud.google.com/storage/docs/lifecycle)
    * @param location GCS bucket location (https://cloud.google.com/storage/docs/locations)
    * @return the resource description object that was created
@@ -341,7 +341,7 @@ public class WorkspaceManager {
   public ResourceDescription createControlledGcsBucket(
       ResourceDescription resourceToCreate,
       @Nullable GcpGcsBucketDefaultStorageClass defaultStorageClass,
-      List<GcpGcsBucketLifecycleRule> lifecycleRules,
+      GcsBucketLifecycle lifecycle,
       @Nullable String location) {
     return createResource(
         resourceToCreate.getMetadata().getName(),
@@ -352,7 +352,7 @@ public class WorkspaceManager {
                     workspaceContext.getWorkspaceId(),
                     resourceToCreate,
                     defaultStorageClass,
-                    lifecycleRules,
+                    lifecycle,
                     location));
   }
 

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -3,6 +3,7 @@ package bio.terra.cli.service.utils;
 import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.context.ServerSpecification;
 import bio.terra.cli.context.TerraUser;
+import bio.terra.cli.context.resources.GcsBucketLifecycle;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
@@ -476,7 +477,7 @@ public class WorkspaceManagerService {
    * @param resourceToCreate resource definition to create
    * @param defaultStorageClass GCS storage class
    *     (https://cloud.google.com/storage/docs/storage-classes)
-   * @param lifecycleRules list of lifecycle rules for the bucket
+   * @param lifecycle list of lifecycle rules for the bucket
    *     (https://cloud.google.com/storage/docs/lifecycle)
    * @param location GCS bucket location (https://cloud.google.com/storage/docs/locations)
    * @return the GCS bucket resource object
@@ -485,8 +486,11 @@ public class WorkspaceManagerService {
       UUID workspaceId,
       ResourceDescription resourceToCreate,
       @Nullable GcpGcsBucketDefaultStorageClass defaultStorageClass,
-      List<GcpGcsBucketLifecycleRule> lifecycleRules,
+      GcsBucketLifecycle lifecycle,
       @Nullable String location) {
+    // convert the CLI lifecycle rule object into the WSM request objects
+    List<GcpGcsBucketLifecycleRule> lifecycleRules = lifecycle.toWsmLifecycleRules();
+
     // TODO (PF-718): default storage class and lifecycle rule are currently required. remove this
     // manual defaulting once they are made optional on the server
     if (defaultStorageClass == null) {


### PR DESCRIPTION
- Added two new options to the `terra resources create gcs-bucket` command, to allow specifying bucket lifecycle rules.
  - `--lifecycle` takes a path to a JSON-formatted file that specifies the lifecycle rules. The expected format for this file matches that used by the `gsutil lifecycle` [command](https://cloud.google.com/storage/docs/gsutil/commands/lifecycle). This structure is a subset of the GCS resource [specification](https://cloud.google.com/storage/docs/json_api/v1/buckets#lifecycle).
  - `--auto-delete` takes a number of days. This option is a shortcut for specifying a lifecycle rule that auto-deletes objects in the bucket after some number of days.
  - Included example JSON files for specifying lifecycle rules in the README.
- Defined CLI-specific classes for specifying the lifecycle rule object(s), so that:
  - The CLI is not tied to the WSM API definition (e.g. for enum naming).
  - The CLI syntax does not change whenever the WSM API changes.
  - The CLI can more easily control the JSON mapping behavior (e.g. to allow case insensitivity).
  - This is a small part of the larger ticket ([PF-729](https://broadworkbench.atlassian.net/browse/PF-729)) to use CLI-specific classes everywhere.
- Small Jackson-related changes.
  - Bumped the Jackson library version to suppress some warning messages when deserializing dates.
  - Added `findAndRegisterModules` to places where we construct a Jackson `ObjectMapper` to make sure we can use the time/date serialization logic included in the `jackson-datatype-jsr310` module. Just including this library in `build.gradle` is not enough to make sure we can use it.
  - Added a `JacksonMapper` utility class that maintains a singleton instance of the default `ObjectMapper`. If any mapper features are specified, we create a copy of the default object, so that these features are not sticky.