### PR TITLE
[no ticket] fix set server command in install script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -42,7 +42,7 @@ docker pull $defaultDockerImage
 
 echo "-- Setting the server to its current value, to pull any changes"
 currentServer=$(./terra config get-value server)
-./terra config set server $currentServer
+./terra config set server --name=$currentServer
 
 echo "--  Install complete"
 echo "You can add the ./terra executable to your \$PATH"


### PR DESCRIPTION
This is causing some errors in the notebooks post startup script where the CLI install doesn't finish with a successful error code (even though the CLI is actually basically set up by the time it errors here).

This breaks backwards compatibility for installing some past version where the set server didn't use `--name`.