### PR TITLE
PF-513: Add retries to WSM calls.

### DIFF
--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -307,8 +307,7 @@ public class HttpUtils {
       // information to propagate (this delay seems to happen on inviting a new user -- sometimes it
       // takes several seconds for WSM to recognize a newly invited user in SAM. not sure why)
       return callWithRetries(
-          makeRequest,
-          (ex2) -> isOneTimeError.test(ex2) || handleOneTimeErrorIsRetryable.test(ex2));
+          makeRequest, (ex2) -> isOneTimeError.test(ex2) || makeRequestIsRetryable.test(ex2));
     }
   }
 


### PR DESCRIPTION
- Add retries for WSM calls and include more retryable status code for SAM calls.
- Both now retry 500, 502, 503, 504 (so all the 5xx except 501 not implemented, 505 http version not supported).
- Also fixed a bug where adding a user to a SAM group failed with a bad request if the user is not already registered. Changed to invite the user if they're not found, and then add them to the group.