### PR TITLE
PF-857: Fix exit code for pass through apps run in local process mode.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -54,7 +54,7 @@ public class LocalProcessCommandRunner extends CommandRunner {
       throws PassthroughException {
     List<String> processCommand = new ArrayList<>();
     processCommand.add("bash");
-    processCommand.add("-c");
+    processCommand.add("-ce");
     processCommand.add(command);
 
     // set the path to the pet SA key file

--- a/src/test/java/harness/TestBashScript.java
+++ b/src/test/java/harness/TestBashScript.java
@@ -74,7 +74,7 @@ public class TestBashScript {
    * @param workingDirectory the working directory to launch the process from
    * @return process exit code
    */
-  public static int launchChildProcess(
+  private static int launchChildProcess(
       List<String> command, Map<String, String> envVars, Path workingDirectory) {
     // build and run process from the specified working directory
     ProcessBuilder procBuilder = new ProcessBuilder(command);
@@ -106,10 +106,18 @@ public class TestBashScript {
   /**
    * Helper method to get the absolute path to a script in the test/resources/testscripts directory.
    */
-  public static Path getPathFromScriptName(String name) {
+  private static Path getPathFromScriptName(String name) {
     Path scriptPath =
         Path.of(TestBashScript.class.getClassLoader().getResource("testscripts/" + name).getPath())
             .toAbsolutePath();
     return scriptPath;
+  }
+
+  /**
+   * Helper method to get the absolute path to an output file in the working directory used for
+   * running bash scripts.
+   */
+  public static Path getOutputFilePath(String fileName) {
+    return Path.of(System.getProperty("TERRA_WORKING_DIR")).resolve(fileName).toAbsolutePath();
   }
 }

--- a/src/test/java/integration/Nextflow.java
+++ b/src/test/java/integration/Nextflow.java
@@ -1,17 +1,44 @@
 package integration;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import harness.TestBashScript;
 import harness.TestUsers;
 import harness.baseclasses.ClearContextIntegration;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("integration")
 public class Nextflow extends ClearContextIntegration {
+  @Test
+  @DisplayName("nextflow run hello")
+  void helloWorld() throws IOException {
+    // select a test user and login
+    TestUsers testUser = TestUsers.chooseTestUserWithSpendAccess();
+    testUser.login();
+
+    // run the script that runs the NF hello world workflow
+    int exitCode = TestBashScript.runScript("NextflowHelloWorld.sh");
+
+    // check that the NF script ran successfully
+    assertEquals(0, exitCode, "script completed without errors");
+
+    // check that the NF output includes the "Hello world!" string that indicates the workflow ran
+    String scriptOutput =
+        Files.readString(
+            TestBashScript.getOutputFilePath("nextflowHelloWorld_stdout.txt"),
+            StandardCharsets.UTF_8);
+    assertThat(
+        "nextflow output includes the hello world string",
+        scriptOutput,
+        CoreMatchers.containsString("Hello world!"));
+  }
 
   @Test
   @DisplayName("nextflow config and run with GLS tutorial")

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -3,11 +3,12 @@ set -e
 ## This script checks if there is a logged in user. If there is, it deletes the current workspace.
 
 terra status
+terra auth status
 
-isLoggedIn=$(terra auth status | jq .loggedIn)
+isLoggedIn=$(terra auth status --format=json | jq .loggedIn)
 if [[ "true" = "$isLoggedIn" ]]
 then
-  currentUser=$(terra auth status | jq .userEmail)
+  currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Deleting the current workspace."
   terra workspace delete
 else

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 set -e
-## This script deletes the current workspace after running an integration test.
+## This script checks if there is a logged in user. If there is, it deletes the current workspace.
 
 terra status
 
-# delete the workspace
-terra workspace delete
+isLoggedIn=$(terra auth status | jq .loggedIn)
+if [[ "true" = "$isLoggedIn" ]]
+then
+  currentUser=$(terra auth status | jq .userEmail)
+  echo "User $currentUser is logged in. Deleting the current workspace."
+  terra workspace delete
+else
+  echo "No user is logged in. Skipping deleting the current workspace."
+fi

--- a/src/test/resources/testscripts/NextflowHelloWorld.sh
+++ b/src/test/resources/testscripts/NextflowHelloWorld.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+## This script runs a hello world Nextflow pipeline.
+## Do this in an integration test because it generates local files, which are cleaned up by integration,
+# but not unit, tests.
+
+terra status
+terra workspace create
+terra status
+
+terra nextflow run hello > nextflowHelloWorld_stdout.txt


### PR DESCRIPTION
Pass-through apps are third-party tools that users can call in the context of a workspace by prefixing it with `terra`. e.g.
`terra nextflow run ...`, `terra gsutil ls ...`. They can be run in 2 modes:
  - `DOCKER_CONTAINER` is the default and means that the app is run in a docker container shipped with the CLI and pre-installed with supported tools (e.g. `nextflow`, `gcloud`).
  - `LOCAL_PROCESS` means that the app is run in a child process on the local machine and uses tools that are installed locally. The CLI doesn't have any control over what's installed locally, but this can be useful to users who want to run apps that are not yet supported by Terra.
-------------------------
- The process exit code is now passed through to the CLI caller for `LOCAL_PROCESS` mode. Previously it was sometimes swallowed and the CLI returned 0 = success. This happened when the follow-on commands to reset the `gcloud` configuration after the app command succeeded.
- This is a follow-on to the [PR for PF-798](https://github.com/DataBiosphere/terra-cli/pull/89), which fixed this exit code problem for `DOCKER_CONTAINER` mode.

- Also added two new tests: one for the local process exist code and one that runs the Nextflow hello world example.