### PR TITLE
PF-787: Domain-wide delegation for CLI test users.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,38 @@ This is the run script that wraps the Java call to the CLI.
 It is included in the `terra-cli.tar` install package in each GitHub release.
 This is the script users can add to their `$PATH` to invoke the CLI more easily from another directory.
 
+#### Setup test users
+Tests use domain-wide delegation (i.e. Harry Potter users). This avoids the Google OAuth flow, which requires
+interacting with a browser. Before running tests against a Terra server, the test users need to be setup there.
+Setup happens exclusively in SAM, so if there are multiple Terra servers that all talk to the same SAM instance,
+then you only need to do this setup once.
+
+The CLI only uses the test users defined in the `TestUsers` enum class. The list includes a mix of users that:
+- Have permission to use the default WSM spend profile via the `cli-test-users` SAM group.
+- Have permission to use the default WSM spend profile directly on the SAM resource.
+- Do not have permission to use the default WSM spend profile.
+
+Below is the script used to setup the initial set of test users on the SAM dev instance.
+```
+# create the cli-test-users SAM group and add it as a user on the spend profile
+terra groups create cli-test-users
+terra spend enable --policy=user $(terra groups describe cli-test-users)
+
+# penelope is an owner on both the cli-test-users group and the spend profile resource
+terra groups add-user --group=cli-test-users --policy=admin Penelope.TwilightsHammer@test.firecloud.org
+terra spend enable --policy=owner Penelope.TwilightsHammer@test.firecloud.org
+
+# john and lily are members of the cli-test-users group
+terra groups add-user --group=cli-test-users --policy=member John.Whiteclaw@test.firecloud.org
+terra groups add-user --group=cli-test-users --policy=member Lily.Shadowmoon@test.firecloud.org
+
+# brooklyn and noah are users of the spend profile resource
+terra spend enable --policy=user Brooklyn.Thunderlord@test.firecloud.org
+terra spend enable --policy=user Noah.Frostwolf@test.firecloud.org
+
+# ethan has no spend profile access
+# do nothing: Ethan.Bonechewer@test.firecloud.org
+```
 
 ### Docker
 The `docker/` directory contains files required to build the Docker image.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
     * [terra](#terra)
 3. [Testing](#testing)
     * [Override context directory](#override-context-directory)
+    * [Setup test users](#setup-test-users)
 4. [Docker](#docker)
     * [Pull an existing image](#pull-an-existing-image)
     * [Build a new image](#build-a-new-image)
@@ -107,6 +108,20 @@ This is the run script that wraps the Java call to the CLI.
 It is included in the `terra-cli.tar` install package in each GitHub release.
 This is the script users can add to their `$PATH` to invoke the CLI more easily from another directory.
 
+
+### Testing
+
+#### Override context directory
+The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
+You can override this default by setting the `TERRA_CONTEXT_PARENT_DIR` environment variable to a valid directory.
+```
+export TERRA_CONTEXT_PARENT_DIR="/Desktop/cli-testing"
+terra config list
+```
+If the environment variable override does not point to a valid directory, then the CLI will throw a `SystemException`.
+
+This option is intended for tests, so that they don't overwrite the context for an installation on the same machine.
+
 #### Setup test users
 Tests use domain-wide delegation (i.e. Harry Potter users). This avoids the Google OAuth flow, which requires
 interacting with a browser. Before running tests against a Terra server, the test users need to be setup there.
@@ -139,19 +154,6 @@ terra spend enable --policy=user Noah.Frostwolf@test.firecloud.org
 # ethan has no spend profile access
 # do nothing: Ethan.Bonechewer@test.firecloud.org
 ```
-
-### Testing
-
-#### Override context directory
-The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
-You can override this default by setting the `TERRA_CONTEXT_PARENT_DIR` environment variable to a valid directory.
-```
-export TERRA_CONTEXT_PARENT_DIR="/Desktop/cli-testing"
-terra config list
-```
-If the environment variable override does not point to a valid directory, then the CLI will throw a `SystemException`.
-
-This option is intended for tests, so that they don't overwrite the context for an installation on the same machine.
 
 
 ### Docker

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
         // needed for WSM client library
         swaggerAnnotations = "2.1.5"
         jersey = "2.30.1"
+
+        // testing
+        junit = "5.7.2"
+        hamcrest = "2.2"
     }
 
     implementation "info.picocli:picocli:${picocli}"
@@ -103,11 +107,31 @@ dependencies {
     compile "io.swagger.core.v3:swagger-annotations:${swaggerAnnotations}"
     compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
 
+    testImplementation platform("org.junit:junit-bom:${junit}")
+    testImplementation "org.junit.jupiter:junit-jupiter"
+    testImplementation "org.hamcrest:hamcrest:${hamcrest}"
 }
 
 test {
     testLogging {
         showStandardStreams = true // disable stdout & stderr redirection
+    }
+    useJUnitPlatform()
+}
+
+task unitTest(type: Test) {
+    useJUnitPlatform {
+        includeTags 'unit'
+    }
+    // force tests to always be re-run
+    outputs.upToDateWhen { false }
+
+    doFirst {
+        if(!project.hasProperty("useDefaultContextDir")) {
+            environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
+        }
+        String serverName = project.hasProperty("server") ? project.findProperty("server") : "terra-dev"
+        systemProperty "TERRA_SERVER", serverName
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -129,6 +129,7 @@ task unitTest(type: Test) {
     doFirst {
         if(!project.hasProperty("useDefaultContextDir")) {
             environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
+            mkdir "${project.buildDir}/test-context/"
         }
         String serverName = project.hasProperty("server") ? project.findProperty("server") : "terra-dev"
         systemProperty "TERRA_SERVER", serverName

--- a/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
@@ -1,6 +1,5 @@
 package bio.terra.cli.auth;
 
-import bio.terra.cli.command.exception.SystemException;
 import bio.terra.cli.context.utils.Printer;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.oauth2.StoredCredential;
@@ -249,9 +248,9 @@ public final class GoogleCredentialUtils {
   public static AccessToken getAccessToken(GoogleCredentials credential) {
     try {
       credential.refreshIfExpired();
-      return credential.getAccessToken();
     } catch (IOException ioEx) {
-      throw new SystemException("Error refreshing access token", ioEx);
+      logger.warn("Error refreshing access token", ioEx);
     }
+    return credential.getAccessToken();
   }
 }

--- a/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/auth/GoogleCredentialUtils.java
@@ -250,6 +250,9 @@ public final class GoogleCredentialUtils {
       credential.refreshIfExpired();
     } catch (IOException ioEx) {
       logger.warn("Error refreshing access token", ioEx);
+      // don't throw an exception here because the token may not be expired, in which case it's fine
+      // to use it without refreshing first. if the token is expired, then we'll get a permission
+      // error when we try to re-use it anyway, and this log statement may help with debugging.
     }
     return credential.getAccessToken();
   }

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -122,8 +122,15 @@ public class GlobalContext {
 
   /** Set the current terra user. Persists on disk. */
   public void setCurrentTerraUser(TerraUser terraUser) {
+    boolean isNewUser = this.terraUser == null;
     this.terraUser = terraUser;
-    writeToFile();
+
+    // only need to persist the user if there was no user defined previously
+    // otherwise, this method just updates the credentials stored on the TerraUser object, which are
+    // not persisted to disk
+    if (isNewUser) {
+      writeToFile();
+    }
   }
 
   /** Clear the current terra user. Persists on disk. */

--- a/src/main/java/bio/terra/cli/context/GlobalContext.java
+++ b/src/main/java/bio/terra/cli/context/GlobalContext.java
@@ -108,7 +108,7 @@ public class GlobalContext {
   // ====================================================
   // Auth
 
-  /** Getter for the current Terra user. Returns null if no current user is defined. */
+  /** Getter for the current Terra user. Returns empty if no current user is defined. */
   @JsonIgnore
   public Optional<TerraUser> getCurrentTerraUser() {
     return Optional.ofNullable(terraUser);

--- a/src/main/java/bio/terra/cli/context/TerraUser.java
+++ b/src/main/java/bio/terra/cli/context/TerraUser.java
@@ -16,11 +16,6 @@ import org.slf4j.LoggerFactory;
 public class TerraUser {
   private static final Logger logger = LoggerFactory.getLogger(TerraUser.class);
 
-  // The CLI generates a random UUID for each user, to keep track of which credentials belong to
-  // which user. (Note: It would be better to use the SAM/Terra subject id, but we don't have that
-  // until after logging in because we need Google credentials to get the subject id from SAM.)
-  public String cliGeneratedUserKey;
-
   // This field stores the id that Terra uses to identify a user. The CLI queries SAM for a user's
   // subject id to populate this field.
   public String terraUserId;
@@ -38,10 +33,6 @@ public class TerraUser {
   @JsonIgnore public ServiceAccountCredentials petSACredentials;
 
   public TerraUser() {}
-
-  public TerraUser(String cliGeneratedUserKey) {
-    this.cliGeneratedUserKey = cliGeneratedUserKey;
-  }
 
   /** Check if the user credentials are expired. */
   public boolean requiresReauthentication() {

--- a/src/test/java/auth/LoginTestUser.java
+++ b/src/test/java/auth/LoginTestUser.java
@@ -34,10 +34,10 @@ public class LoginTestUser {
 
   @AfterEach
   void cleanup() throws IOException {
-    //    TestContext.deleteGlobalContext();
+    TestContext.deleteGlobalContext();
   }
 
-  //  @Test
+  @Test
   @DisplayName("test user login updates global context")
   void loginTestUser() throws IOException {
     // select a test user and login

--- a/src/test/java/auth/LoginTestUser.java
+++ b/src/test/java/auth/LoginTestUser.java
@@ -1,0 +1,87 @@
+package auth;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.cli.auth.GoogleCredentialUtils;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.TerraUser;
+import bio.terra.cli.service.utils.SamService;
+import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.api.client.util.store.DataStore;
+import harness.TestContext;
+import harness.TestUsers;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("unit")
+public class LoginTestUser {
+  @BeforeEach
+  void setup() throws IOException {
+    TestContext.resetGlobalContext();
+  }
+
+  @AfterEach
+  void cleanup() throws IOException {
+    //    TestContext.deleteGlobalContext();
+  }
+
+  //  @Test
+  @DisplayName("test user login updates global context")
+  void loginTestUser() throws IOException {
+    // select a test user and login
+    TestUsers testUser = TestUsers.chooseTestUser();
+    testUser.login(GlobalContext.readFromFile());
+
+    // check that the credential exists in the store on disk
+    DataStore<StoredCredential> dataStore = TestUsers.getCredentialStore();
+    assertEquals(1, dataStore.keySet().size(), "credential store only contains one entry");
+    assertTrue(
+        dataStore.containsKey(GoogleCredentialUtils.CREDENTIAL_STORE_KEY),
+        "credential store contains hard-coded single user key");
+    StoredCredential storedCredential = dataStore.get(GoogleCredentialUtils.CREDENTIAL_STORE_KEY);
+    assertThat(storedCredential.getAccessToken(), CoreMatchers.not(emptyOrNullString()));
+
+    // check that the current user in the global context = the test user
+    // read the global context in from disk again to make sure it got persisted
+    GlobalContext globalContext = GlobalContext.readFromFile();
+    Optional<TerraUser> currentTerraUser = globalContext.getCurrentTerraUser();
+    assertTrue(currentTerraUser.isPresent(), "current user set in global context");
+    assertThat(
+        "test user email matches the current user set in global context",
+        testUser.email,
+        equalToIgnoringCase(currentTerraUser.get().terraUserEmail));
+  }
+
+  @Test
+  @DisplayName("all test users enabled in SAM")
+  void checkEnabled() throws IOException {
+    // check that each test user is enabled in SAM
+    for (TestUsers testUser : Arrays.asList(TestUsers.values())) {
+      // login the user, so we have their credentials
+      GlobalContext globalContext = GlobalContext.readFromFile();
+      testUser.login(globalContext);
+
+      // build a SAM client with the test user's credentials
+      SamService samService =
+          new SamService(globalContext.server, globalContext.requireCurrentTerraUser());
+
+      // check that the user is enabled
+      UserStatusInfo userStatusInfo = samService.getUserInfo();
+      assertTrue(userStatusInfo.getEnabled(), "test user is enabled in SAM");
+
+      testUser.logout(globalContext);
+    }
+  }
+}

--- a/src/test/java/harness/TestContext.java
+++ b/src/test/java/harness/TestContext.java
@@ -1,0 +1,54 @@
+package harness;
+
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.utils.Logger;
+import bio.terra.cli.service.ServerManager;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+/** Utility methods for manipulating the context during testing. */
+public class TestContext {
+
+  private TestContext() {}
+
+  /** Delete the global context directory. */
+  public static void deleteGlobalContext() throws IOException {
+    Path globalContextDir = GlobalContext.getGlobalContextDir();
+    if (!globalContextDir.toFile().exists()) {
+      return;
+    }
+
+    //   - walk the file tree and build a list of paths
+    //   - sort the list from longest paths to shortest
+    //   - delete the files in this order
+    // File.delete only works on file or empty directories
+    // since longer paths come first, all children of a directory will be deleted before we get to
+    // the directory
+    Files.walk(globalContextDir)
+        .sorted(Comparator.reverseOrder())
+        .map(Path::toFile)
+        .forEach(File::delete);
+  }
+
+  /**
+   * Reset the global context: delete the existing directory and setup a new global context for
+   * testing. This setup includes logging and setting the server.
+   */
+  public static void resetGlobalContext() throws IOException {
+    deleteGlobalContext();
+    GlobalContext globalContext = GlobalContext.readFromFile();
+
+    // setup logging for testing (console = OFF, file = DEBUG)
+    globalContext.consoleLoggingLevel = Logger.LogLevel.OFF;
+    globalContext.fileLoggingLevel = Logger.LogLevel.DEBUG;
+    new Logger(globalContext).setupLogging();
+
+    // set the server to the one specified by the test
+    // (see the Gradle unitTest task for how this system property gets set from a Gradle property)
+    String serverName = System.getProperty("TERRA_SERVER");
+    new ServerManager(globalContext).updateServer(serverName);
+  }
+}

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -104,18 +105,17 @@ public enum TestUsers {
 
   /** Randomly chooses a test user. */
   public static TestUsers chooseTestUser() {
-    return chooseTestUser(Arrays.asList(SpendEnabled.values()));
+    return chooseTestUser(Set.of(SpendEnabled.values()));
   }
 
   /** Randomly chooses a test user with spend profile access. */
   public static TestUsers chooseTestUserWithSpendAccess() {
     return chooseTestUser(
-        Arrays.asList(
-            new SpendEnabled[] {SpendEnabled.CLI_TEST_USERS_GROUP, SpendEnabled.DIRECTLY}));
+        Set.of(new SpendEnabled[] {SpendEnabled.CLI_TEST_USERS_GROUP, SpendEnabled.DIRECTLY}));
   }
 
   /** Randomly chooses a test user that matches one of the specified spend enabled values. */
-  public static TestUsers chooseTestUser(List<SpendEnabled> spendEnabledFilter) {
+  public static TestUsers chooseTestUser(Set<SpendEnabled> spendEnabledFilter) {
     // filter the list of all test users to include only those that match one of the specified spend
     // enabled values
     List<TestUsers> testUsers =

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 /**
  * This enum lists the test users available for CLI tests. They have varying permissions on the WSM
  * spend profile. These permissions were configured manually, and are not part of the CLI test
- * harness.
+ * harness. See CONTRIBUTING.md for more details about the manual setup.
  *
  * <p>This class also includes a {@link #login(GlobalContext)} method specifically for testing. Most
  * CLI tests will start with a call to this method to login a test user.

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -1,0 +1,133 @@
+package harness;
+
+import bio.terra.cli.auth.AuthenticationManager;
+import bio.terra.cli.auth.GoogleCredentialUtils;
+import bio.terra.cli.context.GlobalContext;
+import bio.terra.cli.context.WorkspaceContext;
+import com.google.api.client.auth.oauth2.StoredCredential;
+import com.google.api.client.util.store.DataStore;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This enum lists the test users available for CLI tests. They have varying permissions on the WSM
+ * spend profile. These permissions were configured manually, and are not part of the CLI test
+ * harness.
+ *
+ * <p>This class also includes a {@link #login(GlobalContext)} method specifically for testing. Most
+ * CLI tests will start with a call to this method to login a test user.
+ */
+public enum TestUsers {
+  PENELOPE_TWILIGHTSHAMMER("Penelope.TwilightsHammer@test.firecloud.org", SpendEnabled.OWNER),
+  JOHN_WHITECLAW("John.Whiteclaw@test.firecloud.org", SpendEnabled.CLI_TEST_USERS_GROUP),
+  LILY_SHADOWMOON("Lily.Shadowmoon@test.firecloud.org", SpendEnabled.CLI_TEST_USERS_GROUP),
+  BROOKLYN_THUNDERLORD("Brooklyn.Thunderlord@test.firecloud.org", SpendEnabled.DIRECTLY),
+  NOAH_FROSTWOLF("Noah.Frostwolf@test.firecloud.org", SpendEnabled.DIRECTLY),
+  ETHAN_BONECHEWER("Ethan.Bonechewer@test.firecloud.org", SpendEnabled.NO);
+
+  public final String email;
+  public final SpendEnabled spendEnabled;
+
+  TestUsers(String email, SpendEnabled spendEnabled) {
+    this.email = email;
+    this.spendEnabled = spendEnabled;
+  }
+
+  /** This enum lists the different ways a user can be enabled on the WSM default spend profile. */
+  public enum SpendEnabled {
+    OWNER, // owner of the cli-test-users group and owner on the spend profile resource
+    NO, // not enabled
+    CLI_TEST_USERS_GROUP, // member of cli-test-users group, which is enabled on spend profile
+    DIRECTLY; // user of the spend profile resource
+  }
+
+  /**
+   * This method mimics the typical CLI login flow, in a way that is more useful for testing. It
+   * uses domain-wide delegation to populate test user credentials, instead of the usual Google
+   * Oauth login flow, which requires manual interaction with a browser.
+   */
+  public void login(GlobalContext globalContext) throws IOException {
+    // get a credential for the test-user SA
+    Path jsonKey = Path.of("rendered", "test-user-account.json");
+    if (!jsonKey.toFile().exists()) {
+      throw new FileNotFoundException(
+          "Test user SA key file for domain-wide delegation not found. Try re-running tools/render-config.sh. ("
+              + jsonKey.toAbsolutePath()
+              + ")");
+    }
+    GoogleCredentials serviceAccountCredential =
+        ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
+            .createScoped(AuthenticationManager.SCOPES);
+
+    // use the test-user SA to get a domain-wide delegated credential for the test user
+    GoogleCredentials delegatedUserCredential = serviceAccountCredential.createDelegated(email);
+    delegatedUserCredential.refreshIfExpired();
+
+    // use the domain-wide delegated credential to build a stored credential for the test user
+    StoredCredential dwdStoredCredential = new StoredCredential();
+    dwdStoredCredential.setAccessToken(delegatedUserCredential.getAccessToken().getTokenValue());
+    dwdStoredCredential.setExpirationTimeMilliseconds(
+        delegatedUserCredential.getAccessToken().getExpirationTime().getTime());
+
+    // update the credential store on disk
+    // set the single entry to the stored credential for the test user
+    DataStore<StoredCredential> dataStore = getCredentialStore();
+    dataStore.set(GoogleCredentialUtils.CREDENTIAL_STORE_KEY, dwdStoredCredential);
+
+    // unset the current user in the global context if already specified
+    globalContext.unsetCurrentTerraUser();
+
+    // do the login flow to populate the global context with the current user
+    new AuthenticationManager(globalContext, WorkspaceContext.readFromFile()).loginTerraUser();
+  }
+
+  /** Utility method to logout the current user. */
+  public void logout(GlobalContext globalContext) {
+    new AuthenticationManager(globalContext, WorkspaceContext.readFromFile()).logoutTerraUser();
+  }
+
+  /** Helper method that returns a pointer to the credential store on disk. */
+  public static DataStore<StoredCredential> getCredentialStore() throws IOException {
+    Path globalContextDir = GlobalContext.getGlobalContextDir();
+    FileDataStoreFactory dataStoreFactory = new FileDataStoreFactory(globalContextDir.toFile());
+    return dataStoreFactory.getDataStore(StoredCredential.DEFAULT_DATA_STORE_ID);
+  }
+
+  /** Randomly chooses a test user. */
+  public static TestUsers chooseTestUser() {
+    return chooseTestUser(Arrays.asList(SpendEnabled.values()));
+  }
+
+  /** Randomly chooses a test user with spend profile access. */
+  public static TestUsers chooseTestUserWithSpendAccess() {
+    return chooseTestUser(
+        Arrays.asList(
+            new SpendEnabled[] {SpendEnabled.CLI_TEST_USERS_GROUP, SpendEnabled.DIRECTLY}));
+  }
+
+  /** Randomly chooses a test user that matches one of the specified spend enabled values. */
+  public static TestUsers chooseTestUser(List<SpendEnabled> spendEnabledFilter) {
+    // filter the list of all test users to include only those that match one of the specified spend
+    // enabled values
+    List<TestUsers> testUsers =
+        Arrays.asList(TestUsers.values()).stream()
+            .filter(testUser -> spendEnabledFilter.contains(testUser.spendEnabled))
+            .collect(Collectors.toList());
+    if (testUsers.isEmpty()) {
+      throw new IllegalArgumentException("No test users match the specified spend enabled values");
+    }
+
+    // randomly reorder the list, so we can get a different user each time
+    Collections.shuffle(testUsers);
+    return testUsers.get(0);
+  }
+}

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -14,6 +14,7 @@ fi
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
 CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
+TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
 
 mkdir -p rendered
 
@@ -21,3 +22,8 @@ echo "Reading the CI service account key file from Vault"
 docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${CI_SA_VAULT_PATH} \
             | jq -r .data > rendered/ci-account.json
+
+echo "Reading the domain-wide delegated test users service account key file from Vault"
+docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json ${TEST_USER_SA_VAULT_PATH} \
+            | jq -r .data > rendered/test-user-account.json


### PR DESCRIPTION
- Implemented domain-wide delegation for CLI test uesrs.
  - Added the `TestUsers` class that lists the test users available for CLI tests and includes a `login` method. This `login` method mimics the typical CLI login flow in a way that is more useful for testing, because it doesn't require manual interaction with a browser.
  - Wrote two unit tests to check that
    - The domain-wide delegated credentials were getting populated in the global context correctly
    - All the test users are enabled in SAM.
  - Updated the `render-config.sh` script to also pull a firecloud SA for domain-wide delegation.
  - Added section to CONTRIBUTING.md with instructions for setting up test users on a new Terra environment.

- Made some small changes to the authentication code to support testing.
  - Populate the access token field on the `UserCredentials` object. The domain-wide delegated credentials I used for testing only have an access token, not a refresh token.
  - Check if the refresh token is populated before trying to refresh the `UserCredentials` on each command. This is strictly to handle the testing case.

- Cleaned up the authentication code to only store a single credential at a time.
  - I originally wrote this code with the intent of supporting multiple identity contexts at the same time (like `gcloud auth list`). Product needs have changed a lot since then and that's not looking likely anytime soon. So I removed all places where we could store >1 credential or user reference, because it makes the code simpler and testing more straightforward.
  - The single key for the credential store on disk is now hard-coded to `TERRA_USER` instead of generating a random string or using the user's email.

- Added a new `unitTest` Gradle task with two optional flags to control test behavior:
  - `./gradlew unitTest -i` to run the two existing tests.
  - `-PuseDefaultContextDir` causes the test to use the default global context directory, under `$HOME`. Not specifying the flag will default to using the `test-context` sub-directory of the Gradle build directory.
  - `-Pserver=verily-cli` causes the test to use the `verily-cli` server. Not specifying the flag will default to the `terra-dev` server.
