### PR TITLE
PF-707: Call WSM endpoint to delete controlled BQ datasets.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 
         // terra libraries
         samClient = "0.1-9435410-SNAP"
-        workspaceManagerClient = "0.22.0-SNAPSHOT"
+        workspaceManagerClient = "0.23.0-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -693,7 +693,12 @@ public class WorkspaceManagerService {
    * @param resourceId the resource id
    */
   public void deleteControlledBigQueryDataset(UUID workspaceId, UUID resourceId) {
-    // TODO (PF-419): update this once the endpoint for deleting a controlled BQ dataset is ready
-    throw new SystemException("Delete controlled BQ dataset endpoint not implemented yet.");
+    ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
+    try {
+      controlledGcpResourceApi.deleteBigQueryDataset(workspaceId, resourceId);
+    } catch (ApiException ex) {
+      throw new SystemException(
+          "Error deleting controlled Big Query dataset in the workspace.", ex);
+    }
   }
 }


### PR DESCRIPTION
- Replaced a "not implemented yet" exception with a call to the WSM endpoint to delete a controlled BQ dataset resource.
- Bumped the WSM client library version to include the new endpoint.