### PR TITLE
[no ticket] Restore bash e option in local-dev script.

### DIFF
--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 set -e
 ## This script sets up the environment for local development.
 ## Dependencies: docker, chmod
@@ -32,3 +33,7 @@ chmod a+x tools/*
 
 # pull credentials needed for development
 ./tools/render-config.sh
+
+# restore the bash setting to exit on a failing command
+# (this script is typically called with `source`, and so we don't want to modify the calling shell)
+set +e


### PR DESCRIPTION
Added `set +e` to the `local-dev.sh` script. This script is typically called with `source` and so it modifies the calling shell. So after you run `source tools/local-dev.sh`, the next time you run a failing command (e.g. `git stats` instead of `git status`) the shell process exits.

We could also just remove this option in the script, but I think the option is sometimes helpful, and unsetting it on a successful run seems like a good compromise.