### PR TITLE
PF-825: Tests for referenced and controlled GCS bucket resources.

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -40,12 +40,14 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect this
-          # key to be stored in rendered/test-user-account.json
+          # regardless of how it was fetched, tests expect these
+          # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+          echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
+          DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
       - name: Run tests
         id: run_tests
         run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -62,12 +62,14 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect this
-          # key to be stored in rendered/test-user-account.json
+          # regardless of how it was fetched, tests expect these
+          # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+          echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
+          DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
       - name: Run tests
         id: run_tests
         run: |

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
@@ -7,7 +7,6 @@ import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.ManagedBy;
 import bio.terra.workspace.model.StewardshipType;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -21,7 +20,6 @@ import java.util.UUID;
  *
  * <p>See the {@link Resource} class for a resource's internal representation.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonDeserialize(builder = UFResource.Builder.class)
 public abstract class UFResource {
   public final UUID id;

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
@@ -3,7 +3,6 @@ package bio.terra.cli.serialization.userfacing.resources;
 import bio.terra.cli.businessobject.resources.AiNotebook;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.cli.utils.Printer;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.api.services.notebooks.v1.model.Instance;
@@ -16,7 +15,6 @@ import java.io.PrintStream;
  *
  * <p>See the {@link AiNotebook} class for a notebook's internal representation.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonDeserialize(builder = UFAiNotebook.Builder.class)
 public class UFAiNotebook extends UFResource {
   public final String projectId;

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
@@ -3,7 +3,6 @@ package bio.terra.cli.serialization.userfacing.resources;
 import bio.terra.cli.businessobject.resources.BqDataset;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.cli.utils.Printer;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -15,7 +14,6 @@ import java.io.PrintStream;
  *
  * <p>See the {@link BqDataset} class for a dataset's internal representation.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonDeserialize(builder = UFBqDataset.Builder.class)
 public class UFBqDataset extends UFResource {
   public final String projectId;

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFGcsBucket.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFGcsBucket.java
@@ -3,7 +3,6 @@ package bio.terra.cli.serialization.userfacing.resources;
 import bio.terra.cli.businessobject.resources.GcsBucket;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.cli.utils.Printer;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -15,7 +14,6 @@ import java.io.PrintStream;
  *
  * <p>See the {@link GcsBucket} class for a bucket's internal representation.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @JsonDeserialize(builder = UFGcsBucket.Builder.class)
 public class UFGcsBucket extends UFResource {
   public final String bucketName;

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -65,11 +65,16 @@ public class TestCommand {
     return objectMapper.readValue(cmd.stdOut, objectType);
   }
 
+  /** Helper method to run a command and check its exit code matches that specified. */
+  public static Result runCommandExpectExitCode(int exitCode, String... args) {
+    Result cmd = runCommand(args);
+    assertEquals(exitCode, cmd.exitCode, "exit code = " + exitCode);
+    return cmd;
+  }
+
   /** Helper method to run a command and check its exit code is 0=success. */
   public static Result runCommandExpectSuccess(String... args) {
-    Result cmd = runCommand(args);
-    assertEquals(0, cmd.exitCode, "exit code = success");
-    return cmd;
+    return runCommandExpectExitCode(0, args);
   }
 
   /**

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class TestCommand {
 
-  private static ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+  private static ObjectMapper objectMapper = new ObjectMapper();
 
   private TestCommand() {}
 
@@ -53,7 +53,10 @@ public class TestCommand {
     return new Result(exitCode, stdOutStr, stdErrStr);
   }
 
-  /** Helper method to run a command and check its exit code matches that specified. */
+  /**
+   * Helper method to run a command and check its exit code matches that specified. Returns the
+   * standard error string for validating an error message.
+   */
   public static String runCommandExpectExitCode(int exitCode, String... args) {
     Result cmd = runCommand(args);
     assertEquals(exitCode, cmd.exitCode, "exit code = " + exitCode);

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility methods for executing commands and reading their outputs during testing. This class is
@@ -71,24 +74,31 @@ public class TestCommand {
 
   /**
    * Helper method to run a command, check its exit code is 0=success, and read what's written to
-   * standard out into a Java object.
+   * standard out into a Java object. Adds `--format=json` to the argument list.
    */
   public static <T> T runAndParseCommandExpectSuccess(Class<T> objectType, String... args)
       throws JsonProcessingException {
-    Result cmd = runCommand(args);
+    Result cmd = runCommand(addFormatJsonArg(args));
     assertEquals(0, cmd.exitCode, "exit code = success");
     return cmd.readObjectFromStdOut(objectType);
   }
 
   /**
    * Helper method to run a command, check its exit code is 0=success, and read what's written to
-   * standard out into a Java object.
+   * standard out into a Java object. Adds `--format=json` to the argument list.
    */
   public static <T> T runAndParseCommandExpectSuccess(TypeReference<T> objectType, String... args)
       throws JsonProcessingException {
-    Result cmd = runCommand(args);
+    Result cmd = runCommand(addFormatJsonArg(args));
     assertEquals(0, cmd.exitCode, "exit code = success");
     return cmd.readObjectFromStdOut(objectType);
+  }
+
+  /** Add the `--format=json` argument to the end of the arguments list. */
+  private static String[] addFormatJsonArg(String... args) {
+    List<String> argsWithFormatJson = new ArrayList<>(Arrays.asList(args));
+    argsWithFormatJson.add("--format=json");
+    return argsWithFormatJson.toArray(new String[0]);
   }
 
   /** Helper class to return all outputs of a command: exit code, standard out, standard error. */

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -17,7 +17,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class TestCommand {
 
-  private static ObjectMapper objectMapper = new ObjectMapper();
+  private static ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
   private TestCommand() {}
 

--- a/src/test/java/harness/TestGCSBucketReferences.java
+++ b/src/test/java/harness/TestGCSBucketReferences.java
@@ -1,0 +1,98 @@
+package harness;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.Identity;
+import com.google.cloud.Policy;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageClass;
+import com.google.cloud.storage.StorageOptions;
+import com.google.cloud.storage.StorageRoles;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/** Utility methods for creating external GCS buckets for testing workspace references. */
+public class TestGCSBucketReferences {
+  public static final String gcpProjectId = "terra-cli-dev";
+
+  private static final String saKeyFile = "./rendered/ci-account.json";
+  private static final List<String> cloudPlatformScope =
+      Collections.unmodifiableList(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
+
+  /**
+   * Create a bucket in an external project. This is helpful for testing referenced GCS bucket
+   * resources.
+   */
+  public static Bucket createBucket() throws IOException {
+    String bucketName = UUID.randomUUID().toString();
+    StorageClass storageClass = StorageClass.STANDARD;
+    String location = "US";
+
+    Bucket bucket =
+        getStorageClient()
+            .create(
+                BucketInfo.newBuilder(bucketName)
+                    .setStorageClass(storageClass)
+                    .setLocation(location)
+                    .build());
+
+    System.out.println(
+        "Created bucket "
+            + bucket.getName()
+            + " in "
+            + bucket.getLocation()
+            + " with storage class "
+            + bucket.getStorageClass()
+            + " in project "
+            + gcpProjectId);
+    return bucket;
+  }
+
+  /**
+   * Delete a bucket in an external project. This is helpful for testing referenced GCS bucket
+   * resources.
+   */
+  public static void deleteBucket(Bucket bucket) throws IOException {
+    getStorageClient().delete(bucket.getName());
+  }
+
+  /** Grant a given user object viewer access to a bucket. */
+  public static void grantReadAccess(Bucket bucket, String email) throws IOException {
+    Storage storage = getStorageClient();
+    Policy currentPolicy = storage.getIamPolicy(bucket.getName());
+    Policy updatedPolicy =
+        storage.setIamPolicy(
+            bucket.getName(),
+            currentPolicy
+                .toBuilder()
+                // TODO (PF-717): revisit this once we're calling WSM endpoints for check-access
+                .addIdentity(StorageRoles.objectViewer(), Identity.user(email))
+                .addIdentity(StorageRoles.legacyBucketReader(), Identity.user(email))
+                .build());
+    getStorageClient().setIamPolicy(bucket.getName(), updatedPolicy);
+    try {
+      TimeUnit.SECONDS.sleep(20);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /** Helper method to build the GCS client object with the appropriate SA credentials. */
+  private static Storage getStorageClient() throws IOException {
+    GoogleCredentials saCredentials =
+        ServiceAccountCredentials.fromStream(new FileInputStream(saKeyFile))
+            .createScoped(cloudPlatformScope);
+    return StorageOptions.newBuilder()
+        .setProjectId(gcpProjectId)
+        .setCredentials(saCredentials)
+        .build()
+        .getService();
+  }
+}

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -58,22 +58,9 @@ public enum TestUsers {
    * @return global context object, populated with the user's credentials
    */
   public void login() throws IOException {
-    // get a credential for the test-user SA
-    Path jsonKey = Path.of("rendered", "test-user-account.json");
-    if (!jsonKey.toFile().exists()) {
-      throw new FileNotFoundException(
-          "Test user SA key file for domain-wide delegation not found. Try re-running tools/render-config.sh. ("
-              + jsonKey.toAbsolutePath()
-              + ")");
-    }
-    GoogleCredentials serviceAccountCredential =
-        ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
-            .createScoped(User.SCOPES);
-
-    // use the test-user SA to get a domain-wide delegated credential for the test user
+    // get domain-wide delegated credentials for this user
     System.out.println("Logging in test user: " + email);
-    GoogleCredentials delegatedUserCredential = serviceAccountCredential.createDelegated(email);
-    delegatedUserCredential.refreshIfExpired();
+    GoogleCredentials delegatedUserCredential = getCredentials();
 
     // use the domain-wide delegated credential to build a stored credential for the test user
     StoredCredential dwdStoredCredential = new StoredCredential();
@@ -91,6 +78,27 @@ public enum TestUsers {
 
     // do the login flow to populate the global context with the current user
     User.login();
+  }
+
+  /** Get domain-wide delegated Google credentials for this user. */
+  public GoogleCredentials getCredentials() throws IOException {
+    // get a credential for the test-user SA
+    Path jsonKey = Path.of("rendered", "test-user-account.json");
+    if (!jsonKey.toFile().exists()) {
+      throw new FileNotFoundException(
+          "Test user SA key file for domain-wide delegation not found. Try re-running tools/render-config.sh. ("
+              + jsonKey.toAbsolutePath()
+              + ")");
+    }
+    GoogleCredentials serviceAccountCredential =
+        ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
+            .createScoped(User.SCOPES);
+
+    // use the test-user SA to get a domain-wide delegated credential for the test user
+    System.out.println("Logging in test user: " + email);
+    GoogleCredentials delegatedUserCredential = serviceAccountCredential.createDelegated(email);
+    delegatedUserCredential.refreshIfExpired();
+    return delegatedUserCredential;
   }
 
   /** Helper method that returns a pointer to the credential store on disk. */

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
 
 /**
  * Base class for unit tests that only need a single workspace for all test methods. This makes the
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
  * we're not starting with a completely clean state each time, but that's easy to do just for
  * debugging a particular failure.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SingleWorkspaceUnit extends ClearContextUnit {
   protected static final TestUsers workspaceCreator = TestUsers.chooseTestUserWithSpendAccess();;
   private static UUID workspaceId;
@@ -24,7 +26,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
   }
 
   @BeforeAll
-  static void setupOnce() throws IOException {
+  protected void setupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 
@@ -32,13 +34,12 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
 
     // `terra workspace create --format=json`
     UFWorkspace createWorkspace =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "create", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
     workspaceId = createWorkspace.id;
   }
 
   @AfterAll
-  static void cleanupOnce() throws IOException {
+  protected void cleanupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -24,7 +24,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
   }
 
   @BeforeAll
-  protected static void setupOnce() throws IOException {
+  static void setupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 
@@ -38,7 +38,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
   }
 
   @AfterAll
-  protected static void cleanupOnce() throws IOException {
+  static void cleanupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -24,7 +24,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
   }
 
   @BeforeAll
-  static void setupOnce() throws IOException {
+  protected static void setupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 
@@ -38,7 +38,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
   }
 
   @AfterAll
-  static void cleanupOnce() throws IOException {
+  protected static void cleanupOnce() throws IOException {
     TestContext.clearGlobalContextDir();
     resetContext();
 

--- a/src/test/java/harness/utils/ExternalGCSBuckets.java
+++ b/src/test/java/harness/utils/ExternalGCSBuckets.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /** Utility methods for creating external GCS buckets for testing workspace references. */
 public class ExternalGCSBuckets {
@@ -90,11 +89,6 @@ public class ExternalGCSBuckets {
                 .addIdentity(StorageRoles.legacyBucketReader(), Identity.user(email))
                 .build());
     getStorageClient().setIamPolicy(bucket.getName(), updatedPolicy);
-    try {
-      TimeUnit.SECONDS.sleep(20);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
   }
 
   /** Helper method to build the GCS client object with SA credentials for an external project. */

--- a/src/test/java/harness/utils/ExternalGCSBuckets.java
+++ b/src/test/java/harness/utils/ExternalGCSBuckets.java
@@ -28,7 +28,8 @@ public class ExternalGCSBuckets {
 
   /**
    * Get a bucket. This is helpful for testing controlled GCS bucket resources. It allows tests to
-   * check metadata that is not stored in WSM, only in GCS.
+   * check metadata that is not stored in WSM, only in GCS. This method takes in the credentials to
+   * use because tests typically want to check metadata as the test user.
    */
   public static Bucket getBucket(String bucketName, GoogleCredentials credentials)
       throws IOException {
@@ -37,7 +38,7 @@ public class ExternalGCSBuckets {
 
   /**
    * Create a bucket in an external project. This is helpful for testing referenced GCS bucket
-   * resources.
+   * resources. This method uses SA credentials for an external project.
    */
   public static Bucket createBucket() throws IOException {
     String bucketName = UUID.randomUUID().toString();
@@ -66,13 +67,16 @@ public class ExternalGCSBuckets {
 
   /**
    * Delete a bucket in an external project. This is helpful for testing referenced GCS bucket
-   * resources.
+   * resources. This method uses SA credentials for an external project.
    */
   public static void deleteBucket(Bucket bucket) throws IOException {
     getStorageClient().delete(bucket.getName());
   }
 
-  /** Grant a given user object viewer access to a bucket. */
+  /**
+   * Grant a given user object viewer access to a bucket. This method uses SA credentials for an
+   * external project.
+   */
   public static void grantReadAccess(Bucket bucket, String email) throws IOException {
     Storage storage = getStorageClient();
     Policy currentPolicy = storage.getIamPolicy(bucket.getName());
@@ -93,7 +97,7 @@ public class ExternalGCSBuckets {
     }
   }
 
-  /** Helper method to build the GCS client object with the appropriate SA credentials. */
+  /** Helper method to build the GCS client object with SA credentials for an external project. */
   private static Storage getStorageClient() throws IOException {
     GoogleCredentials saCredentials =
         ServiceAccountCredentials.fromStream(new FileInputStream(saKeyFile))

--- a/src/test/java/harness/utils/ExternalGCSBuckets.java
+++ b/src/test/java/harness/utils/ExternalGCSBuckets.java
@@ -26,16 +26,6 @@ public class ExternalGCSBuckets {
       Collections.unmodifiableList(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
 
   /**
-   * Get a bucket. This is helpful for testing controlled GCS bucket resources. It allows tests to
-   * check metadata that is not stored in WSM, only in GCS. This method takes in the credentials to
-   * use because tests typically want to check metadata as the test user.
-   */
-  public static Bucket getBucket(String bucketName, GoogleCredentials credentials)
-      throws IOException {
-    return getStorageClient(credentials).get(bucketName);
-  }
-
-  /**
    * Create a bucket in an external project. This is helpful for testing referenced GCS bucket
    * resources. This method uses SA credentials for an external project.
    */
@@ -65,14 +55,6 @@ public class ExternalGCSBuckets {
   }
 
   /**
-   * Delete a bucket in an external project. This is helpful for testing referenced GCS bucket
-   * resources. This method uses SA credentials for an external project.
-   */
-  public static void deleteBucket(Bucket bucket) throws IOException {
-    getStorageClient().delete(bucket.getName());
-  }
-
-  /**
    * Grant a given user object viewer access to a bucket. This method uses SA credentials for an
    * external project.
    */
@@ -92,7 +74,7 @@ public class ExternalGCSBuckets {
   }
 
   /** Helper method to build the GCS client object with SA credentials for an external project. */
-  private static Storage getStorageClient() throws IOException {
+  public static Storage getStorageClient() throws IOException {
     GoogleCredentials saCredentials =
         ServiceAccountCredentials.fromStream(new FileInputStream(saKeyFile))
             .createScoped(cloudPlatformScope);
@@ -100,7 +82,7 @@ public class ExternalGCSBuckets {
   }
 
   /** Helper method to build the GCS client object with the given credentials. */
-  private static Storage getStorageClient(GoogleCredentials credentials) throws IOException {
+  public static Storage getStorageClient(GoogleCredentials credentials) throws IOException {
     return StorageOptions.newBuilder()
         .setProjectId(gcpProjectId)
         .setCredentials(credentials)

--- a/src/test/java/unit/AuthStatus.java
+++ b/src/test/java/unit/AuthStatus.java
@@ -28,8 +28,7 @@ public class AuthStatus extends ClearContextUnit {
 
     // `terra auth status --format=json`
     UFAuthStatus authStatus =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFAuthStatus.class, "auth", "status", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
 
     // check that it says logged in and includes the user & proxy emails
     assertThat(
@@ -48,8 +47,7 @@ public class AuthStatus extends ClearContextUnit {
   void authStatusWhenLoggedOut() throws IOException {
     // `terra auth status --format=json`
     UFAuthStatus authStatus =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFAuthStatus.class, "auth", "status", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
 
     // check that it says logged out and doesn't include user or proxy emails
     assertThat(
@@ -70,8 +68,7 @@ public class AuthStatus extends ClearContextUnit {
 
     // `terra auth status --format=json`
     UFAuthStatus authStatus =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFAuthStatus.class, "auth", "status", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
 
     // check that it says logged in
     assertTrue(authStatus.loggedIn, "auth status indicates user is logged in");
@@ -80,9 +77,7 @@ public class AuthStatus extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess("auth", "revoke");
 
     // `terra auth status --format=json`
-    authStatus =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFAuthStatus.class, "auth", "status", "--format=json");
+    authStatus = TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
 
     // check that it says logged out
     assertFalse(authStatus.loggedIn, "auth status indicates user is logged out");

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -45,8 +45,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
             "create",
             "gcs-bucket",
             "--name=" + name,
-            "--bucket-name=" + bucketName,
-            "--format=json");
+            "--bucket-name=" + bucketName);
 
     // check that the name and bucket name match
     assertEquals(name, createdBucket.name, "create output matches name");
@@ -55,12 +54,12 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // check that the bucket is in the list
     UFGcsBucket matchedResource = listOneBucketResourceWithName(name);
     assertEquals(name, matchedResource.name, "list output matches name");
-    assertEquals(bucketName, (matchedResource).bucketName, "list output matches bucket name");
+    assertEquals(bucketName, matchedResource.bucketName, "list output matches bucket name");
 
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "describe", "--name=" + name);
 
     // check that the name and bucket name match
     assertEquals(name, describeResource.name, "describe resource output matches name");
@@ -93,7 +92,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFGcsBucket deletedBucket =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "delete", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "delete", "--name=" + name);
 
     // check that the name and bucket name match
     assertEquals(name, deletedBucket.name, "delete output matches name");
@@ -126,18 +125,13 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resources resolve --name=$name --format=json`
     String resolved =
         TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resources", "resolve", "--name=" + name, "--format=json");
+            String.class, "resources", "resolve", "--name=" + name);
     assertEquals("gs://" + bucketName, resolved, "default resolve includes gs:// prefix");
 
     // `terra resources resolve --name=$name --exclude-bucket-prefix --format=json`
     String resolvedExcludePrefix =
         TestCommand.runAndParseCommandExpectSuccess(
-            String.class,
-            "resources",
-            "resolve",
-            "--name=" + name,
-            "--exclude-bucket-prefix",
-            "--format=json");
+            String.class, "resources", "resolve", "--name=" + name, "--exclude-bucket-prefix");
     assertEquals(
         bucketName, resolvedExcludePrefix, "exclude prefix resolve only includes bucket name");
 
@@ -209,8 +203,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
             "--email=" + workspaceCreator.email.toLowerCase(),
             "--iam-roles=" + iamRole,
             "--location=" + location,
-            "--storage=" + storage,
-            "--format=json");
+            "--storage=" + storage);
 
     // check that the properties match
     assertEquals(name, createdBucket.name, "create output matches name");
@@ -225,7 +218,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     Bucket createdBucketOnCloud =
-        ExternalGCSBuckets.getBucket(bucketName, workspaceCreator.getCredentials());
+        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentials()).get(bucketName);
     assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         location, createdBucketOnCloud.getLocation(), "bucket location matches create input");
@@ -237,7 +230,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "describe", "--name=" + name);
 
     // check that the properties match
     assertEquals(name, describeResource.name, "describe resource output matches name");
@@ -274,7 +267,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resources list --type=GCS_BUCKET --format=json`
     List<UFGcsBucket> listedResources =
         TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "resources", "list", "--type=GCS_BUCKET", "--format=json");
+            new TypeReference<>() {}, "resources", "list", "--type=GCS_BUCKET");
 
     // find the matching bucket in the list
     return listedResources.stream()

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -184,8 +184,9 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --cloning=$cloning
-    // --description=$description --format=json`
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --access=$access
+    // --cloning=$cloning --description=$description --email=$email --iam-roles=$iamRole
+    // --location=$location --storage=$storage --format=json`
     String name = "createWithAllOptionsExceptLifecycle";
     String bucketName = UUID.randomUUID().toString();
     AccessScope access = AccessScope.PRIVATE_ACCESS;

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -1,9 +1,14 @@
 package unit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import bio.terra.cli.serialization.userfacing.inputs.GcsStorageClass;
 import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
+import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.storage.Bucket;
 import harness.TestCommand;
@@ -11,67 +16,49 @@ import harness.baseclasses.SingleWorkspaceUnit;
 import harness.utils.ExternalGCSBuckets;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/** Tests for the `terra resources` commands that handle referenced GCS buckets. */
+/** Tests for the `terra resources` commands that handle controlled GCS buckets. */
 @Tag("unit")
-public class GcsBucketReferenced extends SingleWorkspaceUnit {
-
-  // external bucket to use for creating GCS bucket references in the workspace
-  private Bucket externalBucket;
-
-  @BeforeEach
-  @Override
-  protected void setupEachTime() throws IOException {
-    super.setupEachTime();
-    externalBucket = ExternalGCSBuckets.createBucket();
-    ExternalGCSBuckets.grantReadAccess(externalBucket, workspaceCreator.email);
-  }
-
-  @AfterEach
-  protected void cleanupEachTime() throws IOException {
-    ExternalGCSBuckets.deleteBucket(externalBucket);
-    externalBucket = null;
-  }
-
+public class GcsBucketControlled extends SingleWorkspaceUnit {
   @Test
-  @DisplayName("list and describe reflect adding a new referenced bucket")
-  void listDescribeReflectAdd() throws IOException {
+  @DisplayName("list and describe reflect creating a new controlled bucket")
+  void listDescribeReflectCreate() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
-    String name = "listDescribeReflectAdd";
-    UFGcsBucket addedBucket =
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "listDescribeReflectCreate";
+    String bucketName = UUID.randomUUID().toString();
+    UFGcsBucket createdBucket =
         TestCommand.runCommandExpectSuccess(
             UFGcsBucket.class,
             "resources",
-            "add-ref",
+            "create",
             "gcs-bucket",
             "--name=" + name,
-            "--bucket-name=" + externalBucket.getName(),
+            "--bucket-name=" + bucketName,
             "--format=json");
 
     // check that the name and bucket name match
-    assertEquals(name, addedBucket.name, "add ref output matches name");
-    assertEquals(
-        externalBucket.getName(), addedBucket.bucketName, "add ref output matches bucket name");
+    assertEquals(name, createdBucket.name, "create output matches name");
+    assertEquals(bucketName, createdBucket.bucketName, "create output matches bucket name");
 
-    // `terra resources list --type=GCS_BUCKET --stewardship=REFERENCED --format=json`
+    // `terra resources list --type=GCS_BUCKET --stewardship=CONTROLLED --format=json`
     List<UFGcsBucket> listedResources =
         TestCommand.runCommandExpectSuccess(
             new TypeReference<>() {},
             "resources",
             "list",
             "--type=GCS_BUCKET",
-            "--stewardship=REFERENCED",
+            "--stewardship=CONTROLLED",
             "--format=json");
 
     // check that the bucket is in the list
@@ -82,9 +69,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
     assertEquals(name, matchedResources.get(0).name, "list output matches name");
     assertEquals(
-        externalBucket.getName(),
-        (matchedResources.get(0)).bucketName,
-        "list output matches bucket name");
+        bucketName, (matchedResources.get(0)).bucketName, "list output matches bucket name");
 
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
@@ -94,30 +79,29 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // check that the name and bucket name match
     assertEquals(name, describeResource.name, "describe resource output matches name");
     assertEquals(
-        externalBucket.getName(),
-        describeResource.bucketName,
-        "describe resource output matches bucket name");
+        bucketName, describeResource.bucketName, "describe resource output matches bucket name");
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
   }
 
   @Test
-  @DisplayName("list reflects deleting a referenced bucket")
+  @DisplayName("list reflects deleting a controlled bucket")
   void listReflectsDelete() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "listReflectsDelete";
+    String bucketName = UUID.randomUUID().toString();
     TestCommand.runCommandExpectSuccess(
         "resources",
-        "add-ref",
+        "create",
         "gcs-bucket",
         "--name=" + name,
-        "--bucket-name=" + externalBucket.getName(),
+        "--bucket-name=" + bucketName,
         "--format=json");
 
     // `terra resources delete --name=$name --format=json`
@@ -127,8 +111,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
 
     // check that the name and bucket name match
     assertEquals(name, deletedBucket.name, "delete output matches name");
-    assertEquals(
-        externalBucket.getName(), deletedBucket.bucketName, "delete output matches bucket name");
+    assertEquals(bucketName, deletedBucket.bucketName, "delete output matches bucket name");
 
     // `terra resources list --type=GCS_BUCKET --stewardship=REFERENCED --format=json`
     List<UFGcsBucket> listedResources =
@@ -137,7 +120,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
             "resources",
             "list",
             "--type=GCS_BUCKET",
-            "--stewardship=REFERENCED",
+            "--stewardship=CONTROLLED",
             "--format=json");
 
     // check that the bucket is not in the list
@@ -149,29 +132,29 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
   }
 
   @Test
-  @DisplayName("resolve a referenced bucket")
+  @DisplayName("resolve a controlled bucket")
   void resolve() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "resolve";
+    String bucketName = UUID.randomUUID().toString();
     TestCommand.runCommandExpectSuccess(
         "resources",
-        "add-ref",
+        "create",
         "gcs-bucket",
         "--name=" + name,
-        "--bucket-name=" + externalBucket.getName(),
+        "--bucket-name=" + bucketName,
         "--format=json");
 
     // `terra resources resolve --name=$name --format=json`
     String resolved =
         TestCommand.runCommandExpectSuccess(
             String.class, "resources", "resolve", "--name=" + name, "--format=json");
-    assertEquals(
-        "gs://" + externalBucket.getName(), resolved, "default resolve includes gs:// prefix");
+    assertEquals("gs://" + bucketName, resolved, "default resolve includes gs:// prefix");
 
     // `terra resources resolve --name=$name --exclude-bucket-prefix --format=json`
     String resolvedExcludePrefix =
@@ -183,70 +166,105 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
             "--exclude-bucket-prefix",
             "--format=json");
     assertEquals(
-        externalBucket.getName(),
-        resolvedExcludePrefix,
-        "exclude prefix resolve only includes bucket name");
+        bucketName, resolvedExcludePrefix, "exclude prefix resolve only includes bucket name");
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
   }
 
   @Test
-  @DisplayName("check-access for a referenced bucket")
+  @DisplayName("check-access for a controlled bucket")
   void checkAccess() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "checkAccess";
+    String bucketName = UUID.randomUUID().toString();
     TestCommand.runCommandExpectSuccess(
         "resources",
-        "add-ref",
+        "create",
         "gcs-bucket",
         "--name=" + name,
-        "--bucket-name=" + externalBucket.getName(),
+        "--bucket-name=" + bucketName,
         "--format=json");
 
-    // `terra resources check-access --name=$name
-    TestCommand.runCommandExpectSuccess("resources", "check-access", "--name=" + name);
+    // `terra resources check-access --name=$name`
+    TestCommand.Result cmd =
+        TestCommand.runCommandExpectExitCode(1, "resources", "check-access", "--name=" + name);
+    assertThat(
+        "error message includes wrong stewardship type",
+        cmd.stdErr,
+        CoreMatchers.containsString("Checking access is intended for REFERENCED resources only"));
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
   }
 
   @Test
-  @DisplayName("add a referenced bucket, specifying all options except lifecycle")
-  void addWithAllOptionsExceptLifecycle() throws IOException {
+  @DisplayName("create a controlled bucket, specifying all options except lifecycle")
+  void createWithAllOptionsExceptLifecycle() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --cloning=$cloning
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --cloning=$cloning
     // --description=$description --format=json`
-    String name = "addWithAllOptionsExceptLifecycle";
+    String name = "createWithAllOptionsExceptLifecycle";
+    String bucketName = UUID.randomUUID().toString();
+    AccessScope access = AccessScope.PRIVATE_ACCESS;
     CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
-    String description = "add with all options except lifecycle";
-    UFGcsBucket addedBucket =
+    String description = "\"create with all options except lifecycle\"";
+    IamRole iamRole = IamRole.WRITER;
+    String location = "US";
+    GcsStorageClass storage = GcsStorageClass.NEARLINE;
+    UFGcsBucket createdBucket =
         TestCommand.runCommandExpectSuccess(
             UFGcsBucket.class,
             "resources",
-            "add-ref",
+            "create",
             "gcs-bucket",
             "--name=" + name,
-            "--bucket-name=" + externalBucket.getName(),
+            "--bucket-name=" + bucketName,
+            "--access=" + access,
             "--cloning=" + cloning,
             "--description=" + description,
+            "--email=" + workspaceCreator.email.toLowerCase(),
+            "--iam-roles=" + iamRole,
+            "--location=" + location,
+            "--storage=" + storage,
             "--format=json");
 
     // check that the properties match
-    assertEquals(name, addedBucket.name, "add ref output matches name");
+    assertEquals(name, createdBucket.name, "create output matches name");
+    assertEquals(bucketName, createdBucket.bucketName, "create output matches bucket name");
+    assertEquals(access, createdBucket.accessScope, "create output matches access");
+    assertEquals(cloning, createdBucket.cloningInstructions, "create output matches cloning");
+    assertEquals(description, createdBucket.description, "create output matches description");
     assertEquals(
-        externalBucket.getName(), addedBucket.bucketName, "add ref output matches bucket name");
-    assertEquals(cloning, addedBucket.cloningInstructions, "add ref output matches cloning");
-    assertEquals(description, addedBucket.description, "add ref output matches description");
+        workspaceCreator.email.toLowerCase(),
+        createdBucket.privateUserName.toLowerCase(),
+        "create output matches private user name");
+    // TODO (PF-616): check the private user roles once WSM returns them
+    //    assertEquals(
+    //        1, createdBucket.privateUserRoles.size(), "create output matches private user roles
+    // size");
+    //    assertEquals(
+    //        iamRole, createdBucket.privateUserRoles.get(0), "create output matches private user
+    // roles");
+
+    Bucket createdBucketOnCloud =
+        ExternalGCSBuckets.getBucket(bucketName, workspaceCreator.getCredentials());
+    assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
+    assertEquals(
+        location, createdBucketOnCloud.getLocation(), "bucket location matches create input");
+    assertEquals(
+        storage.toString(),
+        createdBucketOnCloud.getStorageClass().toString(),
+        "bucket storage class matches create input");
 
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
@@ -256,11 +274,23 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // check that the name and bucket name match
     assertEquals(name, describeResource.name, "describe resource output matches name");
     assertEquals(
-        externalBucket.getName(),
-        describeResource.bucketName,
-        "describe resource output matches bucket name");
+        bucketName, describeResource.bucketName, "describe resource output matches bucket name");
+    assertEquals(access, describeResource.accessScope, "describe output matches access");
     assertEquals(cloning, describeResource.cloningInstructions, "describe output matches cloning");
     assertEquals(description, describeResource.description, "describe output matches description");
+    assertEquals(
+        workspaceCreator.email.toLowerCase(),
+        describeResource.privateUserName.toLowerCase(),
+        "describe output matches private user name");
+    // TODO (PF-616): check the private user roles once WSM returns them
+    //    assertEquals(
+    //        1,
+    //        describeResource.privateUserRoles.size(),
+    //        "describe output matches private user roles size");
+    //    assertEquals(
+    //        iamRole,
+    //        describeResource.privateUserRoles.get(0),
+    //        "describe output matches private user roles");
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -12,8 +12,8 @@ import harness.baseclasses.SingleWorkspaceUnit;
 import harness.utils.ExternalGCSBuckets;
 import java.io.IOException;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -25,17 +25,19 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
   // external bucket to use for creating GCS bucket references in the workspace
   private Bucket externalBucket;
 
-  @BeforeEach
+  @BeforeAll
   @Override
-  protected void setupEachTime() throws IOException {
-    super.setupEachTime();
+  protected void setupOnce() throws IOException {
+    super.setupOnce();
     externalBucket = ExternalGCSBuckets.createBucket();
     ExternalGCSBuckets.grantReadAccess(externalBucket, workspaceCreator.email);
   }
 
-  @AfterEach
-  protected void cleanupEachTime() throws IOException {
-    ExternalGCSBuckets.deleteBucket(externalBucket);
+  @AfterAll
+  @Override
+  protected void cleanupOnce() throws IOException {
+    super.cleanupOnce();
+    ExternalGCSBuckets.getStorageClient().delete(externalBucket.getName());
     externalBucket = null;
   }
 
@@ -56,8 +58,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
             "add-ref",
             "gcs-bucket",
             "--name=" + name,
-            "--bucket-name=" + externalBucket.getName(),
-            "--format=json");
+            "--bucket-name=" + externalBucket.getName());
 
     // check that the name and bucket name match
     assertEquals(name, addedBucket.name, "add ref output matches name");
@@ -68,12 +69,12 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     UFGcsBucket matchedResource = listOneBucketResourceWithName(name);
     assertEquals(name, matchedResource.name, "list output matches name");
     assertEquals(
-        externalBucket.getName(), (matchedResource).bucketName, "list output matches bucket name");
+        externalBucket.getName(), matchedResource.bucketName, "list output matches bucket name");
 
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "describe", "--name=" + name);
 
     // check that the name and bucket name match
     assertEquals(name, describeResource.name, "describe resource output matches name");
@@ -107,7 +108,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFGcsBucket deletedBucket =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "delete", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "delete", "--name=" + name);
 
     // check that the name and bucket name match
     assertEquals(name, deletedBucket.name, "delete output matches name");
@@ -140,19 +141,14 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resources resolve --name=$name --format=json`
     String resolved =
         TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resources", "resolve", "--name=" + name, "--format=json");
+            String.class, "resources", "resolve", "--name=" + name);
     assertEquals(
         "gs://" + externalBucket.getName(), resolved, "default resolve includes gs:// prefix");
 
     // `terra resources resolve --name=$name --exclude-bucket-prefix --format=json`
     String resolvedExcludePrefix =
         TestCommand.runAndParseCommandExpectSuccess(
-            String.class,
-            "resources",
-            "resolve",
-            "--name=" + name,
-            "--exclude-bucket-prefix",
-            "--format=json");
+            String.class, "resources", "resolve", "--name=" + name, "--exclude-bucket-prefix");
     assertEquals(
         externalBucket.getName(),
         resolvedExcludePrefix,
@@ -188,8 +184,8 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
   }
 
   @Test
-  @DisplayName("add a referenced bucket, specifying all options except lifecycle")
-  void addWithAllOptionsExceptLifecycle() throws IOException {
+  @DisplayName("add a referenced bucket, specifying all options")
+  void addWithAllOptions() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
@@ -209,8 +205,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
             "--name=" + name,
             "--bucket-name=" + externalBucket.getName(),
             "--cloning=" + cloning,
-            "--description=" + description,
-            "--format=json");
+            "--description=" + description);
 
     // check that the properties match
     assertEquals(name, addedBucket.name, "add ref output matches name");
@@ -222,7 +217,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resources describe --name=$name --format=json`
     UFGcsBucket describeResource =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+            UFGcsBucket.class, "resources", "describe", "--name=" + name);
 
     // check that the properties match
     assertEquals(name, describeResource.name, "describe resource output matches name");

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -1,0 +1,268 @@
+package unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.cloud.storage.Bucket;
+import harness.TestCommand;
+import harness.TestGCSBucketReferences;
+import harness.baseclasses.SingleWorkspaceUnit;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra resources` commands that handle referenced GCS buckets. */
+@Tag("unit")
+public class GcsBucketReferenced extends SingleWorkspaceUnit {
+
+  // external bucket to use for creating GCS bucket references in the workspace
+  private Bucket externalBucket;
+
+  @BeforeEach
+  @Override
+  protected void setupEachTime() throws IOException {
+    super.setupEachTime();
+    externalBucket = TestGCSBucketReferences.createBucket();
+    TestGCSBucketReferences.grantReadAccess(externalBucket, workspaceCreator.email);
+  }
+
+  @AfterEach
+  protected void cleanupEachTime() throws IOException {
+    TestGCSBucketReferences.deleteBucket(externalBucket);
+    externalBucket = null;
+  }
+
+  @Test
+  @DisplayName("list and describe reflect adding a new referenced bucket")
+  void listDescribeReflectAdd() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "listDescribeReflectAdd";
+    UFGcsBucket addedBucket =
+        TestCommand.runCommandExpectSuccess(
+            UFGcsBucket.class,
+            "resources",
+            "add-ref",
+            "gcs-bucket",
+            "--name=" + name,
+            "--bucket-name=" + externalBucket.getName(),
+            "--format=json");
+
+    // check that the name and bucket name match
+    assertEquals(name, addedBucket.name, "add ref output matches name");
+    assertEquals(
+        externalBucket.getName(), addedBucket.bucketName, "add ref output matches bucket name");
+
+    // `terra resources list --type=GCS_BUCKET --stewardship=REFERENCED --format=json`
+    List<UFGcsBucket> listedResources =
+        TestCommand.runCommandExpectSuccess(
+            new TypeReference<>() {},
+            "resources",
+            "list",
+            "--type=GCS_BUCKET",
+            "--stewardship=REFERENCED",
+            "--format=json");
+
+    // check that the bucket is in the list
+    List<UFGcsBucket> matchedResources =
+        listedResources.stream()
+            .filter(resource -> resource.name.equals(name))
+            .collect(Collectors.toList());
+    assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
+    assertEquals(name, matchedResources.get(0).name, "list output matches name");
+    assertEquals(
+        externalBucket.getName(),
+        (matchedResources.get(0)).bucketName,
+        "list output matches bucket name");
+
+    // `terra resources describe --name=$name --format=json`
+    UFGcsBucket describeResource =
+        TestCommand.runCommandExpectSuccess(
+            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+
+    // check that the name and bucket name match
+    assertEquals(name, describeResource.name, "describe resource output matches name");
+    assertEquals(
+        externalBucket.getName(),
+        describeResource.bucketName,
+        "describe resource output matches bucket name");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("list reflects deleting a referenced bucket")
+  void listReflectsDelete() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "listReflectsDelete";
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "add-ref",
+        "gcs-bucket",
+        "--name=" + name,
+        "--bucket-name=" + externalBucket.getName(),
+        "--format=json");
+
+    // `terra resources delete --name=$name --format=json`
+    UFGcsBucket deletedBucket =
+        TestCommand.runCommandExpectSuccess(
+            UFGcsBucket.class, "resources", "delete", "--name=" + name, "--format=json");
+
+    // check that the name and bucket name match
+    assertEquals(name, deletedBucket.name, "delete output matches name");
+    assertEquals(
+        externalBucket.getName(), deletedBucket.bucketName, "delete output matches bucket name");
+
+    // `terra resources list --type=GCS_BUCKET --stewardship=REFERENCED --format=json`
+    List<UFGcsBucket> listedResources =
+        TestCommand.runCommandExpectSuccess(
+            new TypeReference<>() {},
+            "resources",
+            "list",
+            "--type=GCS_BUCKET",
+            "--stewardship=REFERENCED",
+            "--format=json");
+
+    // check that the bucket is not in the list
+    List<UFGcsBucket> matchedResources =
+        listedResources.stream()
+            .filter(resource -> resource.name.equals(name))
+            .collect(Collectors.toList());
+    assertEquals(0, matchedResources.size(), "no resource found with this name");
+  }
+
+  @Test
+  @DisplayName("resolve a referenced bucket")
+  void resolve() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "resolve";
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "add-ref",
+        "gcs-bucket",
+        "--name=" + name,
+        "--bucket-name=" + externalBucket.getName(),
+        "--format=json");
+
+    // `terra resources resolve --name=$name --format=json`
+    String resolved =
+        TestCommand.runCommandExpectSuccess(
+            String.class, "resources", "resolve", "--name=" + name, "--format=json");
+    assertEquals(
+        "gs://" + externalBucket.getName(), resolved, "default resolve includes gs:// prefix");
+
+    // `terra resources resolve --name=$name --exclude-bucket-prefix --format=json`
+    String resolvedExcludePrefix =
+        TestCommand.runCommandExpectSuccess(
+            String.class,
+            "resources",
+            "resolve",
+            "--name=" + name,
+            "--exclude-bucket-prefix",
+            "--format=json");
+    assertEquals(
+        externalBucket.getName(),
+        resolvedExcludePrefix,
+        "exclude prefix resolve only includes bucket name");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("check-access for a referenced bucket")
+  void checkAccess() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "checkAccess";
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "add-ref",
+        "gcs-bucket",
+        "--name=" + name,
+        "--bucket-name=" + externalBucket.getName(),
+        "--format=json");
+
+    // `terra resources check-access --name=$name
+    TestCommand.runCommandExpectSuccess("resources", "check-access", "--name=" + name);
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("add a referenced bucket, specifying all options except lifecycle")
+  void addWithAllOptionsExceptLifecycle() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --cloning=$cloning
+    // --description=$description --format=json`
+    String name = "addWithAllOptionsExceptLifecycle";
+    CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
+    String description = "add with all options except lifecycle";
+    UFGcsBucket addedBucket =
+        TestCommand.runCommandExpectSuccess(
+            UFGcsBucket.class,
+            "resources",
+            "add-ref",
+            "gcs-bucket",
+            "--name=" + name,
+            "--bucket-name=" + externalBucket.getName(),
+            "--cloning=" + cloning,
+            "--description=" + description,
+            "--format=json");
+
+    // check that the properties match
+    assertEquals(name, addedBucket.name, "add ref output matches name");
+    assertEquals(
+        externalBucket.getName(), addedBucket.bucketName, "add ref output matches bucket name");
+    assertEquals(cloning, addedBucket.cloningInstructions, "add ref output matches cloning");
+    assertEquals(description, addedBucket.description, "add ref output matches description");
+
+    // `terra resources describe --name=$name --format=json`
+    UFGcsBucket describeResource =
+        TestCommand.runCommandExpectSuccess(
+            UFGcsBucket.class, "resources", "describe", "--name=" + name, "--format=json");
+
+    // check that the name and bucket name match
+    assertEquals(name, describeResource.name, "describe resource output matches name");
+    assertEquals(
+        externalBucket.getName(),
+        describeResource.bucketName,
+        "describe resource output matches bucket name");
+    assertEquals(cloning, describeResource.cloningInstructions, "describe output matches cloning");
+    assertEquals(description, describeResource.description, "describe output matches description");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+}

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -251,8 +251,7 @@ public class Workspace extends ClearContextUnit {
     testUser.login();
 
     // `terra workspace create`
-    TestCommand.Result cmd = TestCommand.runCommand("workspace", "create");
-    assertEquals(2, cmd.exitCode, "exit code = system exception");
+    TestCommand.Result cmd = TestCommand.runCommandExpectExitCode(2, "workspace", "create");
     assertThat(
         "error message includes spend profile unauthorized",
         cmd.stdErr,

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -34,8 +34,7 @@ public class Workspace extends ClearContextUnit {
 
     // `terra workspace create --format=json`
     UFWorkspace createWorkspace =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "create", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
 
     // check the created workspace has an id and a google project
     assertNotNull(createWorkspace.id, "create workspace returned a workspace id");
@@ -46,8 +45,7 @@ public class Workspace extends ClearContextUnit {
         equalToIgnoringCase(testUser.email));
 
     // `terra status --format=json`
-    UFStatus status =
-        TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status", "--format=json");
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
 
     // check the current status reflects the new workspace
     assertThat(
@@ -83,13 +81,11 @@ public class Workspace extends ClearContextUnit {
 
     // `terra workspace create --format=json`
     UFWorkspace createWorkspace =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "create", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
 
     // `terra workspace delete --format=json`
     UFWorkspace deleteWorkspace =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "delete", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "delete");
 
     // check the deleted workspace matches the created workspace
     assertEquals(createWorkspace.id, deleteWorkspace.id, "deleted workspace id matches created");
@@ -99,8 +95,7 @@ public class Workspace extends ClearContextUnit {
         "deleted workspace gcp project matches created");
 
     // `terra status --format=json`
-    UFStatus status =
-        TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status", "--format=json");
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
 
     // check the current status reflects the deleted workspace
     assertNull(status.workspace, "status has no workspace after delete");
@@ -125,7 +120,6 @@ public class Workspace extends ClearContextUnit {
             UFWorkspace.class,
             "workspace",
             "create",
-            "--format=json",
             "--name=" + name,
             "--description=" + description);
 
@@ -144,8 +138,7 @@ public class Workspace extends ClearContextUnit {
         "--description=" + newDescription);
 
     // `terra status --format=json`
-    UFStatus status =
-        TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status", "--format=json");
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
 
     // check the current status reflects the update
     assertEquals(newName, status.workspace.name, "status matches updated workspace name");
@@ -178,23 +171,20 @@ public class Workspace extends ClearContextUnit {
 
     // `terra workspace create --format=json` (workspace 1)
     UFWorkspace createWorkspace1 =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "create", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
 
     // `terra workspace create --format=json` (workspace 2)
     UFWorkspace createWorkspace2 =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "create", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
 
     // set current workspace = workspace 1
     UFWorkspace setWorkspace1 =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + createWorkspace1.id, "--format=json");
+            UFWorkspace.class, "workspace", "set", "--id=" + createWorkspace1.id);
     assertEquals(createWorkspace1.id, setWorkspace1.id, "set returned the expected workspace (1)");
 
     // `terra status --format=json`
-    UFStatus status =
-        TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status", "--format=json");
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
 
     // check the current status reflects the workspace set
     assertEquals(createWorkspace1.id, status.workspace.id, "status matches set workspace id (1)");
@@ -202,11 +192,11 @@ public class Workspace extends ClearContextUnit {
     // set current workspace = workspace 2
     UFWorkspace setWorkspace2 =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + createWorkspace2.id, "--format=json");
+            UFWorkspace.class, "workspace", "set", "--id=" + createWorkspace2.id);
     assertEquals(createWorkspace2.id, setWorkspace2.id, "set returned the expected workspace (2)");
 
     // `terra status --format=json`
-    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status", "--format=json");
+    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
 
     // check the current status reflects the workspace set
     assertEquals(createWorkspace2.id, status.workspace.id, "status matches set workspace id (2)");
@@ -244,8 +234,7 @@ public class Workspace extends ClearContextUnit {
       throws JsonProcessingException {
     // `terra workspace list --format=json`
     List<UFWorkspace> listWorkspaces =
-        TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "workspace", "list", "--format=json");
+        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "workspace", "list");
 
     return listWorkspaces.stream()
         .filter(workspace -> workspace.id.equals(workspaceId))

--- a/src/test/java/unit/WorkspaceUser.java
+++ b/src/test/java/unit/WorkspaceUser.java
@@ -33,7 +33,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
     // `terra workspace list-users --format=json`
     List<UFWorkspaceUser> listWorkspaceUsers =
         TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "workspace", "list-users", "--format=json");
+            new TypeReference<>() {}, "workspace", "list-users");
 
     for (UFWorkspaceUser user : listWorkspaceUsers) {
       if (user.email.equalsIgnoreCase(workspaceCreator.email)) {
@@ -78,8 +78,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
             "workspace",
             "add-user",
             "--email=" + testUser.email,
-            "--role=READER",
-            "--format=json");
+            "--role=READER");
 
     // check that the user has the READER role
     assertTrue(addUserReader.roles.contains(IamRole.READER), "reader role returned by add-user");
@@ -94,8 +93,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
             "workspace",
             "add-user",
             "--email=" + testUser.email,
-            "--role=WRITER",
-            "--format=json");
+            "--role=WRITER");
 
     // check that the user has both the READER and WRITER roles
     assertTrue(
@@ -163,7 +161,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
     // `terra workspace list-users --format=json`
     List<UFWorkspaceUser> listWorkspaceUsers =
         TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "workspace", "list-users", "--format=json");
+            new TypeReference<>() {}, "workspace", "list-users");
 
     // find the user in the list
     return listWorkspaceUsers.stream()


### PR DESCRIPTION
- Added tests for referenced and controlled GCS bucket resources.
- The referenced GCS bucket tests generate buckets in an external project using a SA. This project is currently set to `terra-cli-dev`, but should be changed in a future ticket to use different hard-coded project + SA that is generated by Terraform (PF-829).
- Removed some Jackson annotations in the `UFResource` classes so that we don't include the `@class` property in the user-facing command output.