### PR TITLE
PF-724: Add top-level resolve command.

### DIFF
--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -32,6 +32,7 @@ import picocli.CommandLine.ParseResult;
       Groups.class,
       Spend.class,
       Config.class,
+      Resolve.class,
       Gcloud.class,
       Gsutil.class,
       Bq.class,

--- a/src/main/java/bio/terra/cli/command/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/Resolve.java
@@ -1,0 +1,45 @@
+package bio.terra.cli.command;
+
+import static bio.terra.cli.service.WorkspaceManager.getBigQueryDatasetPath;
+import static bio.terra.cli.service.WorkspaceManager.getGcsBucketUrl;
+
+import bio.terra.cli.command.helperclasses.BaseCommand;
+import bio.terra.cli.command.helperclasses.options.Format;
+import bio.terra.cli.service.WorkspaceManager;
+import bio.terra.workspace.model.ResourceDescription;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the second-level "terra resolve" command. */
+@Command(name = "resolve", description = "Resolve a resource to its cloud id or path.")
+public class Resolve extends BaseCommand {
+  @CommandLine.Parameters(
+      index = "0",
+      description = "Name of the resource, scoped to the workspace.")
+  private String resourceName;
+
+  @CommandLine.Mixin Format formatOption;
+
+  /** Resolve a resource in the workspace to its cloud identifier. */
+  @Override
+  protected void execute() {
+    ResourceDescription resource =
+        new WorkspaceManager(globalContext, workspaceContext).getResource(resourceName);
+
+    // return the "default" cloud identifier (i.e. the format returned by the `terra resource
+    // resolve ...` commands if no options are specified)
+    String cloudId;
+    switch (resource.getMetadata().getResourceType()) {
+      case GCS_BUCKET:
+        cloudId = getGcsBucketUrl(resource);
+        break;
+      case BIG_QUERY_DATASET:
+        cloudId = getBigQueryDatasetPath(resource);
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            "Resource type not supported: " + resource.getMetadata().getResourceType());
+    }
+    formatOption.printReturnValue(cloudId);
+  }
+}


### PR DESCRIPTION
Added a top-level `terra resolve` command. This is just a shortcut for what we expect to be a fairly heavily used command.

It is functionally equivalent to calling the `terra resources resolve ...` command for the appropriate resource type, with all default options. i.e.:
`terra resolve bucketctrl1` = `terra resources resolve gcs-bucket --name=bucketctrl1`
`terra resolve bqref1` = `terra resources resolve bq-dataset --name=bqref1`
where `bucketctrl1`=name of a controlled GCS bucket resource and `bqref1`=name of a referenced BQ dataset resource.

The `terra resources resolve ...` commands are still useful because:
- They provide options around what format of resolved cloud identifier is returned (e.g. `--exclude-prefix` for GCS buckets, `--cloud-id-format=DATASET_ID_ONLY` for BQ datasets)
- They are grouped near the other `resources` related commands, so potentially easier to find.
