### PR TITLE
PF-497: `--workspace` flag to override current workspace.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +203,7 @@ public class Context {
 
   public static Optional<Workspace> getWorkspace() {
     if (useOverrideWorkspace) {
-      return Optional.of(overrideWorkspace);
+      return Optional.ofNullable(overrideWorkspace);
     } else {
       return Optional.ofNullable(currentWorkspace);
     }
@@ -225,7 +226,8 @@ public class Context {
     }
   }
 
-  public static void useOverrideWorkspace() {
+  public static void useOverrideWorkspace(UUID id) {
     useOverrideWorkspace = true;
+    Workspace.load(id);
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -24,6 +24,12 @@ public class Context {
   private static User currentUser;
   private static Workspace currentWorkspace;
 
+  // functions as the current workspace for this command execution only
+  // unlike the other parts of the current context, this property is not persisted to disk
+  private static Workspace overrideWorkspace;
+  // true if the current command is using an override workspace
+  private static boolean useOverrideWorkspace;
+
   // env var name to optionally override where the context is persisted on disk
   private static final String CONTEXT_DIR_OVERRIDE_NAME = "TERRA_CONTEXT_PARENT_DIR";
 
@@ -61,6 +67,8 @@ public class Context {
       currentUser = null;
       currentWorkspace = null;
     }
+    overrideWorkspace = null;
+    useOverrideWorkspace = false;
   }
 
   /**
@@ -193,7 +201,11 @@ public class Context {
   }
 
   public static Optional<Workspace> getWorkspace() {
-    return Optional.ofNullable(currentWorkspace);
+    if (useOverrideWorkspace) {
+      return Optional.of(overrideWorkspace);
+    } else {
+      return Optional.ofNullable(currentWorkspace);
+    }
   }
 
   public static Workspace requireWorkspace() {
@@ -205,7 +217,15 @@ public class Context {
   }
 
   public static void setWorkspace(Workspace workspace) {
-    currentWorkspace = workspace;
-    synchronizeToDisk();
+    if (useOverrideWorkspace) {
+      overrideWorkspace = workspace;
+    } else {
+      currentWorkspace = workspace;
+      synchronizeToDisk();
+    }
+  }
+
+  public static void useOverrideWorkspace() {
+    useOverrideWorkspace = true;
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -181,7 +181,7 @@ public class Workspace {
   }
 
   /** Populate the list of resources for this workspace. Does not sync to disk. */
-  public void populateResources() {
+  private void populateResources() {
     List<ResourceDescription> wsmObjects =
         new WorkspaceManagerService()
             .enumerateAllResources(id, Context.getConfig().getResourcesCacheSize());

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -103,11 +103,11 @@ public class Workspace {
     // convert the WSM object to a CLI object
     Workspace workspace = new Workspace(loadedWorkspace);
 
+    // fetch the list of resources in this workspace
+    workspace.populateResources();
+
     // update the global context with the current workspace
     Context.setWorkspace(workspace);
-
-    // fetch the list of resources in this workspace
-    workspace.listResourcesAndSync();
 
     // fetch the pet SA credentials for the user + this workspace
     // do this here so we have them stored locally before the user tries to run an app in the
@@ -180,8 +180,8 @@ public class Workspace {
         () -> new UserActionableException("Resource not found: " + name));
   }
 
-  /** Fetch the list of resources for the current workspace. Sync the cached list of resources. */
-  public List<Resource> listResourcesAndSync() {
+  /** Populate the list of resources for this workspace. Does not sync to disk. */
+  public void populateResources() {
     List<ResourceDescription> wsmObjects =
         new WorkspaceManagerService()
             .enumerateAllResources(id, Context.getConfig().getResourcesCacheSize());
@@ -189,6 +189,14 @@ public class Workspace {
         wsmObjects.stream().map(Resource::deserializeFromWsm).collect(Collectors.toList());
 
     this.resources = resources;
+  }
+
+  /**
+   * Fetch the list of resources for the current workspace. Sync the cached list of resources to
+   * disk.
+   */
+  public List<Resource> listResourcesAndSync() {
+    populateResources();
     Context.synchronizeToDisk();
     return resources;
   }

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command;
 import bio.terra.cli.command.workspace.AddUser;
 import bio.terra.cli.command.workspace.Create;
 import bio.terra.cli.command.workspace.Delete;
+import bio.terra.cli.command.workspace.Describe;
 import bio.terra.cli.command.workspace.List;
 import bio.terra.cli.command.workspace.ListUsers;
 import bio.terra.cli.command.workspace.RemoveUser;
@@ -22,6 +23,7 @@ import picocli.CommandLine.Command;
       Create.class,
       Set.class,
       Delete.class,
+      Describe.class,
       Update.class,
       ListUsers.class,
       AddUser.class,

--- a/src/main/java/bio/terra/cli/command/app/Execute.java
+++ b/src/main/java/bio/terra/cli/command/app/Execute.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.app;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import java.util.List;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -13,6 +14,8 @@ import picocli.CommandLine.Command;
         "[FOR DEBUG] Execute a command in the application container for the Terra workspace, with no setup.")
 public class Execute extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+
   @CommandLine.Parameters(
       index = "0",
       paramLabel = "command",
@@ -23,6 +26,7 @@ public class Execute extends BaseCommand {
   /** Pass the command through to the CLI Docker image. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Context.getConfig().getCommandRunnerOption().getRunner().runToolCommand(command);
   }
 }

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Bq.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Bq.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.app.passthrough;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine;
@@ -11,11 +12,13 @@ import picocli.CommandLine.Command;
 @Command(name = "bq", description = "Call bq in the Terra workspace.")
 public class Bq extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Unmatched private List<String> command = new ArrayList<>();
 
   /** Pass the command through to the CLI Docker image. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // no need for any special setup or teardown logic since bq is already initialized when the
     // container starts
     command.add(0, "bq");

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Gcloud.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Gcloud.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.app.passthrough;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine;
@@ -11,11 +12,13 @@ import picocli.CommandLine.Command;
 @Command(name = "gcloud", description = "Call gcloud in the Terra workspace.")
 public class Gcloud extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Unmatched private List<String> command = new ArrayList<>();
 
   /** Pass the command through to the CLI Docker image. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // no need for any special setup or teardown logic since gcloud is already initialized when the
     // container starts
     command.add(0, "gcloud");

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Gsutil.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Gsutil.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.app.passthrough;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import java.util.ArrayList;
 import java.util.List;
 import picocli.CommandLine;
@@ -11,11 +12,13 @@ import picocli.CommandLine.Command;
 @Command(name = "gsutil", description = "Call gsutil in the Terra workspace.")
 public class Gsutil extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Unmatched private List<String> command = new ArrayList<>();
 
   /** Pass the command through to the CLI Docker image. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // no need for any special setup or teardown logic since gsutil is already initialized when the
     // container starts
     command.add(0, "gsutil");

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.app.passthrough;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,11 +14,13 @@ import picocli.CommandLine.Command;
 @Command(name = "nextflow", description = "Call nextflow in the Terra workspace.")
 public class Nextflow extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Unmatched private List<String> command = new ArrayList<>();
 
   /** Pass the command through to the CLI Docker image. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     command.add(0, "nextflow");
     Map<String, String> envVars = new HashMap<>();
     envVars.put("NXF_MODE", "google");

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.notebooks;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.NotebookInstance;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.service.GoogleAiNotebooks;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import picocli.CommandLine;
@@ -15,9 +16,11 @@ import picocli.CommandLine;
 public class Start extends BaseCommand {
 
   @CommandLine.Mixin NotebookInstance instanceOption;
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     InstanceName instanceName = instanceOption.toInstanceName();
     GoogleAiNotebooks notebooks = new GoogleAiNotebooks(Context.requireUser().getUserCredentials());
     notebooks.start(instanceName);

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.notebooks;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.NotebookInstance;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.service.GoogleAiNotebooks;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import picocli.CommandLine;
@@ -15,9 +16,11 @@ import picocli.CommandLine;
 public class Stop extends BaseCommand {
 
   @CommandLine.Mixin NotebookInstance instanceOption;
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     InstanceName instanceName = instanceOption.toInstanceName();
     GoogleAiNotebooks notebooks = new GoogleAiNotebooks(Context.requireUser().getUserCredentials());
     notebooks.stop(instanceName);

--- a/src/main/java/bio/terra/cli/command/resources/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/resources/CheckAccess.java
@@ -6,6 +6,7 @@ import bio.terra.cli.businessobject.User;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra resources check-access" command. */
@@ -15,6 +16,7 @@ import picocli.CommandLine;
 public class CheckAccess extends BaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /**
@@ -22,6 +24,7 @@ public class CheckAccess extends BaseCommand {
    */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     boolean userHasAccess = resource.checkAccess(Resource.CheckAccessCredentials.USER);
     boolean proxyGroupHasAccess = resource.checkAccess(Resource.CheckAccessCredentials.PET_SA);

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -5,6 +5,7 @@ import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import picocli.CommandLine;
 
@@ -13,11 +14,13 @@ import picocli.CommandLine;
 public class Delete extends BaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Delete a resource from the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     resource.delete();
     formatOption.printReturnValue(resource.serializeToCommand(), Delete::printText);

--- a/src/main/java/bio/terra/cli/command/resources/Describe.java
+++ b/src/main/java/bio/terra/cli/command/resources/Describe.java
@@ -5,6 +5,7 @@ import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import picocli.CommandLine;
 
@@ -13,11 +14,13 @@ import picocli.CommandLine;
 public class Describe extends BaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Describe a resource. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     formatOption.printReturnValue(resource.serializeToCommand(), UFResource::print);
   }

--- a/src/main/java/bio/terra/cli/command/resources/List.java
+++ b/src/main/java/bio/terra/cli/command/resources/List.java
@@ -4,6 +4,7 @@ import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.workspace.model.StewardshipType;
 import java.util.stream.Collectors;
@@ -22,11 +23,13 @@ public class List extends BaseCommand {
       description = "Filter on a particular resource type: ${COMPLETION-CANDIDATES}")
   private Resource.Type type;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** List the resources in the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     java.util.List<UFResource> resources =
         Context.requireWorkspace().listResourcesAndSync().stream()
             .filter(

--- a/src/main/java/bio/terra/cli/command/resources/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resources/Resolve.java
@@ -7,6 +7,7 @@ import bio.terra.cli.businessobject.resources.GcsBucket;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -27,11 +28,13 @@ public class Resolve extends BaseCommand {
           "[For BIG_QUERY_DATASET] Cloud id format: FULL_PATH=[project id].[dataset id], DATASET_ID_ONLY=[dataset id], PROJECT_ID_ONLY=[project id]")
   private BqDataset.ResolveOptions bqPathFormat = BqDataset.ResolveOptions.FULL_PATH;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Resolve a resource in the workspace to its cloud identifier. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
 
     String cloudId;

--- a/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resources.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.CreateResource;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateBqDataset;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateResource;
 import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
@@ -23,11 +24,13 @@ public class BqDataset extends BaseCommand {
   @CommandLine.Option(names = "--dataset-id", required = true, description = "Big Query dataset id")
   private String bigQueryDatasetId;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add a referenced Big Query dataset to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateUpdateResource.Builder createResourceParams =
         createResourceOptions.populateMetadataFields().stewardshipType(StewardshipType.REFERENCED);

--- a/src/main/java/bio/terra/cli/command/resources/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/addref/GcsBucket.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resources.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.CreateResource;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateGcsBucket;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateResource;
 import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
@@ -24,11 +25,13 @@ public class GcsBucket extends BaseCommand {
           "Name of the GCS bucket, without the prefix. (e.g. 'my-bucket', not 'gs://my-bucket')")
   private String bucketName;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add a referenced GCS bucket to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateUpdateResource.Builder createResourceParams =
         createResourceOptions.populateMetadataFields().stewardshipType(StewardshipType.REFERENCED);

--- a/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
@@ -5,6 +5,7 @@ import bio.terra.cli.businessobject.User;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.CreateResource;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateAiNotebook;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateResource;
 import bio.terra.cli.serialization.userfacing.resources.UFAiNotebook;
@@ -223,11 +224,13 @@ public class AiNotebook extends BaseCommand {
     String type;
   }
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add a controlled AI Notebook instance to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     // build the resource object to create. force the resource to be private
     CreateUpdateResource.Builder createResourceParams =
         createResourceOptions

--- a/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resources.create;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.CreateControlledResource;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateBqDataset;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateResource;
 import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
@@ -25,11 +26,13 @@ public class BqDataset extends BaseCommand {
       description = "Dataset location (https://cloud.google.com/storage/docs/locations)")
   private String location;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add a controlled Big Query dataset to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     createControlledResourceOptions.validateAccessOptions();
 
     // build the resource object to create

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resources.create;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.CreateControlledResource;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateGcsBucket;
 import bio.terra.cli.serialization.userfacing.inputs.CreateUpdateResource;
@@ -60,11 +61,13 @@ public class GcsBucket extends BaseCommand {
     private Integer autoDelete;
   }
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add a controlled GCS bucket to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     createControlledResourceOptions.validateAccessOptions();
 
     // build the resource object to create

--- a/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.Workspace;
 import java.util.UUID;
 import picocli.CommandLine;
 
@@ -24,8 +23,7 @@ public class WorkspaceOverride {
   /** Helper method to override the current workspace if the `--workspace` flag specifies an id. */
   public void overrideIfSpecified() {
     if (id != null) {
-      Context.useOverrideWorkspace();
-      Workspace.load(id);
+      Context.useOverrideWorkspace(id);
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
@@ -1,0 +1,31 @@
+package bio.terra.cli.command.shared.options;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Workspace;
+import java.util.UUID;
+import picocli.CommandLine;
+
+/**
+ * Command helper class that defines the --workspace flag for overriding the current workspace just
+ * for this command.
+ *
+ * <p>Commands that use this option should call {@link #overrideIfSpecified()} before all other
+ * logic.
+ *
+ * <p>This class is meant to be used as a @CommandLine.Mixin.
+ */
+public class WorkspaceOverride {
+
+  @CommandLine.Option(
+      names = "--workspace",
+      description = "Workspace id to use for this command only")
+  private UUID id;
+
+  /** Helper method to override the current workspace if the `--workspace` flag specifies an id. */
+  public void overrideIfSpecified() {
+    if (id != null) {
+      Context.useOverrideWorkspace();
+      Workspace.load(id);
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
 import bio.terra.workspace.model.IamRole;
 import picocli.CommandLine;
@@ -21,11 +22,13 @@ public class AddUser extends BaseCommand {
       description = "Role to grant: ${COMPLETION-CANDIDATES}")
   private IamRole role;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Add an email to the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     WorkspaceUser workspaceUser = WorkspaceUser.add(email, role);
     formatOption.printReturnValue(new UFWorkspaceUser(workspaceUser), AddUser::printText);
   }

--- a/src/main/java/bio/terra/cli/command/workspace/Describe.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Describe.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -9,25 +8,22 @@ import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-/** This class corresponds to the third-level "terra workspace delete" command. */
-@Command(name = "delete", description = "Delete an existing workspace.")
-public class Delete extends BaseCommand {
+/** This class corresponds to the third-level "terra workspace describe" command. */
+@Command(name = "describe", description = "Describe the workspace.", showDefaultValues = true)
+public class Describe extends BaseCommand {
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
-  /** Delete an existing workspace. */
+  /** Describe the current workspace. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    Workspace workspaceToDelete = Context.requireWorkspace();
-    workspaceToDelete.delete();
-    formatOption.printReturnValue(new UFWorkspace(workspaceToDelete), this::printText);
+    formatOption.printReturnValue(new UFWorkspace(Context.requireWorkspace()), this::printText);
   }
 
   /** Print this command's output in text format. */
   private void printText(UFWorkspace returnValue) {
-    OUT.println("Workspace successfully deleted.");
     returnValue.print();
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
 import java.util.stream.Collectors;
 import picocli.CommandLine;
@@ -12,11 +13,13 @@ import picocli.CommandLine.Command;
 @Command(name = "list-users", description = "List the users of the workspace.")
 public class ListUsers extends BaseCommand {
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** List all users of the workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     java.util.List<WorkspaceUser> workspaceUsers = WorkspaceUser.list();
     formatOption.printReturnValue(
         workspaceUsers.stream()

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.workspace.model.IamRole;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -19,9 +20,12 @@ public class RemoveUser extends BaseCommand {
       description = "Role to grant: ${COMPLETION-CANDIDATES}")
   private IamRole role;
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+
   /** Remove a user from a workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     WorkspaceUser.remove(email, role);
     OUT.println("User (" + email + ") removed from workspace role (" + role + ").");
   }

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -4,6 +4,7 @@ import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -29,11 +30,13 @@ public class Update extends BaseCommand {
     private String description;
   }
 
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Update the mutable properties of an existing workspace. */
   @Override
   protected void execute() {
+    workspaceOption.overrideIfSpecified();
     Workspace updatedWorkspace =
         Context.requireWorkspace().update(argGroup.displayName, argGroup.description);
     formatOption.printReturnValue(new UFWorkspace(updatedWorkspace), this::printText);

--- a/src/test/java/harness/baseclasses/ClearContextUnit.java
+++ b/src/test/java/harness/baseclasses/ClearContextUnit.java
@@ -7,11 +7,13 @@ import harness.TestCommand;
 import harness.TestContext;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 
 /**
  * Base class for unit tests that includes standard setup/cleanup. Because they are for unit tests,
  * these methods call the setup/cleanup commands directly in Java.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClearContextUnit {
   @BeforeEach
   /**

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.TestInstance;
 
 /**
  * Base class for unit tests that only need a single workspace for all test methods. This makes the
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.TestInstance;
  * we're not starting with a completely clean state each time, but that's easy to do just for
  * debugging a particular failure.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class SingleWorkspaceUnit extends ClearContextUnit {
   protected static final TestUsers workspaceCreator = TestUsers.chooseTestUserWithSpendAccess();;
   private static UUID workspaceId;

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -108,7 +108,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     assertEquals(datasetId, deletedDataset.datasetId, "delete output matches dataset id");
 
     // check that the dataset is not in the list
-    List<UFBqDataset> matchedResources = listDatasetResourceWithName(name);
+    List<UFBqDataset> matchedResources = listDatasetResourcesWithName(name);
     assertEquals(0, matchedResources.size(), "no resource found with this name");
   }
 
@@ -277,7 +277,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
    */
   static UFBqDataset listOneDatasetResourceWithName(String resourceName, UUID workspaceId)
       throws JsonProcessingException {
-    List<UFBqDataset> matchedResources = listDatasetResourceWithName(resourceName, workspaceId);
+    List<UFBqDataset> matchedResources = listDatasetResourcesWithName(resourceName, workspaceId);
 
     assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
     return matchedResources.get(0);
@@ -287,15 +287,15 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name. Uses the current workspace.
    */
-  static List<UFBqDataset> listDatasetResourceWithName(String resourceName)
+  static List<UFBqDataset> listDatasetResourcesWithName(String resourceName)
       throws JsonProcessingException {
-    return listDatasetResourceWithName(resourceName, null);
+    return listDatasetResourcesWithName(resourceName, null);
   }
   /**
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name and workspace (uses the current workspace if null).
    */
-  static List<UFBqDataset> listDatasetResourceWithName(String resourceName, UUID workspaceId)
+  static List<UFBqDataset> listDatasetResourcesWithName(String resourceName, UUID workspaceId)
       throws JsonProcessingException {
     // `terra resources list --type=BQ_DATASET --format=json`
     List<UFBqDataset> listedResources =

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -1,7 +1,7 @@
 package unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static unit.BqDatasetControlled.listDatasetResourceWithName;
+import static unit.BqDatasetControlled.listDatasetResourcesWithName;
 import static unit.BqDatasetControlled.listOneDatasetResourceWithName;
 
 import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
@@ -141,7 +141,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
         "delete output matches dataset id");
 
     // check that the dataset is not in the list
-    List<UFBqDataset> matchedResources = listDatasetResourceWithName(name);
+    List<UFBqDataset> matchedResources = listDatasetResourcesWithName(name);
     assertEquals(0, matchedResources.size(), "no resource found with this name");
   }
 

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -99,7 +99,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     assertEquals(bucketName, deletedBucket.bucketName, "delete output matches bucket name");
 
     // check that the bucket is not in the list
-    List<UFGcsBucket> matchedResources = listBucketResourceWithName(name);
+    List<UFGcsBucket> matchedResources = listBucketResourcesWithName(name);
     assertEquals(0, matchedResources.size(), "no resource found with this name");
   }
 
@@ -264,7 +264,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
    */
   static UFGcsBucket listOneBucketResourceWithName(String resourceName, UUID workspaceId)
       throws JsonProcessingException {
-    List<UFGcsBucket> matchedResources = listBucketResourceWithName(resourceName, workspaceId);
+    List<UFGcsBucket> matchedResources = listBucketResourcesWithName(resourceName, workspaceId);
 
     assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
     return matchedResources.get(0);
@@ -274,16 +274,16 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name. Uses the current workspace.
    */
-  static List<UFGcsBucket> listBucketResourceWithName(String resourceName)
+  static List<UFGcsBucket> listBucketResourcesWithName(String resourceName)
       throws JsonProcessingException {
-    return listBucketResourceWithName(resourceName, null);
+    return listBucketResourcesWithName(resourceName, null);
   }
 
   /**
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name and workspace (uses the current workspace if null).
    */
-  static List<UFGcsBucket> listBucketResourceWithName(String resourceName, UUID workspaceId)
+  static List<UFGcsBucket> listBucketResourcesWithName(String resourceName, UUID workspaceId)
       throws JsonProcessingException {
     // `terra resources list --type=GCS_BUCKET --format=json`
     List<UFGcsBucket> listedResources =

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -1,7 +1,7 @@
 package unit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static unit.GcsBucketControlled.listBucketResourceWithName;
+import static unit.GcsBucketControlled.listBucketResourcesWithName;
 import static unit.GcsBucketControlled.listOneBucketResourceWithName;
 
 import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
@@ -116,7 +116,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
         externalBucket.getName(), deletedBucket.bucketName, "delete output matches bucket name");
 
     // check that the bucket is not in the list
-    List<UFGcsBucket> matchedResources = listBucketResourceWithName(name);
+    List<UFGcsBucket> matchedResources = listBucketResourcesWithName(name);
     assertEquals(0, matchedResources.size(), "no resource found with this name");
   }
 

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -1,5 +1,11 @@
 package unit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import bio.terra.cli.serialization.userfacing.UFStatus;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -7,21 +13,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import harness.TestCommand;
 import harness.TestUsers;
 import harness.baseclasses.ClearContextUnit;
-import org.hamcrest.CoreMatchers;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 /** Tests for the `terra workspace` commands. */
 @Tag("unit")
@@ -272,8 +271,7 @@ public class Workspace extends ClearContextUnit {
    * Helper method to call `terra workspace list` and filter the results on the specified workspace
    * id.
    */
-  private static List<UFWorkspace> listWorkspacesWithId(UUID workspaceId)
-      throws JsonProcessingException {
+  static List<UFWorkspace> listWorkspacesWithId(UUID workspaceId) throws JsonProcessingException {
     // `terra workspace list --format=json`
     List<UFWorkspace> listWorkspaces =
         TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "workspace", "list");

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -1,0 +1,375 @@
+package unit;
+
+import static harness.utils.ExternalBQDatasets.randomDatasetId;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static unit.BqDatasetControlled.listDatasetResourceWithName;
+import static unit.BqDatasetControlled.listOneDatasetResourceWithName;
+import static unit.GcsBucketControlled.listBucketResourceWithName;
+import static unit.GcsBucketControlled.listOneBucketResourceWithName;
+import static unit.Workspace.listWorkspacesWithId;
+import static unit.WorkspaceUser.expectListedUserWithRoles;
+import static unit.WorkspaceUser.listWorkspaceUserWithEmail;
+
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
+import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
+import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
+import bio.terra.workspace.model.IamRole;
+import com.google.cloud.bigquery.Dataset;
+import com.google.cloud.storage.Bucket;
+import harness.TestCommand;
+import harness.TestContext;
+import harness.TestUsers;
+import harness.baseclasses.ClearContextUnit;
+import harness.utils.ExternalBQDatasets;
+import harness.utils.ExternalGCSBuckets;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `--workspace` option to override the current workspace just for this command. */
+@Tag("unit")
+public class WorkspaceOverride extends ClearContextUnit {
+  protected static final TestUsers workspaceCreator = TestUsers.chooseTestUserWithSpendAccess();;
+  private static UFWorkspace workspace1;
+  private static UFWorkspace workspace2;
+
+  // external bucket to use for creating GCS bucket references in the workspace
+  private Bucket externalBucket;
+
+  // external dataset to use for creating BQ dataset references in the workspace
+  private Dataset externalDataset;
+
+  /**
+   * Create two workspaces for tests to use, so we can switch between them with the override option.
+   */
+  @BeforeAll
+  protected void setupOnce() throws IOException {
+    TestContext.clearGlobalContextDir();
+    resetContext();
+
+    externalBucket = ExternalGCSBuckets.createBucket();
+    ExternalGCSBuckets.grantReadAccess(externalBucket, workspaceCreator.email);
+    externalDataset = ExternalBQDatasets.createDataset();
+    ExternalBQDatasets.grantReadAccess(externalDataset, workspaceCreator.email);
+
+    workspaceCreator.login();
+
+    // `terra workspace create --format=json`
+    workspace1 =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
+
+    // `terra workspace create --format=json`
+    workspace2 =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
+  }
+
+  /** Delete the two workspaces. */
+  @AfterAll
+  protected void cleanupOnce() throws IOException {
+    TestContext.clearGlobalContextDir();
+    resetContext();
+
+    // login as the same user that created the workspace
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra workspace delete`
+    TestCommand.runCommandExpectSuccess("workspace", "delete");
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace2.id);
+
+    // `terra workspace delete`
+    TestCommand.runCommandExpectSuccess("workspace", "delete");
+
+    ExternalGCSBuckets.getStorageClient().delete(externalBucket.getName());
+    externalBucket = null;
+    ExternalBQDatasets.getBQClient().delete(externalDataset.getDatasetId());
+    externalDataset = null;
+  }
+
+  @Test
+  @DisplayName("gcloud and app execute respect workspace override")
+  void gcloudAppExecute() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id1`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra app execute --workspace=$id2 echo \$GOOGLE_CLOUD_PROJECT`
+    TestCommand.Result cmd =
+        TestCommand.runCommand(
+            "app", "execute", "--workspace=" + workspace2.id, "echo", "$GOOGLE_CLOUD_PROJECT");
+
+    // check that the google cloud project id matches workspace 2
+    assertThat(
+        "GOOGLE_CLOUD_PROJECT set to workspace2's project",
+        cmd.stdOut,
+        CoreMatchers.containsString(workspace2.googleProjectId));
+
+    // `terra gcloud --workspace=$id2 config get-value project`
+    cmd =
+        TestCommand.runCommand(
+            "gcloud", "--workspace=" + workspace2.id, "config", "get-value", "project");
+
+    // check that the workspace id and google cloud project id match workspace 2
+    assertThat(
+        "gcloud project = workspace2's project",
+        cmd.stdOut,
+        CoreMatchers.containsString(workspace2.googleProjectId));
+  }
+
+  @Test
+  @DisplayName("referenced resource commands respect workspace override")
+  void referencedResources() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id1`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra resources add-ref gcs-bucket --name=$resourceNameBucket --bucket-name=$bucketName
+    // --workspace=$id2`
+    String resourceNameBucket = "referencedResources_bucket";
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "add-ref",
+        "gcs-bucket",
+        "--name=" + resourceNameBucket,
+        "--bucket-name=" + externalBucket.getName(),
+        "--workspace=" + workspace2.id);
+
+    // `terra resources add-ref bq-dataset --name=$resourceNameDataset --dataset-id=$datasetId
+    // --workspace=$id2`
+    String resourceNameDataset = "referencedResources_dataset";
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "add-ref",
+        "bq-dataset",
+        "--name=" + resourceNameDataset,
+        "--project-id=" + externalDataset.getDatasetId().getProject(),
+        "--dataset-id=" + externalDataset.getDatasetId().getDataset(),
+        "--workspace=" + workspace2.id);
+
+    // `terra resources list --type=BQ_DATASET`
+    // check that workspace 2 contains both referenced resources above and workspace 1 does not
+    UFGcsBucket matchedBucket = listOneBucketResourceWithName(resourceNameBucket, workspace2.id);
+    assertEquals(
+        resourceNameBucket, matchedBucket.name, "list output for workspace 2 matches bucket name");
+    List<UFGcsBucket> matchedBuckets =
+        listBucketResourceWithName(resourceNameBucket, workspace1.id);
+    assertEquals(0, matchedBuckets.size(), "list output for bucket in workspace 1 is empty");
+
+    UFBqDataset matchedDataset = listOneDatasetResourceWithName(resourceNameDataset, workspace2.id);
+    assertEquals(
+        resourceNameDataset,
+        matchedDataset.name,
+        "list output for workspace 2 matches dataset name");
+    List<UFBqDataset> matchedDatasets =
+        listDatasetResourceWithName(resourceNameDataset, workspace1.id);
+    assertEquals(0, matchedDatasets.size(), "list output for dataset in workspace 1 is empty");
+
+    // check that check-access, describe, and resolve succeed in workspace 2 but not in workspace 1
+
+    // `terra check-access --name=$resourceNameBucket`
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "check-access",
+        "--name=" + resourceNameBucket,
+        "--workspace=" + workspace2.id);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "check-access", "--name=" + resourceNameBucket);
+
+    // `terra describe --name=$resourceNameDataset`
+    TestCommand.runCommandExpectSuccess(
+        "resources", "describe", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "describe", "--name=" + resourceNameDataset);
+
+    // `terra resolve --name=$resourceNameBucket`
+    TestCommand.runCommandExpectSuccess(
+        "resources", "resolve", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+    TestCommand.runCommandExpectExitCode(1, "resources", "resolve", "--name=" + resourceNameBucket);
+
+    // `terra delete --name=$resourceNameBucket --workspace=$id2`
+    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameBucket);
+    TestCommand.runCommandExpectSuccess(
+        "resources", "delete", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+
+    // `terra delete --name=$resourceNameDataset --workspace=$id2`
+    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameDataset);
+    TestCommand.runCommandExpectSuccess(
+        "resources", "delete", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+  }
+
+  @Test
+  @DisplayName("controlled resource commands respect workspace override")
+  void controlledResources() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id1`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra resources create gcs-bucket --name=$resourceNameBucket --bucket-name=$bucketName
+    // --workspace=$id2`
+    String resourceNameBucket = "controlledResources_bucket";
+    String bucketName = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "create",
+        "gcs-bucket",
+        "--name=" + resourceNameBucket,
+        "--bucket-name=" + bucketName,
+        "--workspace=" + workspace2.id);
+
+    // `terra resources create bq-dataset --name=$resourceNameDataset --dataset-id=$datasetId
+    // --workspace=$id2`
+    String resourceNameDataset = "controlledResources_dataset";
+    String datasetId = randomDatasetId();
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "create",
+        "bq-dataset",
+        "--name=" + resourceNameDataset,
+        "--dataset-id=" + datasetId,
+        "--workspace=" + workspace2.id);
+
+    // `terra resources list --type=BQ_DATASET`
+    // check that workspace 2 contains both controlled resources above and workspace 1 does not
+    UFGcsBucket matchedBucket = listOneBucketResourceWithName(resourceNameBucket, workspace2.id);
+    assertEquals(
+        resourceNameBucket, matchedBucket.name, "list output for workspace 2 matches bucket name");
+    List<UFGcsBucket> matchedBuckets =
+        listBucketResourceWithName(resourceNameBucket, workspace1.id);
+    assertEquals(0, matchedBuckets.size(), "list output for bucket in workspace 1 is empty");
+
+    UFBqDataset matchedDataset = listOneDatasetResourceWithName(resourceNameDataset, workspace2.id);
+    assertEquals(
+        resourceNameDataset,
+        matchedDataset.name,
+        "list output for workspace 2 matches dataset name");
+    List<UFBqDataset> matchedDatasets =
+        listDatasetResourceWithName(resourceNameDataset, workspace1.id);
+    assertEquals(0, matchedDatasets.size(), "list output for dataset in workspace 1 is empty");
+
+    // check that describe and resolve succeed in workspace 2 but not in workspace 1
+
+    // `terra describe --name=$resourceNameDataset`
+    TestCommand.runCommandExpectSuccess(
+        "resources", "describe", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "describe", "--name=" + resourceNameDataset);
+
+    // `terra resolve --name=$resourceNameBucket`
+    TestCommand.runCommandExpectSuccess(
+        "resources", "resolve", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+    TestCommand.runCommandExpectExitCode(1, "resources", "resolve", "--name=" + resourceNameBucket);
+
+    // `terra delete --name=$resourceNameBucket --workspace=$id2`
+    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameBucket);
+    TestCommand.runCommandExpectSuccess(
+        "resources", "delete", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+
+    // `terra delete --name=$resourceNameDataset --workspace=$id2`
+    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameDataset);
+    TestCommand.runCommandExpectSuccess(
+        "resources", "delete", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+  }
+
+  @Test
+  @DisplayName("workspace user commands respect workspace override")
+  void workspaceUser() throws IOException {
+    // login as the workspace creator and select a test user to share the workspace with
+    workspaceCreator.login();
+    TestUsers testUser = TestUsers.chooseTestUserWhoIsNot(workspaceCreator);
+
+    // `terra workspace set --id=$id1`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra workspace add-user --email=$email --role=READER --workspace=$id2`
+    TestCommand.runCommandExpectSuccess(
+        "workspace",
+        "add-user",
+        "--email=" + testUser.email,
+        "--role=READER",
+        "--workspace=" + workspace2.id);
+
+    // `terra workspace list-users --email=$email --role=READER --workspace=$id2`
+    // check that the user exists in the list output for workspace 2, but not workspace 1
+    expectListedUserWithRoles(testUser.email, workspace2.id, IamRole.READER);
+    Optional<UFWorkspaceUser> workspaceUser =
+        listWorkspaceUserWithEmail(testUser.email, workspace1.id);
+    assertTrue(workspaceUser.isEmpty(), "test user is not in users list for workspace 1");
+
+    // `terra workspace remove-user --email=$email --role=READER --workspace=$id2`
+    TestCommand.runCommandExpectSuccess(
+        "workspace",
+        "remove-user",
+        "--email=" + testUser.email,
+        "--role=READER",
+        "--workspace=" + workspace2.id);
+
+    // `terra workspace list-users --email=$email --role=READER --workspace=$id2`
+    // check that the user no longer exists in the list output for workspace 2
+    workspaceUser = listWorkspaceUserWithEmail(testUser.email, workspace2.id);
+    assertTrue(workspaceUser.isEmpty(), "test user is no longer in users list for workspace 2");
+  }
+
+  @Test
+  @DisplayName("workspace commands respect workspace override")
+  void workspace() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace create`
+    UFWorkspace workspace3 =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
+
+    // `terra workspace set --id=$id1`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
+
+    // `terra workspace update --name=$newName --description=$newDescription --workspace=$id3`
+    String newName = "workspace3_name_NEW";
+    String newDescription = "workspace3_description_NEW";
+    TestCommand.runCommandExpectSuccess(
+        "workspace",
+        "update",
+        "--name=" + newName,
+        "--description=" + newDescription,
+        "--workspace=" + workspace3.id);
+
+    // `terra workspace describe --workspace=$id3`
+    // check that the workspace 3 description has been updated, and the workspace 1 has not
+    UFWorkspace workspaceDescribe =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "describe", "--workspace=" + workspace3.id);
+    assertEquals(newName, workspaceDescribe.name, "workspace 3 name matches update");
+    assertEquals(
+        newDescription, workspaceDescribe.description, "workspace 3 description matches update");
+    workspaceDescribe =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "describe");
+    assertEquals(workspace1.name, workspaceDescribe.name, "workspace 1 name matches update");
+    assertEquals(
+        workspace1.description,
+        workspaceDescribe.description,
+        "workspace 1 description matches update");
+
+    // `terra workspace delete --workspace=$id3`
+    // check the workspace 3 has been deleted, and workspace 1 has not
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--workspace=" + workspace3.id);
+    List<UFWorkspace> matchingWorkspaces = listWorkspacesWithId(workspace3.id);
+    assertEquals(0, matchingWorkspaces.size(), "deleted workspace 3 is not included in list");
+    matchingWorkspaces = listWorkspacesWithId(workspace1.id);
+    assertEquals(1, matchingWorkspaces.size(), "workspace 1 is still included in list");
+  }
+}

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -4,13 +4,13 @@ import static harness.utils.ExternalBQDatasets.randomDatasetId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static unit.BqDatasetControlled.listDatasetResourceWithName;
+import static unit.BqDatasetControlled.listDatasetResourcesWithName;
 import static unit.BqDatasetControlled.listOneDatasetResourceWithName;
-import static unit.GcsBucketControlled.listBucketResourceWithName;
+import static unit.GcsBucketControlled.listBucketResourcesWithName;
 import static unit.GcsBucketControlled.listOneBucketResourceWithName;
 import static unit.Workspace.listWorkspacesWithId;
 import static unit.WorkspaceUser.expectListedUserWithRoles;
-import static unit.WorkspaceUser.listWorkspaceUserWithEmail;
+import static unit.WorkspaceUser.workspaceListUsersWithEmail;
 
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
@@ -170,7 +170,7 @@ public class WorkspaceOverride extends ClearContextUnit {
         resourceNameBucket, matchedBucket.name, "list output for workspace 2 matches bucket name");
 
     // `terra resources list --type=GCS_BUCKET`
-    List<UFGcsBucket> matchedBuckets = listBucketResourceWithName(resourceNameBucket);
+    List<UFGcsBucket> matchedBuckets = listBucketResourcesWithName(resourceNameBucket);
     assertEquals(0, matchedBuckets.size(), "list output for bucket in workspace 1 is empty");
 
     // `terra resources list --type=BQ_DATASET --workspace=$id2`
@@ -181,7 +181,7 @@ public class WorkspaceOverride extends ClearContextUnit {
         "list output for workspace 2 matches dataset name");
 
     // `terra resources list --type=BQ_DATASET`
-    List<UFBqDataset> matchedDatasets = listDatasetResourceWithName(resourceNameDataset);
+    List<UFBqDataset> matchedDatasets = listDatasetResourcesWithName(resourceNameDataset);
     assertEquals(0, matchedDatasets.size(), "list output for dataset in workspace 1 is empty");
 
     // check that check-access, describe, and resolve succeed in workspace 2 but not in workspace 1
@@ -257,7 +257,7 @@ public class WorkspaceOverride extends ClearContextUnit {
         resourceNameBucket, matchedBucket.name, "list output for workspace 2 matches bucket name");
 
     // `terra resources list --type=GCS_BUCKET`
-    List<UFGcsBucket> matchedBuckets = listBucketResourceWithName(resourceNameBucket);
+    List<UFGcsBucket> matchedBuckets = listBucketResourcesWithName(resourceNameBucket);
     assertEquals(0, matchedBuckets.size(), "list output for bucket in workspace 1 is empty");
 
     // `terra resources list --type=BQ_DATASET --workspace=$id2`
@@ -268,7 +268,7 @@ public class WorkspaceOverride extends ClearContextUnit {
         "list output for workspace 2 matches dataset name");
 
     // `terra resources list --type=BQ_DATASET`
-    List<UFBqDataset> matchedDatasets = listDatasetResourceWithName(resourceNameDataset);
+    List<UFBqDataset> matchedDatasets = listDatasetResourcesWithName(resourceNameDataset);
     assertEquals(0, matchedDatasets.size(), "list output for dataset in workspace 1 is empty");
 
     // check that describe and resolve succeed in workspace 2 but not in workspace 1
@@ -319,7 +319,7 @@ public class WorkspaceOverride extends ClearContextUnit {
     expectListedUserWithRoles(testUser.email, workspace2.id, IamRole.READER);
 
     // `terra workspace list-users --email=$email --role=READER`
-    Optional<UFWorkspaceUser> workspaceUser = listWorkspaceUserWithEmail(testUser.email);
+    Optional<UFWorkspaceUser> workspaceUser = workspaceListUsersWithEmail(testUser.email);
     assertTrue(workspaceUser.isEmpty(), "test user is not in users list for workspace 1");
 
     // `terra workspace remove-user --email=$email --role=READER --workspace=$id2`
@@ -332,7 +332,7 @@ public class WorkspaceOverride extends ClearContextUnit {
 
     // `terra workspace list-users --email=$email --role=READER --workspace=$id2`
     // check that the user no longer exists in the list output for workspace 2
-    workspaceUser = listWorkspaceUserWithEmail(testUser.email, workspace2.id);
+    workspaceUser = workspaceListUsersWithEmail(testUser.email, workspace2.id);
     assertTrue(workspaceUser.isEmpty(), "test user is no longer in users list for workspace 2");
   }
 

--- a/src/test/java/unit/WorkspaceUser.java
+++ b/src/test/java/unit/WorkspaceUser.java
@@ -135,7 +135,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
         "workspace", "remove-user", "--email=" + testUser.email, "--role=OWNER");
 
     // check that the user is not in the list
-    Optional<UFWorkspaceUser> workspaceUser = listWorkspaceUserWithEmail(testUser.email);
+    Optional<UFWorkspaceUser> workspaceUser = workspaceListUsersWithEmail(testUser.email);
     assertTrue(workspaceUser.isEmpty(), "test user is not in users list");
   }
 
@@ -154,7 +154,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
    */
   static void expectListedUserWithRoles(String userEmail, UUID workspaceId, IamRole... roles)
       throws JsonProcessingException {
-    Optional<UFWorkspaceUser> workspaceUser = listWorkspaceUserWithEmail(userEmail, workspaceId);
+    Optional<UFWorkspaceUser> workspaceUser = workspaceListUsersWithEmail(userEmail, workspaceId);
     assertTrue(workspaceUser.isPresent(), "test user is in users list");
     assertEquals(
         roles.length, workspaceUser.get().roles.size(), "test user has the right number of roles");
@@ -167,16 +167,16 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
    * Helper method to call `terra workspace list` and filter the results on the specified user
    * email. Uses the current workspace.
    */
-  static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail)
+  static Optional<UFWorkspaceUser> workspaceListUsersWithEmail(String userEmail)
       throws JsonProcessingException {
-    return listWorkspaceUserWithEmail(userEmail, null);
+    return workspaceListUsersWithEmail(userEmail, null);
   }
 
   /**
    * Helper method to call `terra workspace list` and filter the results on the specified user email
    * and workspace id (uses the current workspace id if null).
    */
-  static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail, UUID workspaceId)
+  static Optional<UFWorkspaceUser> workspaceListUsersWithEmail(String userEmail, UUID workspaceId)
       throws JsonProcessingException {
     // `terra workspace list-users --format=json`
     List<UFWorkspaceUser> listWorkspaceUsers =

--- a/src/test/java/unit/WorkspaceUser.java
+++ b/src/test/java/unit/WorkspaceUser.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -140,10 +141,20 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
 
   /**
    * Helper method to check that a workspace user is included in the list with the specified roles.
+   * Uses the current workspace.
    */
   private static void expectListedUserWithRoles(String userEmail, IamRole... roles)
       throws JsonProcessingException {
-    Optional<UFWorkspaceUser> workspaceUser = listWorkspaceUserWithEmail(userEmail);
+    expectListedUserWithRoles(userEmail, null, roles);
+  }
+
+  /**
+   * Helper method to check that a workspace user is included in the list with the specified roles.
+   * Filters on the specified workspace id; Uses the current workspace if null.
+   */
+  static void expectListedUserWithRoles(String userEmail, UUID workspaceId, IamRole... roles)
+      throws JsonProcessingException {
+    Optional<UFWorkspaceUser> workspaceUser = listWorkspaceUserWithEmail(userEmail, workspaceId);
     assertTrue(workspaceUser.isPresent(), "test user is in users list");
     assertEquals(
         roles.length, workspaceUser.get().roles.size(), "test user has the right number of roles");
@@ -154,14 +165,26 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
 
   /**
    * Helper method to call `terra workspace list` and filter the results on the specified user
-   * email.
+   * email. Uses the current workspace.
    */
   private static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail)
       throws JsonProcessingException {
+    return listWorkspaceUserWithEmail(userEmail, null);
+  }
+
+  /**
+   * Helper method to call `terra workspace list` and filter the results on the specified user email
+   * and workspace id (uses the current workspace id if null).
+   */
+  static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail, UUID workspaceId)
+      throws JsonProcessingException {
     // `terra workspace list-users --format=json`
     List<UFWorkspaceUser> listWorkspaceUsers =
-        TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "workspace", "list-users");
+        workspaceId == null
+            ? TestCommand.runAndParseCommandExpectSuccess(
+                new TypeReference<>() {}, "workspace", "list-users")
+            : TestCommand.runAndParseCommandExpectSuccess(
+                new TypeReference<>() {}, "workspace", "list-users", "--workspace=" + workspaceId);
 
     // find the user in the list
     return listWorkspaceUsers.stream()

--- a/src/test/java/unit/WorkspaceUser.java
+++ b/src/test/java/unit/WorkspaceUser.java
@@ -167,7 +167,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
    * Helper method to call `terra workspace list` and filter the results on the specified user
    * email. Uses the current workspace.
    */
-  private static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail)
+  static Optional<UFWorkspaceUser> listWorkspaceUserWithEmail(String userEmail)
       throws JsonProcessingException {
     return listWorkspaceUserWithEmail(userEmail, null);
   }


### PR DESCRIPTION
- Added a `--workspace` flag to many commands that overrides the configured workspace (i.e. the one specified with `terra workspace set --id=...` or `terra workspace create`).
  - For a single command only, the override workspace is the current workspace. On the next command, provided the flag is not specified again, the current workspace will again be the configured one.
  - The override workspace does not affect the context persisted to disk. It only affects the in-memory workspace for the current command.
  - Added tests for the commands that now have this flag.
- Added a new `terra workspace describe` command to get metadata about the current workspace. This is useful for getting metadata about workspaces other than the current one (i.e. using the `--workspace` flag).