### PR TITLE
PF-798: Fix and tests for pass through app commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,3 +602,6 @@ The CLI sets the process exit code as follows.
 - 1 = User-actionable error (e.g. missing parameter, workspace not defined in the current context)
 - 2 = System or internal error (e.g. error making a request to a Terra service)
 - 3 = Unexpected error (e.g. null pointer exception)
+
+App exit codes will be passed through to the caller. e.g. If `gcloud --malformedOption` returns exit code `2`, then
+`terra gcloud --malformedOption` will also return exit code `2`.

--- a/src/main/java/bio/terra/cli/apps/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/CommandRunner.java
@@ -72,7 +72,12 @@ public abstract class CommandRunner {
     envVars.putAll(terraEnvVars);
 
     // call the sub-class implementation of running a tool command
-    runToolCommandImpl(wrapCommandInSetupCleanup(command), envVars);
+    int exitCode = runToolCommandImpl(wrapCommandInSetupCleanup(command), envVars);
+
+    // if the command is not successful, then pass the exit code out to the CLI caller
+    if (exitCode != 0) {
+      throw new PassthroughException(exitCode);
+    }
   }
 
   /**
@@ -88,10 +93,9 @@ public abstract class CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
-   * @throws PassthroughException if the command returns a non-zero exit code
+   * @return process exit code
    */
-  protected abstract void runToolCommandImpl(String command, Map<String, String> envVars)
-      throws PassthroughException;
+  protected abstract int runToolCommandImpl(String command, Map<String, String> envVars);
 
   /**
    * Build a map of Terra references to use in setting environment variables when running commands.

--- a/src/main/java/bio/terra/cli/apps/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/CommandRunner.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.apps;
 
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.exception.PassthroughException;
 import bio.terra.cli.exception.SystemException;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +51,7 @@ public abstract class CommandRunner {
    * @param envVars a mapping of environment variable names to values
    * @throws SystemException if a Terra environment variable overlaps or conflicts with one passed
    *     into this method
+   * @throws PassthroughException if the command returns a non-zero exit code
    */
   public void runToolCommand(List<String> command, Map<String, String> envVars) {
     for (String commandToken : command) {
@@ -86,8 +88,10 @@ public abstract class CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
+   * @throws PassthroughException if the command returns a non-zero exit code
    */
-  protected abstract void runToolCommandImpl(String command, Map<String, String> envVars);
+  protected abstract void runToolCommandImpl(String command, Map<String, String> envVars)
+      throws PassthroughException;
 
   /**
    * Build a map of Terra references to use in setting environment variables when running commands.

--- a/src/main/java/bio/terra/cli/apps/DockerCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerCommandRunner.java
@@ -2,6 +2,7 @@ package bio.terra.cli.apps;
 
 import bio.terra.cli.apps.utils.DockerClientWrapper;
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.exception.PassthroughException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -52,8 +53,10 @@ public class DockerCommandRunner extends CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
+   * @throws PassthroughException if the command returns a non-zero exit code
    */
-  protected void runToolCommandImpl(String command, Map<String, String> envVars) {
+  protected void runToolCommandImpl(String command, Map<String, String> envVars)
+      throws PassthroughException {
     // set the path to the pet SA key file, which may be different on the container vs the host
     envVars.put("GOOGLE_APPLICATION_CREDENTIALS", getPetSaKeyFileOnContainer().toString());
 
@@ -79,8 +82,17 @@ public class DockerCommandRunner extends CommandRunner {
     Integer statusCode = dockerClientWrapper.waitForContainerToExit();
     logger.debug("docker run status code: {}", statusCode);
 
+    // get the process exit code
+    Long exitCode = dockerClientWrapper.getProcessExitCode();
+    logger.debug("docker inspect exit code: {}", exitCode);
+
     // delete the container
     dockerClientWrapper.deleteContainer();
+
+    // if the command is not successful, then pass the exit code out to the CLI caller
+    if (exitCode != 0) {
+      throw new PassthroughException(exitCode.intValue());
+    }
   }
 
   /**

--- a/src/main/java/bio/terra/cli/apps/DockerCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/DockerCommandRunner.java
@@ -53,9 +53,9 @@ public class DockerCommandRunner extends CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
-   * @throws PassthroughException if the command returns a non-zero exit code
+   * @return process exit code
    */
-  protected void runToolCommandImpl(String command, Map<String, String> envVars)
+  protected int runToolCommandImpl(String command, Map<String, String> envVars)
       throws PassthroughException {
     // set the path to the pet SA key file, which may be different on the container vs the host
     envVars.put("GOOGLE_APPLICATION_CREDENTIALS", getPetSaKeyFileOnContainer().toString());
@@ -89,10 +89,7 @@ public class DockerCommandRunner extends CommandRunner {
     // delete the container
     dockerClientWrapper.deleteContainer();
 
-    // if the command is not successful, then pass the exit code out to the CLI caller
-    if (exitCode != 0) {
-      throw new PassthroughException(exitCode.intValue());
-    }
+    return exitCode.intValue();
   }
 
   /**

--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -48,9 +48,9 @@ public class LocalProcessCommandRunner extends CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
-   * @throws PassthroughException if the command returns a non-zero exit code
+   * @return process exit code
    */
-  protected void runToolCommandImpl(String command, Map<String, String> envVars)
+  protected int runToolCommandImpl(String command, Map<String, String> envVars)
       throws PassthroughException {
     List<String> processCommand = new ArrayList<>();
     processCommand.add("bash");
@@ -71,9 +71,6 @@ public class LocalProcessCommandRunner extends CommandRunner {
     int exitCode = localProcessLauncher.waitForTerminate();
     logger.debug("local process exit code: {}", exitCode);
 
-    // if the command is not successful, then pass the exit code out to the CLI caller
-    if (exitCode != 0) {
-      throw new PassthroughException(exitCode);
-    }
+    return exitCode;
   }
 }

--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -2,6 +2,7 @@ package bio.terra.cli.apps;
 
 import bio.terra.cli.apps.utils.LocalProcessLauncher;
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.exception.PassthroughException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,8 +48,10 @@ public class LocalProcessCommandRunner extends CommandRunner {
    *
    * @param command the full string of command and arguments to execute
    * @param envVars a mapping of environment variable names to values
+   * @throws PassthroughException if the command returns a non-zero exit code
    */
-  protected void runToolCommandImpl(String command, Map<String, String> envVars) {
+  protected void runToolCommandImpl(String command, Map<String, String> envVars)
+      throws PassthroughException {
     List<String> processCommand = new ArrayList<>();
     processCommand.add("bash");
     processCommand.add("-c");
@@ -67,5 +70,10 @@ public class LocalProcessCommandRunner extends CommandRunner {
     // block until the child process exits
     int exitCode = localProcessLauncher.waitForTerminate();
     logger.debug("local process exit code: {}", exitCode);
+
+    // if the command is not successful, then pass the exit code out to the CLI caller
+    if (exitCode != 0) {
+      throw new PassthroughException(exitCode);
+    }
   }
 }

--- a/src/main/java/bio/terra/cli/apps/utils/DockerClientWrapper.java
+++ b/src/main/java/bio/terra/cli/apps/utils/DockerClientWrapper.java
@@ -6,6 +6,7 @@ import bio.terra.cli.utils.Printer;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.WaitContainerResultCallback;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
@@ -148,6 +149,12 @@ public class DockerClientWrapper {
     }
   }
 
+  /** Inspect the container state and return the exit code. */
+  public Long getProcessExitCode() {
+    InspectContainerResponse container = dockerClient.inspectContainerCmd(containerId).exec();
+    return container.getState().getExitCodeLong();
+  }
+
   /** Read the Docker container logs and write them to standard out. */
   public void streamLogsForContainer() {
     try {
@@ -188,9 +195,9 @@ public class DockerClientWrapper {
     @Override
     public void onNext(Frame frame) {
       String logStr = new String(frame.getPayload(), StandardCharsets.UTF_8);
-      PrintStream err = Printer.getErr();
-      err.print(logStr);
-      err.flush();
+      PrintStream out = Printer.getOut();
+      out.print(logStr);
+      out.flush();
 
       if (buildSingleStringOutput) {
         log.append(logStr);

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -11,6 +11,7 @@ import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.utils.Printer;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -161,8 +162,8 @@ public class Main implements Runnable {
         exitCode = SYSTEM_EXIT_CODE;
         printPointerToLogFile = true;
       } else if (ex instanceof PassthroughException) {
-        errorMessage = ex.getMessage() == null ? "" : ex.getMessage();
-        formattedErrorMessage = cmd.getColorScheme().text(errorMessage);
+        errorMessage = Optional.ofNullable(ex.getMessage()).orElse("");
+        formattedErrorMessage = cmd.getColorScheme().errorText(errorMessage);
         exitCode = ((PassthroughException) ex).getExitCode();
         printPointerToLogFile = false;
       } else {

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -5,6 +5,7 @@ import bio.terra.cli.command.app.passthrough.Bq;
 import bio.terra.cli.command.app.passthrough.Gcloud;
 import bio.terra.cli.command.app.passthrough.Gsutil;
 import bio.terra.cli.command.app.passthrough.Nextflow;
+import bio.terra.cli.exception.PassthroughException;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.utils.Printer;
@@ -159,6 +160,11 @@ public class Main implements Runnable {
             systemAndUnexpectedErrorStyle.errorText("[ERROR] ").concat(errorMessage);
         exitCode = SYSTEM_EXIT_CODE;
         printPointerToLogFile = true;
+      } else if (ex instanceof PassthroughException) {
+        errorMessage = ex.getMessage() == null ? "" : ex.getMessage();
+        formattedErrorMessage = cmd.getColorScheme().text(errorMessage);
+        exitCode = ((PassthroughException) ex).getExitCode();
+        printPointerToLogFile = false;
       } else {
         errorMessage =
             "An unexpected error occurred in "

--- a/src/main/java/bio/terra/cli/exception/PassthroughException.java
+++ b/src/main/java/bio/terra/cli/exception/PassthroughException.java
@@ -1,0 +1,40 @@
+package bio.terra.cli.exception;
+
+/**
+ * Custom exception class for exceptions thrown by apps.
+ *
+ * <p>Throwing a PassthroughException will
+ *
+ * <p>-print information about the cause and point users to the log file for more information
+ *
+ * <p>-use a normal font when printing to the terminal (e.g. same as other app output).
+ */
+public class PassthroughException extends RuntimeException {
+  private int exitCode;
+
+  /**
+   * Constructs an exception with the given exit code. The cause is set to null.
+   *
+   * @param exitCode exit code returned by the app, to be passed through as the CLI exit code
+   */
+  public PassthroughException(int exitCode) {
+    super();
+    this.exitCode = exitCode;
+  }
+
+  /**
+   * Constructs an exception with the given exit code and message. The cause is set to null.
+   *
+   * @param exitCode exit code returned by the app, to be passed through as the CLI exit code
+   * @param message description of error that may help with debugging
+   */
+  public PassthroughException(int exitCode, String message) {
+    super(message);
+    this.exitCode = exitCode;
+  }
+
+  /** Get the exit code returned by the app, to be passed through as the CLI exit code. */
+  public int getExitCode() {
+    return exitCode;
+  }
+}

--- a/src/main/java/bio/terra/cli/exception/PassthroughException.java
+++ b/src/main/java/bio/terra/cli/exception/PassthroughException.java
@@ -5,7 +5,7 @@ package bio.terra.cli.exception;
  *
  * <p>Throwing a PassthroughException will
  *
- * <p>-print information about the cause and point users to the log file for more information
+ * <p>-print any message
  *
  * <p>-use a normal font when printing to the terminal (e.g. same as other app output).
  */

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -176,7 +176,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra nextflow run hello`
+    // `terra nextflow -version`
     TestCommand.Result cmd = TestCommand.runCommand("nextflow", "-version");
     assertTrue(cmd.stdOut.contains("http://nextflow.io"), "nextflow version ran successfully");
   }

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -1,0 +1,207 @@
+package unit;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
+import com.fasterxml.jackson.core.type.TypeReference;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import harness.TestCommand;
+import harness.baseclasses.SingleWorkspaceUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static harness.utils.ExternalBQDatasets.randomDatasetId;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the `terra app` commands and the pass-through apps: `terra gcloud`, `terra gsutil`,
+ * `terra bq`, `terra nextflow`.
+ */
+@Tag("unit")
+public class PassthroughApps extends SingleWorkspaceUnit {
+  @Test
+  @DisplayName("app list returns all pass-through apps")
+  void appList() throws IOException {
+    // `terra app list --format=json`
+    List<String> appList =
+        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "app", "list");
+
+    // check that all pass-through apps are returned
+    assertTrue(appList.containsAll(Arrays.asList("gcloud", "gsutil", "bq", "nextflow")));
+  }
+
+  @Test
+  @DisplayName("env vars include workspace cloud project and pet SA key file")
+  @SuppressFBWarnings(
+      value = "NP_NULL_ON_SOME_PATH",
+      justification =
+          "Pet SA key file in the Context must be populated if the earlier login() call succeeded.")
+  void workspaceEnvVars() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    UFWorkspace workspace =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra app execute echo \$GOOGLE_APPLICATION_CREDENTIALS`
+    TestCommand.Result cmd =
+        TestCommand.runCommand("app", "execute", "echo", "$GOOGLE_APPLICATION_CREDENTIALS");
+
+    // check that GOOGLE_APPLICATION_CREDENTIALS = path to pet SA key file
+    assertTrue(
+        cmd.stdOut.contains(Context.getPetSaKeyFile().getFileName().toString()),
+        "GOOGLE_APPLICATION_CREDENTIALS set to pet SA key file");
+
+    // `terra app execute echo \$GOOGLE_APPLICATION_CREDENTIALS`
+    cmd = TestCommand.runCommand("app", "execute", "echo", "$GOOGLE_CLOUD_PROJECT");
+
+    // check that GOOGLE_CLOUD_PROJECT = workspace project
+    assertTrue(
+        cmd.stdOut.contains(workspace.googleProjectId),
+        "GOOGLE_CLOUD_PROJECT set to workspace project");
+  }
+
+  @Test
+  @DisplayName("env vars include a resolved workspace resource")
+  void resourceEnvVars() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "resourceEnvVars";
+    String bucketName = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources", "create", "gcs-bucket", "--name=" + name, "--bucket-name=" + bucketName);
+
+    // `terra app execute echo \$TERRA_$name`
+    TestCommand.Result cmd = TestCommand.runCommand("app", "execute", "echo", "$TERRA_" + name);
+
+    // check that TERRA_$name = resolved bucket name
+    assertTrue(
+        cmd.stdOut.contains("gs://" + bucketName),
+        "TERRA_$resourceName set to resolved bucket path");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("gcloud is configured with the workspace project and pet SA key")
+  void gcloudConfigured() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    UFWorkspace workspace =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra gcloud config get-value project`
+    TestCommand.Result cmd = TestCommand.runCommand("gcloud", "config", "get-value", "project");
+    assertTrue(
+        cmd.stdOut.contains(workspace.googleProjectId), "gcloud project = workspace project");
+
+    // `terra gcloud config get-value account`
+    cmd = TestCommand.runCommand("gcloud", "config", "get-value", "account");
+    assertTrue(
+        cmd.stdOut.contains(Context.requireUser().getPetSACredentials().getClientEmail()),
+        "gcloud account = pet SA email");
+  }
+
+  @Test
+  @DisplayName("gsutil bucket size = 0")
+  void gsutilBucketSize() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name = "gsutilBucketSize";
+    String bucketName = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources", "create", "gcs-bucket", "--name=" + name, "--bucket-name=" + bucketName);
+
+    // `terra gsutil du -s \$TERRA_$name`
+    TestCommand.Result cmd = TestCommand.runCommand("gsutil", "du", "-s", "$TERRA_" + name);
+    assertTrue(
+        cmd.stdOut.contains("0            gs://" + bucketName), "gsutil says bucket size = 0");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("bq show dataset metadata")
+  void bqShow() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
+    String name = "bqShow";
+    String datasetId = randomDatasetId();
+    UFBqDataset dataset =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFBqDataset.class,
+            "resources",
+            "create",
+            "bq-dataset",
+            "--name=" + name,
+            "--dataset-id=" + datasetId);
+
+    // `terra bq show --format=prettyjson [project id]:[dataset id]`
+    TestCommand.Result cmd = TestCommand.runCommand("bq", "show", "--format=prettyjson", datasetId);
+    assertTrue(
+        cmd.stdOut.contains("\"id\": \"" + dataset.projectId + ":" + dataset.datasetId + "\""),
+        "bq show includes the dataset id");
+
+    // `terra resources delete --name=$name`
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("check nextflow version")
+  void nextflowVersion() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra nextflow run hello`
+    TestCommand.Result cmd = TestCommand.runCommand("nextflow", "-version");
+    assertTrue(cmd.stdOut.contains("http://nextflow.io"), "nextflow version ran successfully");
+  }
+
+  @Test
+  @DisplayName("exit code is passed through to CLI caller")
+  void exitCodePassedThrough() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra gcloud -version`
+    // this is another malformed command, should be --version
+    TestCommand.runCommandExpectExitCode(2, "gcloud", "-version");
+
+    // `terra gcloud --version`
+    // this is the correct version of the command
+    TestCommand.Result cmd = TestCommand.runCommand("gcloud", "--version");
+    assertTrue(cmd.stdOut.contains("Google Cloud SDK"), "gcloud version ran successfully");
+
+    // `terra app execute exit 123`
+    // this just returns an arbitrary exit code (similar to doing (exit 123); echo "$?" in a
+    // terminal)
+    TestCommand.runCommandExpectExitCode(123, "app", "execute", "exit", "123");
+  }
+}

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -1,6 +1,7 @@
 package unit;
 
 import static harness.utils.ExternalBQDatasets.randomDatasetId;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cli.businessobject.Context;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -54,17 +56,19 @@ public class PassthroughApps extends SingleWorkspaceUnit {
         TestCommand.runCommand("app", "execute", "echo", "$GOOGLE_APPLICATION_CREDENTIALS");
 
     // check that GOOGLE_APPLICATION_CREDENTIALS = path to pet SA key file
-    assertTrue(
-        cmd.stdOut.contains(Context.getPetSaKeyFile().getFileName().toString()),
-        "GOOGLE_APPLICATION_CREDENTIALS set to pet SA key file");
+    assertThat(
+        "GOOGLE_APPLICATION_CREDENTIALS set to pet SA key file",
+        cmd.stdOut,
+        CoreMatchers.containsString(Context.getPetSaKeyFile().getFileName().toString()));
 
     // `terra app execute echo \$GOOGLE_APPLICATION_CREDENTIALS`
     cmd = TestCommand.runCommand("app", "execute", "echo", "$GOOGLE_CLOUD_PROJECT");
 
     // check that GOOGLE_CLOUD_PROJECT = workspace project
-    assertTrue(
-        cmd.stdOut.contains(workspace.googleProjectId),
-        "GOOGLE_CLOUD_PROJECT set to workspace project");
+    assertThat(
+        "GOOGLE_CLOUD_PROJECT set to workspace project",
+        cmd.stdOut,
+        CoreMatchers.containsString(workspace.googleProjectId));
   }
 
   @Test
@@ -85,9 +89,10 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     TestCommand.Result cmd = TestCommand.runCommand("app", "execute", "echo", "$TERRA_" + name);
 
     // check that TERRA_$name = resolved bucket name
-    assertTrue(
-        cmd.stdOut.contains("gs://" + bucketName),
-        "TERRA_$resourceName set to resolved bucket path");
+    assertThat(
+        "TERRA_$resourceName set to resolved bucket path",
+        cmd.stdOut,
+        CoreMatchers.containsString("gs://" + bucketName));
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
@@ -105,14 +110,17 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
     // `terra gcloud config get-value project`
     TestCommand.Result cmd = TestCommand.runCommand("gcloud", "config", "get-value", "project");
-    assertTrue(
-        cmd.stdOut.contains(workspace.googleProjectId), "gcloud project = workspace project");
+    assertThat(
+        "gcloud project = workspace project",
+        cmd.stdOut,
+        CoreMatchers.containsString(workspace.googleProjectId));
 
     // `terra gcloud config get-value account`
     cmd = TestCommand.runCommand("gcloud", "config", "get-value", "account");
-    assertTrue(
-        cmd.stdOut.contains(Context.requireUser().getPetSACredentials().getClientEmail()),
-        "gcloud account = pet SA email");
+    assertThat(
+        "gcloud account = pet SA email",
+        cmd.stdOut,
+        CoreMatchers.containsString(Context.requireUser().getPetSACredentials().getClientEmail()));
   }
 
   @Test
@@ -132,7 +140,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     // `terra gsutil du -s \$TERRA_$name`
     TestCommand.Result cmd = TestCommand.runCommand("gsutil", "du", "-s", "$TERRA_" + name);
     assertTrue(
-        cmd.stdOut.contains("0            gs://" + bucketName), "gsutil says bucket size = 0");
+        cmd.stdOut.matches("(?s).*0\\s+gs://" + bucketName + ".*"), "gsutil says bucket size = 0");
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
@@ -160,9 +168,11 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
     // `terra bq show --format=prettyjson [project id]:[dataset id]`
     TestCommand.Result cmd = TestCommand.runCommand("bq", "show", "--format=prettyjson", datasetId);
-    assertTrue(
-        cmd.stdOut.contains("\"id\": \"" + dataset.projectId + ":" + dataset.datasetId + "\""),
-        "bq show includes the dataset id");
+    assertThat(
+        "bq show includes the dataset id",
+        cmd.stdOut,
+        CoreMatchers.containsString(
+            "\"id\": \"" + dataset.projectId + ":" + dataset.datasetId + "\""));
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
@@ -178,7 +188,10 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
     // `terra nextflow -version`
     TestCommand.Result cmd = TestCommand.runCommand("nextflow", "-version");
-    assertTrue(cmd.stdOut.contains("http://nextflow.io"), "nextflow version ran successfully");
+    assertThat(
+        "nextflow version ran successfully",
+        cmd.stdOut,
+        CoreMatchers.containsString("http://nextflow.io"));
   }
 
   @Test
@@ -196,7 +209,10 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     // `terra gcloud --version`
     // this is the correct version of the command
     TestCommand.Result cmd = TestCommand.runCommand("gcloud", "--version");
-    assertTrue(cmd.stdOut.contains("Google Cloud SDK"), "gcloud version ran successfully");
+    assertThat(
+        "gcloud version ran successfully",
+        cmd.stdOut,
+        CoreMatchers.containsString("Google Cloud SDK"));
 
     // `terra app execute exit 123`
     // this just returns an arbitrary exit code (similar to doing (exit 123); echo "$?" in a

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -1,5 +1,8 @@
 package unit;
 
+import static harness.utils.ExternalBQDatasets.randomDatasetId;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
@@ -7,17 +10,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-
-import static harness.utils.ExternalBQDatasets.randomDatasetId;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the `terra app` commands and the pass-through apps: `terra gcloud`, `terra gsutil`,


### PR DESCRIPTION
Pass-through apps are third-party tools that users can call in the context of a workspace by prefixing it with `terra`. e.g.
`terra nextflow run ...`, `terra gsutil ls ...`

- Fixes:
  - Output from pass-through apps now prints to standard out. Previously it was printing to standard error.
  - The process exit code is now passed through to the CLI caller. Previously it was swallowed and the CLI always returned 0 = success.
- Added unit tests.