### PR TITLE
PF-757: Run tests nightly.

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -15,7 +15,6 @@ jobs:
         testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
       fail-fast: false
     runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'broadbot')"
     steps:
       - name: Checkout current code
         id: checkout_code

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,35 +1,18 @@
-name: Run tests against PRs (pre and post merge)
+name: Run tests nightly
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '0 5 * * *' # 5AM UTC = 12AM EST
+   # TODO: remove this before merging
   pull_request:
     branches:
       - '**'
 
 jobs:
-  lint-and-static-analysis:
-    runs-on: ubuntu-latest
-    if: "!contains( github.event.sender.login, 'broadbot')"
-    steps:
-      - name: Checkout current code
-        id: checkout_code
-        uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-      - name: Run linter
-        id: run_linter
-        run: |
-          ./gradlew spotlessCheck
-      - name: Run static analysis
-        id: run_static_analysis
-        run: |
-          ./gradlew spotbugsMain spotbugsTest
-  tests-against-source-code:
+  tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testTag: [ "unit", "integration" ]
+        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
       fail-fast: false
     runs-on: ubuntu-latest
     if: "!contains( github.event.sender.login, 'broadbot')"
@@ -72,14 +55,14 @@ jobs:
         id: run_tests
         run: |
           # runs against the default server: terra-dev
-          echo "Running tests with tag: ${{ matrix.testTag }}"
-          ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }}
+          echo "Running tests with options: ${{ matrix.testOptions }}"
+          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-and-context-${{ matrix.testTag }}
+          name: logs-and-context-[${{ matrix.testOptions }}]
           path: |
             build/test-context/.terra/logs/
             build/test-context/.terra/global-context.json

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -3,10 +3,6 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 5 * * *' # 5AM UTC = 12AM EST
-   # TODO: remove this pull_request section before merging. it's just for testing this GH action pre-merge
-  pull_request:
-    branches:
-      - '**'
 
 jobs:
   tests-against-source-code-and-latest-install:

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch: {}
   schedule:
     - cron: '0 5 * * *' # 5AM UTC = 12AM EST
-   # TODO: remove this before merging
+   # TODO: remove this pull_request section before merging. it's just for testing this GH action pre-merge
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - '**'
+   # TODO: uncomment this before merging
+#  pull_request:
+#    branches:
+#      - '**'
 
 jobs:
   lint-and-static-analysis:

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -4,10 +4,9 @@ on:
   push:
     branches:
       - main
-   # TODO: uncomment this before merging
-#  pull_request:
-#    branches:
-#      - '**'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   lint-and-static-analysis:

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -4,13 +4,5 @@ set -e
 
 terra status
 
-# delete any resources
-terra resources list --format=json > resources.json
-jq -c '.[]' resources.json | while read i; do
-  name=$(echo $i | jq -r '.metadata.name');
-  echo "deleting workspace resource $name"
-  terra resources delete --name=$name;
-done
-
 # delete the workspace
 terra workspace delete

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -65,6 +65,7 @@ terra nextflow config rnaseq-nf/main.nf -profile gls
 
 # And kick off the actual Nextflow workflow.
 
+# TODO: uncomment before merging
 #terra nextflow run rnaseq-nf/main.nf -profile gls
 
 # This will take about 10 minutes to complete. [Switch tabs] I started this workflow in a different workspace earlier and here is the resulting HTML report [show local webpage].

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -65,6 +65,6 @@ terra nextflow config rnaseq-nf/main.nf -profile gls
 
 # And kick off the actual Nextflow workflow.
 
-terra nextflow run rnaseq-nf/main.nf -profile gls
+#terra nextflow run rnaseq-nf/main.nf -profile gls
 
 # This will take about 10 minutes to complete. [Switch tabs] I started this workflow in a different workspace earlier and here is the resulting HTML report [show local webpage].

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -67,7 +67,6 @@ terra nextflow config rnaseq-nf/main.nf -profile gls
 
 # And kick off the actual Nextflow workflow.
 
-# TODO: uncomment before merging
-#terra nextflow run rnaseq-nf/main.nf -profile gls
+terra nextflow run rnaseq-nf/main.nf -profile gls
 
 # This will take about 10 minutes to complete. [Switch tabs] I started this workflow in a different workspace earlier and here is the resulting HTML report [show local webpage].

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -32,8 +32,10 @@ terra status
 # Bucket names must be globally unique, so use a random UUID with the dashes removed for the bucket name.
 # Terra resource names must only be unique within the workspace, so use a fixed string for the resource name.
 
-bucketName=$(uuidgen | sed -e 's/-//g')
-terra resources create gcs-bucket --name=terraclitesting --bucket-name=$bucketName
+resourceName="terraclitesting"
+bucketName=$(uuidgen | tr "[:upper:]" "[:lower:]" | sed -e 's/-//g')
+echo "resourceName: $resourceName, bucketName: $bucketName"
+terra resources create gcs-bucket --name=$resourceName --bucket-name=$bucketName
 terra resources list
 
 # I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].


### PR DESCRIPTION
- Added a new GitHub action to run tests nightly.
  - Runs unit tests in job 1.
  - Runs integration tests against an installation built from source code via `./gradlew installDist` in job 2.
  - Runs integration tests against an installation built from the latest GitHub release in job 3.
- Each test job uploads a GitHub action archive with the global context file and all log files generated during the test run.

- Two other fixes/changes:
  - Fixed a bug in the Nextflow integration test. It was fine on the Linux GH action runner, but on my Mac `uuidgen` produces uppercase letters, which are [not allowed](https://cloud.google.com/storage/docs/naming-buckets#requirements) for GCS bucket names.
  - Removed the integration test cleanup code that deleted all resources before deleting a workspace. WSM does this for us now, so it's no longer needed. We can just delete the workspace directly.