### PR TITLE
PF-784: Add env var override for context directory parent.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,14 @@
     * [download-install.sh](#download-installsh)
     * [install.sh](#installsh)
     * [terra](#terra)
-3. [Docker](#docker)
+3. [Testing](#testing)
+    * [Override context directory](#override-context-directory)
+4. [Docker](#docker)
     * [Pull an existing image](#pull-an-existing-image)
     * [Build a new image](#build-a-new-image)
     * [Publish a new image](#publish-a-new-image)
     * [Update the default image](#update-the-default-image)
-4. [Code structure](#code-structure)
+5. [Code structure](#code-structure)
     * [Supported tools](#supported-tools)
         * [Adding a new supported tool](#adding-a-new-supported-tool)
     * [Authentication](#authentication)
@@ -104,6 +106,20 @@ This is the run script that wraps the Java call to the CLI.
 
 It is included in the `terra-cli.tar` install package in each GitHub release.
 This is the script users can add to their `$PATH` to invoke the CLI more easily from another directory.
+
+
+### Testing
+
+#### Override context directory
+The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
+You can override this default by setting the `TERRA_CONTEXT_DIR` environment variable to a valid directory.
+```
+export TERRA_CONTEXT_DIR="/Desktop/cli-testing"
+terra config list
+```
+If the environment variable override does not point to a valid directory, then the CLI will throw a `SystemException`.
+
+This option is intended for tests, so that they don't overwrite the context for an installation on the same machine.
 
 
 ### Docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,9 +112,9 @@ This is the script users can add to their `$PATH` to invoke the CLI more easily 
 
 #### Override context directory
 The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
-You can override this default by setting the `TERRA_CONTEXT_DIR` environment variable to a valid directory.
+You can override this default by setting the `TERRA_CONTEXT_PARENT_DIR` environment variable to a valid directory.
 ```
-export TERRA_CONTEXT_DIR="/Desktop/cli-testing"
+export TERRA_CONTEXT_PARENT_DIR="/Desktop/cli-testing"
 terra config list
 ```
 If the environment variable override does not point to a valid directory, then the CLI will throw a `SystemException`.

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -52,6 +52,9 @@ public class GlobalContext {
   public LogLevel fileLoggingLevel = LogLevel.INFO;
   public LogLevel consoleLoggingLevel = LogLevel.OFF;
 
+  // env var name to optionally override where the context is persisted on disk
+  private static final String CONTEXT_DIR_OVERRIDE_NAME = "TERRA_CONTEXT_DIR";
+
   // file paths related to persisting the global context on disk
   private static final String GLOBAL_CONTEXT_DIRNAME = ".terra";
   private static final String GLOBAL_CONTEXT_FILENAME = "global-context.json";
@@ -267,7 +270,7 @@ public class GlobalContext {
 
   // ====================================================
   // Directory and file names
-  //   - global context directory parent: $HOME/
+  //   - global context directory parent: $HOME/ or $TERRA_CONTEXT_DIR/
   //       - global context directory: .terra/
   //           - persisted global context file: global-context.json
   //           - sub-directory for persisting pet SA keys: pet-keys/[terra user id]/
@@ -282,8 +285,22 @@ public class GlobalContext {
    */
   @JsonIgnore
   public static Path getGlobalContextDir() {
-    // TODO: allow overriding this (e.g. env var != user home directory)
+    // default to the user's home directory
     Path parentDir = Paths.get(System.getProperty("user.home"));
+
+    // if the override environment variable is set and points to a valid directory, then use it
+    // instead
+    String overrideDirName = System.getenv(CONTEXT_DIR_OVERRIDE_NAME);
+    if (overrideDirName != null && !overrideDirName.isBlank()) {
+      Path overrideDir = Paths.get(overrideDirName).toAbsolutePath();
+      if (overrideDir.toFile().exists() && overrideDir.toFile().isDirectory()) {
+        parentDir = overrideDir;
+      } else {
+        throw new SystemException(
+            "Override environment variable does not point to a valid directory: " + overrideDir);
+      }
+    }
+
     return parentDir.resolve(GLOBAL_CONTEXT_DIRNAME).toAbsolutePath();
   }
 

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -53,7 +53,7 @@ public class GlobalContext {
   public LogLevel consoleLoggingLevel = LogLevel.OFF;
 
   // env var name to optionally override where the context is persisted on disk
-  private static final String CONTEXT_DIR_OVERRIDE_NAME = "TERRA_CONTEXT_DIR";
+  private static final String CONTEXT_DIR_OVERRIDE_NAME = "TERRA_CONTEXT_PARENT_DIR";
 
   // file paths related to persisting the global context on disk
   private static final String GLOBAL_CONTEXT_DIRNAME = ".terra";
@@ -270,7 +270,7 @@ public class GlobalContext {
 
   // ====================================================
   // Directory and file names
-  //   - global context directory parent: $HOME/ or $TERRA_CONTEXT_DIR/
+  //   - global context directory parent: $HOME/ or $TERRA_CONTEXT_PARENT_DIR/
   //       - global context directory: .terra/
   //           - persisted global context file: global-context.json
   //           - sub-directory for persisting pet SA keys: pet-keys/[terra user id]/
@@ -296,7 +296,7 @@ public class GlobalContext {
       if (overrideDir.toFile().exists() && overrideDir.toFile().isDirectory()) {
         parentDir = overrideDir;
       } else {
-        throw new SystemException(
+        throw new UserActionableException(
             "Override environment variable does not point to a valid directory: " + overrideDir);
       }
     }


### PR DESCRIPTION
By default, the global context directory is stored in the user's home directory (`$HOME`). Added an option to override this with the `TERRA_CONTEXT_PARENT_DIR ` environment variable.

This will be useful for testing, so that tests don't overwrite an existing installation on the same machine.