### PR TITLE
PF-719: Utility method for polling with retries.

### DIFF
--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -33,6 +33,9 @@ public class WorkspaceContext {
   // map of cloud resources for this workspace (name -> WSM resource description object)
   public Map<String, ResourceDescription> resources;
 
+  // maximum number of resources to cache on disk before throwing an error
+  public static final int MAX_RESOURCES_CACHE_SIZE = 1000;
+
   // file paths related to persisting the workspace context on disk
   private static final String WORKSPACE_CONTEXT_DIRNAME = ".terra";
   private static final String WORKSPACE_CONTEXT_FILENAME = "workspace-context.json";

--- a/src/main/java/bio/terra/cli/context/WorkspaceContext.java
+++ b/src/main/java/bio/terra/cli/context/WorkspaceContext.java
@@ -33,9 +33,6 @@ public class WorkspaceContext {
   // map of cloud resources for this workspace (name -> WSM resource description object)
   public Map<String, ResourceDescription> resources;
 
-  // maximum number of resources to cache on disk before throwing an error
-  public static final int MAX_RESOURCES_CACHE_SIZE = 1000;
-
   // file paths related to persisting the workspace context on disk
   private static final String WORKSPACE_CONTEXT_DIRNAME = ".terra";
   private static final String WORKSPACE_CONTEXT_FILENAME = "workspace-context.json";

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -12,6 +12,7 @@ import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceDescription;
+import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.RoleBindingList;
 import bio.terra.workspace.model.StewardshipType;
 import bio.terra.workspace.model.WorkspaceDescription;
@@ -260,13 +261,13 @@ public class WorkspaceManager {
     TerraUser currentUser = globalContext.requireCurrentTerraUser();
 
     // call WSM to get the list of resources for the existing workspace
-    List<ResourceDescription> resourceList =
+    // TODO (PF-706): keep calling the enumerate endpoint until no results are returned
+    ResourceList resourceList =
         new WorkspaceManagerService(globalContext.server, currentUser)
-            .enumerateAllResources(
-                workspaceContext.getWorkspaceId(), WorkspaceContext.MAX_RESOURCES_CACHE_SIZE);
+            .enumerateResources(workspaceContext.getWorkspaceId(), 0, 100, null, null);
 
     // update the cache with the list of resources fetched from WSM
-    workspaceContext.updateResources(resourceList);
+    workspaceContext.updateResources(resourceList.getResources());
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/WorkspaceManager.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManager.java
@@ -12,7 +12,6 @@ import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpGcsBucketDefaultStorageClass;
 import bio.terra.workspace.model.IamRole;
 import bio.terra.workspace.model.ResourceDescription;
-import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.RoleBindingList;
 import bio.terra.workspace.model.StewardshipType;
 import bio.terra.workspace.model.WorkspaceDescription;
@@ -117,6 +116,9 @@ public class WorkspaceManager {
     // note that this state is persisted to disk. it will be useful for code called in the same or a
     // later CLI command/process
     workspaceContext.updateWorkspace(existingWorkspace);
+
+    // call WSM to fetch the list of resources in the workspace
+    updateResourcesCache();
   }
 
   /**
@@ -258,13 +260,13 @@ public class WorkspaceManager {
     TerraUser currentUser = globalContext.requireCurrentTerraUser();
 
     // call WSM to get the list of resources for the existing workspace
-    // TODO (PF-706): keep calling the enumerate endpoint until no results are returned
-    ResourceList resourceList =
+    List<ResourceDescription> resourceList =
         new WorkspaceManagerService(globalContext.server, currentUser)
-            .enumerateResources(workspaceContext.getWorkspaceId(), 0, 100, null, null);
+            .enumerateAllResources(
+                workspaceContext.getWorkspaceId(), WorkspaceContext.MAX_RESOURCES_CACHE_SIZE);
 
     // update the cache with the list of resources fetched from WSM
-    workspaceContext.updateResources(resourceList.getResources());
+    workspaceContext.updateResources(resourceList);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -22,7 +22,7 @@ public class HttpUtils {
   private static final Logger logger = LoggerFactory.getLogger(HttpUtils.class);
 
   // default value for the maximum number of times to retry HTTP requests
-  public static final int DEFAULT_MAXIMUM_RETRIES = 10;
+  public static final int DEFAULT_MAXIMUM_RETRIES = 30;
 
   // default value for the time to sleep between retries
   public static final Duration DEFAULT_DURATION_SLEEP_FOR_RETRY = Duration.ofSeconds(1);

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -130,8 +130,9 @@ public class HttpUtils {
    * @param isRetryable function to test whether the exception is retryable or not
    * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @return the response object
-   * @throws Exception if makeRequest throws an exception that is not retryable, or if the maximum
-   *     number of retries was exhausted
+   * @throws E if makeRequest throws an exception that is not retryable
+   * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
+   *     threw a retryable exception
    */
   public static <T, E extends Exception> T callWithRetries(
       SupplierWithCheckedException<T, E> makeRequest, Predicate<Exception> isRetryable)
@@ -149,8 +150,9 @@ public class HttpUtils {
    * @param isRetryable function to test whether the exception is retryable or not
    * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @return the response object
-   * @throws Exception if makeRequest throws an exception that is not retryable, or if the maximum
-   *     number of retries was exhausted
+   * @throws E if makeRequest throws an exception that is not retryable
+   * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
+   *     threw a retryable exception
    */
   public static <T, E extends Exception> T callWithRetries(
       int maxCalls,
@@ -170,8 +172,9 @@ public class HttpUtils {
    * @param isRetryable function to test whether the exception is retryable or not
    * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @return the response object
-   * @throws Exception if makeRequest throws an exception that is not retryable, or if the maximum
-   *     number of retries was exhausted
+   * @throws E if makeRequest throws an exception that is not retryable
+   * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
+   *     threw a retryable exception
    */
   public static <T, E extends Exception> T pollWithRetries(
       SupplierWithCheckedException<T, E> makeRequest,
@@ -206,8 +209,9 @@ public class HttpUtils {
    * @param isRetryable function to test whether the exception is retryable or not
    * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @return the response object
-   * @throws Exception if makeRequest throws an exception that is not retryable, or if the maximum
-   *     number of retries was exhausted
+   * @throws E if makeRequest throws an exception that is not retryable
+   * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
+   *     threw a retryable exception
    */
   public static <T, E extends Exception> T pollWithRetries(
       int maxCalls,
@@ -263,8 +267,8 @@ public class HttpUtils {
    * @param makeRequest function to perform the request
    * @param isOneTimeError function to test whether the exception is the expected one-time error
    * @param handleOneTimeError function to handle the one-time error before retrying the request
-   * @param <T> type of the Http response (i.e. return type of the makeRequest function)
-   * @return the Http response
+   * @param <T> type of the response object (i.e. return type of the makeRequest function)
+   * @return the response object
    * @throws E1 if makeRequest throws an exception that is not the expected one-time error
    * @throws E2 if handleOneTimeError throws an exception
    */

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -229,8 +229,14 @@ public class HttpUtils {
         T result = makeRequest.makeRequest();
         logger.debug("Result: {}", result);
 
-        if (isDone.test(result) || numTries > maxCalls) {
+        boolean jobCompleted = isDone.test(result);
+        boolean timedOut = numTries > maxCalls;
+        if (jobCompleted || timedOut) {
           // polling is either done (i.e. job completed) or timed out: return the last result
+          logger.debug(
+              "polling with retries completed. jobCompleted = {}, timedOut = {}",
+              jobCompleted,
+              timedOut);
           return result;
         }
       } catch (Exception ex) {

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -138,30 +138,30 @@ public class HttpUtils {
       SupplierWithCheckedException<T, E> makeRequest, Predicate<Exception> isRetryable)
       throws E, InterruptedException {
     return callWithRetries(
-        DEFAULT_MAXIMUM_RETRIES, DEFAULT_DURATION_SLEEP_FOR_RETRY, makeRequest, isRetryable);
+        makeRequest, isRetryable, DEFAULT_MAXIMUM_RETRIES, DEFAULT_DURATION_SLEEP_FOR_RETRY);
   }
 
   /**
    * Helper method to call a function with retries.
    *
-   * @param maxCalls maximum number of times to retry
-   * @param sleepDuration time to sleep between tries
+   * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @param makeRequest function to perform the request
    * @param isRetryable function to test whether the exception is retryable or not
-   * @param <T> type of the response object (i.e. return type of the makeRequest function)
+   * @param maxCalls maximum number of times to retry
+   * @param sleepDuration time to sleep between tries
    * @return the response object
    * @throws E if makeRequest throws an exception that is not retryable
    * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
    *     threw a retryable exception
    */
   public static <T, E extends Exception> T callWithRetries(
-      int maxCalls,
-      Duration sleepDuration,
       SupplierWithCheckedException<T, E> makeRequest,
-      Predicate<Exception> isRetryable)
+      Predicate<Exception> isRetryable,
+      int maxCalls,
+      Duration sleepDuration)
       throws E, InterruptedException {
     // isDone always return true
-    return pollWithRetries(maxCalls, sleepDuration, makeRequest, (result) -> true, isRetryable);
+    return pollWithRetries(makeRequest, (result) -> true, isRetryable, maxCalls, sleepDuration);
   }
 
   /**
@@ -182,11 +182,11 @@ public class HttpUtils {
       Predicate<Exception> isRetryable)
       throws E, InterruptedException {
     return pollWithRetries(
-        DEFAULT_MAXIMUM_RETRIES,
-        DEFAULT_DURATION_SLEEP_FOR_RETRY,
         makeRequest,
         isDone,
-        isRetryable);
+        isRetryable,
+        DEFAULT_MAXIMUM_RETRIES,
+        DEFAULT_DURATION_SLEEP_FOR_RETRY);
   }
 
   /**
@@ -202,23 +202,23 @@ public class HttpUtils {
    * <p>- If the last attempt threw a retryable exception, then this method re-throws that last
    * exception wrapped in a {@link SystemException} with a timeout message.
    *
-   * @param maxCalls maximum number of times to poll or retry
-   * @param sleepDuration time to sleep between tries
+   * @param <T> type of the response object (i.e. return type of the makeRequest function)
    * @param makeRequest function to perform the request
    * @param isDone function to decide whether to keep polling or not, based on the result
    * @param isRetryable function to test whether the exception is retryable or not
-   * @param <T> type of the response object (i.e. return type of the makeRequest function)
+   * @param maxCalls maximum number of times to poll or retry
+   * @param sleepDuration time to sleep between tries
    * @return the response object
    * @throws E if makeRequest throws an exception that is not retryable
    * @throws SystemException if the maximum number of retries is exhausted, and the last attempt
    *     threw a retryable exception
    */
   public static <T, E extends Exception> T pollWithRetries(
-      int maxCalls,
-      Duration sleepDuration,
       SupplierWithCheckedException<T, E> makeRequest,
       Predicate<T> isDone,
-      Predicate<Exception> isRetryable)
+      Predicate<Exception> isRetryable,
+      int maxCalls,
+      Duration sleepDuration)
       throws E, InterruptedException {
     int numTries = 0;
     Exception lastRetryableException = null;

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.service.utils;
 
 import bio.terra.cli.command.exception.SystemException;
+import bio.terra.cli.command.exception.UserActionableException;
 import bio.terra.cli.context.ServerSpecification;
 import bio.terra.cli.context.TerraUser;
 import bio.terra.cli.context.resources.GcsBucketLifecycle;
@@ -24,6 +25,7 @@ import bio.terra.workspace.model.CreateGcpGcsBucketReferenceRequestBody;
 import bio.terra.workspace.model.CreateWorkspaceRequestBody;
 import bio.terra.workspace.model.DeleteControlledGcpGcsBucketRequest;
 import bio.terra.workspace.model.DeleteControlledGcpGcsBucketResult;
+import bio.terra.workspace.model.ErrorReport;
 import bio.terra.workspace.model.GcpBigQueryDatasetAttributes;
 import bio.terra.workspace.model.GcpBigQueryDatasetCreationParameters;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
@@ -46,9 +48,7 @@ import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceList;
-import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.RoleBindingList;
-import bio.terra.workspace.model.StewardshipType;
 import bio.terra.workspace.model.SystemStatus;
 import bio.terra.workspace.model.SystemVersion;
 import bio.terra.workspace.model.UpdateWorkspaceRequestBody;
@@ -57,10 +57,11 @@ import bio.terra.workspace.model.WorkspaceDescriptionList;
 import bio.terra.workspace.model.WorkspaceStageModel;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,6 +78,13 @@ public class WorkspaceManagerService {
 
   // the client object used for talking to WSM
   private final ApiClient apiClient;
+
+  // the maximum number of retries and time to sleep for creating a new workspace
+  private static final int CREATE_WORKSPACE_MAXIMUM_RETRIES = 120;
+  private static final Duration CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY = Duration.ofSeconds(1);
+
+  // maximum number of resources to enumerate per request
+  private static final int MAX_RESOURCES_PER_ENUMERATE_REQUEST = 100;
 
   /**
    * Constructor for class that talks to the Workspace Manager service. The user must be
@@ -175,6 +183,8 @@ public class WorkspaceManagerService {
    * @param displayName optional display name
    * @param description optional description
    * @return the Workspace Manager workspace description object
+   * @throws SystemException if the job to create the workspace cloud context fails
+   * @throws UserActionableException if the CLI times out waiting for the job to complete
    */
   public WorkspaceDescription createWorkspace(
       @Nullable String displayName, @Nullable String description) {
@@ -195,36 +205,22 @@ public class WorkspaceManagerService {
       CreateCloudContextRequest cloudContextRequest = new CreateCloudContextRequest();
       cloudContextRequest.setCloudPlatform(CloudPlatform.GCP);
       cloudContextRequest.setJobControl(new JobControl().id(jobId.toString()));
+
+      // make the initial create context request
       workspaceApi.createCloudContext(cloudContextRequest, workspaceId);
 
-      // poll the job result endpoint until the job status is completed
-      final int MAX_JOB_POLLING_TRIES = 120; // maximum 120 seconds sleep
-      int numJobPollingTries = 1;
-      CreateCloudContextResult cloudContextResult;
-      JobReport.StatusEnum jobReportStatus;
-      do {
-        logger.info(
-            "Job polling try #{}, workspace id: {}, job id: {}",
-            numJobPollingTries,
-            workspaceId,
-            jobId);
-        cloudContextResult =
-            workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString());
-        jobReportStatus = cloudContextResult.getJobReport().getStatus();
-        logger.debug("Create workspace cloudContextResult: {}", cloudContextResult);
-        numJobPollingTries++;
-        if (jobReportStatus.equals(JobReport.StatusEnum.RUNNING)) {
-          Thread.sleep(1000);
-        }
-      } while (jobReportStatus.equals(JobReport.StatusEnum.RUNNING)
-          && numJobPollingTries < MAX_JOB_POLLING_TRIES);
+      // poll the result endpoint until the job is no longer RUNNING
+      CreateCloudContextResult createContextResult =
+          HttpUtils.pollWithRetries(
+              CREATE_WORKSPACE_MAXIMUM_RETRIES,
+              CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY,
+              () -> workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString()),
+              (result) -> !result.getJobReport().getStatus().equals(JobReport.StatusEnum.RUNNING),
+              WorkspaceManagerService::isRetryable);
+      logger.debug("create workspace context result: {}", createContextResult);
 
-      if (jobReportStatus.equals(JobReport.StatusEnum.FAILED)) {
-        logger.error(
-            "Job to create a new workspace failed: {}", cloudContextResult.getErrorReport());
-      } else if (jobReportStatus.equals(JobReport.StatusEnum.RUNNING)) {
-        logger.error("Job to create a new workspace timed out in the CLI");
-      }
+      throwIfJobNotCompleted(
+          createContextResult.getJobReport(), createContextResult.getErrorReport());
 
       // call the get workspace endpoint to get the full description object
       return workspaceApi.getWorkspace(workspaceId);
@@ -371,22 +367,48 @@ public class WorkspaceManagerService {
   }
 
   /**
-   * Call the Workspace Manager GET "/api/workspaces/v1/{workspaceId}/resources" endpoint to get a
-   * list of resources (controlled and referenced).
+   * Poll the Workspace Manager GET "/api/workspaces/v1/{workspaceId}/resources" endpoint to get a
+   * list of all resources (controlled and referenced) in the workspace.
    *
    * @param workspaceId the workspace to query
-   * @param offset the offset to use when listing workspaces (zero to start from the beginning)
-   * @param limit the maximum number of workspaces to return
-   * @param resource the resource type to filter on
-   * @param stewardship the stewardship type to filter on
+   * @param limit the maximum number of resources to return
    * @return a list of resources, wrapped in a the ResourceList object
    */
-  public ResourceList enumerateResources(
-      UUID workspaceId, int offset, int limit, ResourceType resource, StewardshipType stewardship) {
+  public List<ResourceDescription> enumerateAllResources(UUID workspaceId, int limit) {
     ResourceApi resourceApi = new ResourceApi(apiClient);
     try {
-      return resourceApi.enumerateResources(workspaceId, offset, limit, resource, stewardship);
-    } catch (ApiException ex) {
+      // poll the enumerate endpoint until no results are returned, or we hit the limit
+      List<ResourceDescription> allResources = new ArrayList<>();
+      HttpUtils.pollWithRetries(
+          () -> {
+            int offset = allResources.size();
+            ResourceList result =
+                resourceApi.enumerateResources(
+                    workspaceId, offset, MAX_RESOURCES_PER_ENUMERATE_REQUEST, null, null);
+
+            // add all fetched resources to the running list
+            allResources.addAll(result.getResources());
+
+            // return the number of resources added
+            return result.getResources().size();
+          },
+          // quit polling when we've either fetched more than the limit, or this last fetch returned
+          // less than the maximum allowed per request (because that indicates there are no more)
+          (result) -> allResources.size() > limit || result < MAX_RESOURCES_PER_ENUMERATE_REQUEST,
+          WorkspaceManagerService::isRetryable);
+      logger.debug("fetched total number of resources: {}", allResources.size());
+
+      // if we have fetched more than the limit, then throw an exception
+      if (allResources.size() > limit) {
+        throw new SystemException(
+            "Total number of resources ("
+                + allResources.size()
+                + ") exceeds the CLI limit ("
+                + limit
+                + ")");
+      }
+      return allResources;
+    } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error enumerating resources in the workspace.", ex);
     }
   }
@@ -669,20 +691,27 @@ public class WorkspaceManagerService {
    *
    * @param workspaceId the workspace to remove the resource from
    * @param resourceId the resource id
+   * @throws SystemException if the job to delete the bucket fails
+   * @throws UserActionableException if the CLI times out waiting for the job to complete
    */
   public void deleteControlledGcsBucket(UUID workspaceId, UUID resourceId) {
     ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
     String asyncJobId = UUID.randomUUID().toString();
     DeleteControlledGcpGcsBucketRequest deleteRequest =
         new DeleteControlledGcpGcsBucketRequest().jobControl(new JobControl().id(asyncJobId));
-    // TODO (PF-719): factor out this polling pattern into a utility method
     try {
+      // make the initial delete request
+      controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId);
+
+      // poll the result endpoint until the job is no longer RUNNING
       DeleteControlledGcpGcsBucketResult deleteResult =
-          controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId);
-      while (deleteResult.getJobReport().getStatus().equals(JobReport.StatusEnum.RUNNING)) {
-        TimeUnit.SECONDS.sleep(5);
-        deleteResult = controlledGcpResourceApi.getDeleteBucketResult(workspaceId, asyncJobId);
-      }
+          HttpUtils.pollWithRetries(
+              () -> controlledGcpResourceApi.getDeleteBucketResult(workspaceId, asyncJobId),
+              (result) -> !result.getJobReport().getStatus().equals(JobReport.StatusEnum.RUNNING),
+              WorkspaceManagerService::isRetryable);
+      logger.debug("delete controlled gcs bucket result: {}", deleteResult);
+
+      throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error deleting controlled GCS bucket in the workspace.", ex);
     }
@@ -704,5 +733,42 @@ public class WorkspaceManagerService {
       throw new SystemException(
           "Error deleting controlled Big Query dataset in the workspace.", ex);
     }
+  }
+
+  /**
+   * Helper method that checks a JobReport's status and throws an exception if it's not COMPLETED.
+   *
+   * <p>- Throws a {@link SystemException} if the job FAILED.
+   *
+   * <p>- Throws a {@link UserActionableException} if the job is still RUNNING. Some actions are
+   * expected to take a long time (e.g. deleting a bucket with lots of objects), and a timeout is
+   * not necessarily a failure. The action the user can take is to wait a bit longer and then check
+   * back (e.g. by listing the buckets in the workspace) later to see if the job completed.
+   *
+   * @param jobReport WSM job report object
+   * @param errorReport WSM error report object
+   */
+  private static void throwIfJobNotCompleted(JobReport jobReport, ErrorReport errorReport) {
+    switch (jobReport.getStatus()) {
+      case FAILED:
+        throw new SystemException("Job failed: " + errorReport.getMessage());
+      case RUNNING:
+        throw new UserActionableException(
+            "CLI timed out waiting for the job to complete. It's still running on the server.");
+    }
+  }
+
+  /**
+   * Utility method that checks if an exception thrown by the WSM client is retryable.
+   *
+   * @param ex exception to test
+   * @return true if the exception is retryable
+   */
+  private static boolean isRetryable(Exception ex) {
+    if (!(ex instanceof ApiException)) {
+      return false;
+    }
+    // TODO (PF-513): add retries for WSM calls after confirm what codes should be retryable
+    return false;
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/utils/WorkspaceManagerService.java
@@ -213,11 +213,11 @@ public class WorkspaceManagerService {
       // poll the result endpoint until the job is no longer RUNNING
       CreateCloudContextResult createContextResult =
           HttpUtils.pollWithRetries(
-              CREATE_WORKSPACE_MAXIMUM_RETRIES,
-              CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY,
               () -> workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString()),
               (result) -> !result.getJobReport().getStatus().equals(JobReport.StatusEnum.RUNNING),
-              WorkspaceManagerService::isRetryable);
+              WorkspaceManagerService::isRetryable,
+              CREATE_WORKSPACE_MAXIMUM_RETRIES,
+              CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY);
       logger.debug("create workspace context result: {}", createContextResult);
 
       throwIfJobNotCompleted(


### PR DESCRIPTION
- Added `pollWithRetries` utility method that polls or retries a specified number of times, with a sleep in between each.
  - Poll = check the result of an operation to see if it's done (e.g. polling to see if a job is done)
  - Retry = try an operation again if a specific kind of exception is thrown (e.g. retry after 500 errors)
  - This is basically the same as the existing `callWithRetries` utility method, except that it takes an additional lambda parameter `isDone` and tests the result each time instead of just returning the first result that doesn't throw an exception.
- Called the new method when:
  - Deleting a controlled GCS bucket resource
  - Creating a new workspace
- Increased the default number of retries from 10 -> 30.

- Also fixed an unrelated bug, where the resources cache was not being updated when mounting an existing workspace.