### PR TITLE
PF-796: Workspace config command. Config tests.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -3,12 +3,11 @@ package bio.terra.cli.apps;
 import bio.terra.cli.apps.utils.LocalProcessLauncher;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.exception.PassthroughException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** This class runs client-side tools in a local process. */
 public class LocalProcessCommandRunner extends CommandRunner {

--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -3,11 +3,12 @@ package bio.terra.cli.apps;
 import bio.terra.cli.apps.utils.LocalProcessLauncher;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.exception.PassthroughException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** This class runs client-side tools in a local process. */
 public class LocalProcessCommandRunner extends CommandRunner {
@@ -36,7 +37,8 @@ public class LocalProcessCommandRunner extends CommandRunner {
     bashCommands.add(buildFullCommand(command));
     bashCommands.add(
         "echo 'Restoring the original gcloud project configuration:' $TERRA_PREV_GCLOUD_PROJECT");
-    bashCommands.add("gcloud config set project $TERRA_PREV_GCLOUD_PROJECT");
+    bashCommands.add(
+        "if [[ -z \"$TERRA_PREV_GCLOUD_PROJECT\" ]]; then gcloud config set project $TERRA_PREV_GCLOUD_PROJECT; else gcloud config unset project; fi");
     return String.join("; ", bashCommands);
   }
 

--- a/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/apps/LocalProcessCommandRunner.java
@@ -37,7 +37,7 @@ public class LocalProcessCommandRunner extends CommandRunner {
     bashCommands.add(
         "echo 'Restoring the original gcloud project configuration:' $TERRA_PREV_GCLOUD_PROJECT");
     bashCommands.add(
-        "if [[ -z \"$TERRA_PREV_GCLOUD_PROJECT\" ]]; then gcloud config set project $TERRA_PREV_GCLOUD_PROJECT; else gcloud config unset project; fi");
+        "if [[ -z \"$TERRA_PREV_GCLOUD_PROJECT\" ]]; then gcloud config unset project; else gcloud config set project $TERRA_PREV_GCLOUD_PROJECT; fi");
     return String.join("; ", bashCommands);
   }
 

--- a/src/main/java/bio/terra/cli/command/config/GetValue.java
+++ b/src/main/java/bio/terra/cli/command/config/GetValue.java
@@ -6,6 +6,7 @@ import bio.terra.cli.command.config.getvalue.Image;
 import bio.terra.cli.command.config.getvalue.Logging;
 import bio.terra.cli.command.config.getvalue.ResourceLimit;
 import bio.terra.cli.command.config.getvalue.Server;
+import bio.terra.cli.command.config.getvalue.Workspace;
 import picocli.CommandLine.Command;
 
 /**
@@ -21,6 +22,7 @@ import picocli.CommandLine.Command;
       Image.class,
       Logging.class,
       ResourceLimit.class,
-      Server.class
+      Server.class,
+      Workspace.class
     })
 public class GetValue {}

--- a/src/main/java/bio/terra/cli/command/config/List.java
+++ b/src/main/java/bio/terra/cli/command/config/List.java
@@ -18,28 +18,13 @@ public class List extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        new UFConfig(Context.getConfig(), Context.getServer()), List::printText);
+        new UFConfig(Context.getConfig(), Context.getServer(), Context.getWorkspace()),
+        List::printText);
   }
 
   /** Print this command's output in text format. */
   private static void printText(UFConfig returnValue) {
-    OUT.println("[app-launch] app launch mode = " + returnValue.commandRunnerOption);
-    OUT.println("[browser] browser launch for login = " + returnValue.browserLaunchOption);
-    OUT.println("[image] docker image id = " + returnValue.dockerImageId);
-    OUT.println(
-        "[resource-limit] max number of resources to allow per workspace = "
-            + returnValue.resourcesCacheSize);
-    OUT.println();
-    OUT.println(
-        "[logging, console] logging level for printing directly to the terminal = "
-            + returnValue.consoleLoggingLevel);
-    OUT.println(
-        "[logging, file] logging level for writing to files in "
-            + Context.getLogFile().getParent()
-            + " = "
-            + returnValue.fileLoggingLevel);
-    OUT.println();
-    OUT.println("[server] server = " + returnValue.serverName);
+    returnValue.print();
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/config/Set.java
+++ b/src/main/java/bio/terra/cli/command/config/Set.java
@@ -6,6 +6,7 @@ import bio.terra.cli.command.config.set.Image;
 import bio.terra.cli.command.config.set.Logging;
 import bio.terra.cli.command.config.set.ResourceLimit;
 import bio.terra.cli.command.config.set.Server;
+import bio.terra.cli.command.config.set.Workspace;
 import picocli.CommandLine.Command;
 
 /**
@@ -21,6 +22,7 @@ import picocli.CommandLine.Command;
       Image.class,
       Logging.class,
       ResourceLimit.class,
-      Server.class
+      Server.class,
+      Workspace.class
     })
 public class Set {}

--- a/src/main/java/bio/terra/cli/command/config/getvalue/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/config/getvalue/Workspace.java
@@ -1,0 +1,34 @@
+package bio.terra.cli.command.config.getvalue;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the fourth-level "terra config get-value workspace" command. */
+@Command(name = "workspace", description = "Get the current Terra workspace.")
+public class Workspace extends BaseCommand {
+
+  @CommandLine.Mixin Format formatOption;
+
+  /** Return the workspace property of the global context. */
+  @Override
+  protected void execute() {
+    UFWorkspace currentWorkspace =
+        Context.getWorkspace().isPresent() ? new UFWorkspace(Context.requireWorkspace()) : null;
+    formatOption.printReturnValue(currentWorkspace, Workspace::printText);
+  }
+
+  /** Print this command's output in text format. */
+  public static void printText(UFWorkspace returnValue) {
+    OUT.println(returnValue == null ? "" : returnValue.id);
+  }
+
+  /** This command never requires login. */
+  @Override
+  protected boolean requiresLogin() {
+    return false;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/config/set/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Workspace.java
@@ -1,0 +1,11 @@
+package bio.terra.cli.command.config.set;
+
+import bio.terra.cli.command.workspace.Set;
+import picocli.CommandLine.Command;
+
+/**
+ * This class corresponds to the fourth-level "terra config set workspace" command. It is exactly
+ * the same command as "terra workspace set".
+ */
+@Command(name = "workspace", description = "Set the workspace to an existing one.")
+public class Workspace extends Set {}

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
@@ -74,7 +74,7 @@ public class UFConfig {
             + fileLoggingLevel);
     OUT.println();
     OUT.println("[server] server = " + serverName);
-    OUT.println("[workspace] workspace = " + (workspaceId == null ? "" : workspaceId));
+    OUT.println("[workspace] workspace = " + (workspaceId == null ? "(unset)" : workspaceId));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
@@ -3,11 +3,14 @@ package bio.terra.cli.serialization.userfacing;
 import bio.terra.cli.businessobject.Config;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
+import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.Logger;
 import bio.terra.cli.utils.Printer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * External representation of a configuration for command input/output.
@@ -25,9 +28,11 @@ public class UFConfig {
   public final Logger.LogLevel fileLoggingLevel;
   public final Logger.LogLevel consoleLoggingLevel;
   public final String serverName;
+  public final UUID workspaceId;
 
   /** Serialize an instance of the internal class to the command format. */
-  public UFConfig(Config internalConfig, Server internalServer) {
+  public UFConfig(
+      Config internalConfig, Server internalServer, Optional<Workspace> internalWorkspace) {
     this.browserLaunchOption = internalConfig.getBrowserLaunchOption();
     this.commandRunnerOption = internalConfig.getCommandRunnerOption();
     this.dockerImageId = internalConfig.getDockerImageId();
@@ -35,6 +40,7 @@ public class UFConfig {
     this.fileLoggingLevel = internalConfig.getFileLoggingLevel();
     this.consoleLoggingLevel = internalConfig.getConsoleLoggingLevel();
     this.serverName = internalServer.getName();
+    this.workspaceId = internalWorkspace.isPresent() ? internalWorkspace.get().getId() : null;
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -46,6 +52,7 @@ public class UFConfig {
     this.fileLoggingLevel = builder.fileLoggingLevel;
     this.consoleLoggingLevel = builder.consoleLoggingLevel;
     this.serverName = builder.serverName;
+    this.workspaceId = builder.workspaceId;
   }
 
   /** Print out this object in text format. */
@@ -67,6 +74,7 @@ public class UFConfig {
             + fileLoggingLevel);
     OUT.println();
     OUT.println("[server] server = " + serverName);
+    OUT.println("[workspace] workspace = " + (workspaceId == null ? "" : workspaceId));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -78,6 +86,7 @@ public class UFConfig {
     private Logger.LogLevel fileLoggingLevel;
     private Logger.LogLevel consoleLoggingLevel;
     private String serverName;
+    private UUID workspaceId;
 
     public Builder browserLaunchOption(Config.BrowserLaunchOption browserLaunchOption) {
       this.browserLaunchOption = browserLaunchOption;
@@ -111,6 +120,11 @@ public class UFConfig {
 
     public Builder serverName(String serverName) {
       this.serverName = serverName;
+      return this;
+    }
+
+    public Builder workspaceId(UUID workspaceId) {
+      this.workspaceId = workspaceId;
       return this;
     }
 

--- a/src/test/java/integration/Config.java
+++ b/src/test/java/integration/Config.java
@@ -1,0 +1,91 @@
+package integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import harness.TestBashScript;
+import harness.baseclasses.ClearContextIntegration;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("integration")
+public class Config extends ClearContextIntegration {
+  @Test
+  @DisplayName("browser manual config prompts for code")
+  void browserManual() throws IOException {
+    String authLoginOutputFilename = "Config_browserManual_stdout.txt";
+    List<String> commands = new ArrayList<>();
+    commands.add("terra config set browser MANUAL");
+    commands.add("terra auth revoke");
+    commands.add("terra auth login > " + authLoginOutputFilename);
+    int exitCode = TestBashScript.runCommands(commands, Collections.emptyMap());
+    // expect an error reading stdin: No line found
+    assertEquals(3, exitCode, "script failed with an unexpected error");
+
+    // check that the auth login output includes the url and prompt to enter a code manually
+    String authLoginOutput =
+        Files.readString(
+            TestBashScript.getOutputFilePath(authLoginOutputFilename), StandardCharsets.UTF_8);
+    assertThat(
+        "auth login output includes prompt to enter code manually",
+        authLoginOutput,
+        CoreMatchers.containsString("Please enter code:"));
+  }
+
+  @Test
+  @DisplayName("logging console config writes debug output")
+  void loggingConsole() throws IOException {
+    String serverStatusOutputFilename = "Config_loggingConsoleDebug_stdout.txt";
+    List<String> commands = new ArrayList<>();
+    commands.add("terra config set logging --console --level=DEBUG");
+    commands.add("terra server status > " + serverStatusOutputFilename);
+    int exitCode = TestBashScript.runCommands(commands, Collections.emptyMap());
+    assertEquals(0, exitCode, "server status executed successfully");
+
+    // check that the server status output includes INFO and DEBUG statements
+    String serverStatusOutput =
+        Files.readString(
+            TestBashScript.getOutputFilePath(serverStatusOutputFilename), StandardCharsets.UTF_8);
+    assertThat(
+        "server status output includes a DEBUG statement",
+        serverStatusOutput,
+        CoreMatchers.containsString("[main] DEBUG"));
+    assertThat(
+        "server status output includes an INFO statement",
+        serverStatusOutput,
+        CoreMatchers.containsString("[main] INFO"));
+  }
+
+  @Test
+  @DisplayName("image default includes version")
+  void imageDefault() throws IOException {
+    String imageOutputFilename = "Config_imageDefault_stdout.txt";
+    String versionOutputFilename = "Config_version_stdout.txt";
+    List<String> commands = new ArrayList<>();
+    commands.add("terra config set image --default");
+    commands.add("terra config get-value image > " + imageOutputFilename);
+    commands.add("terra version > " + versionOutputFilename);
+    int exitCode = TestBashScript.runCommands(commands, Collections.emptyMap());
+    assertEquals(0, exitCode, "default image and version commands executed successfully");
+
+    // check that the default image id includes the version string
+    String imageDefaultOutput =
+        Files.readString(
+            TestBashScript.getOutputFilePath(imageOutputFilename), StandardCharsets.UTF_8);
+    String versionOutput =
+        Files.readString(
+            TestBashScript.getOutputFilePath(versionOutputFilename), StandardCharsets.UTF_8);
+    assertThat(
+        "server status output includes a DEBUG statement",
+        imageDefaultOutput,
+        CoreMatchers.containsString(versionOutput.trim()));
+  }
+}

--- a/src/test/java/integration/Config.java
+++ b/src/test/java/integration/Config.java
@@ -84,7 +84,7 @@ public class Config extends ClearContextIntegration {
         Files.readString(
             TestBashScript.getOutputFilePath(versionOutputFilename), StandardCharsets.UTF_8);
     assertThat(
-        "server status output includes a DEBUG statement",
+        "default image includes the version string",
         imageDefaultOutput,
         CoreMatchers.containsString(versionOutput.trim()));
   }

--- a/src/test/java/integration/Config.java
+++ b/src/test/java/integration/Config.java
@@ -30,7 +30,7 @@ public class Config extends ClearContextIntegration {
     // expect an error reading stdin: No line found
     assertEquals(3, exitCode, "script failed with an unexpected error");
 
-    // check that the auth login output includes the url and prompt to enter a code manually
+    // check that the auth login output includes a prompt to enter a code manually
     String authLoginOutput =
         Files.readString(
             TestBashScript.getOutputFilePath(authLoginOutputFilename), StandardCharsets.UTF_8);

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -1,0 +1,260 @@
+package unit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import bio.terra.cli.businessobject.Config.BrowserLaunchOption;
+import bio.terra.cli.businessobject.Config.CommandRunnerOption;
+import bio.terra.cli.serialization.userfacing.UFConfig;
+import bio.terra.cli.serialization.userfacing.UFLoggingConfig;
+import bio.terra.cli.serialization.userfacing.UFServer;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.cli.utils.Logger;
+import harness.TestCommand;
+import harness.baseclasses.SingleWorkspaceUnit;
+import java.io.IOException;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra config` commands. */
+@Tag("unit")
+public class Config extends SingleWorkspaceUnit {
+  @Test
+  @DisplayName("app-launch config affects how apps are launched")
+  void appLaunch() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // set the docker image id to an involid string
+    TestCommand.runCommandExpectSuccess("config", "set", "image", "--image=badimageid");
+
+    // `terra config set app-launch LOCAL_PROCESS`
+    TestCommand.runCommandExpectSuccess("config", "set", "app-launch", "LOCAL_PROCESS");
+
+    // apps launched via local process should not be affected
+    TestCommand.Result cmd =
+        TestCommand.runCommand("app", "execute", "echo", "$GOOGLE_CLOUD_PROJECT");
+    // cmd exit code can either be 0=success or 127=command not found if gcloud is not installed on
+    // this machine
+    assertThat(
+        "app execute with local process did not throw system exception",
+        cmd.exitCode == 0 || cmd.exitCode == 127);
+
+    // `terra config set app-launch DOCKER_CONTAINER`
+    TestCommand.runCommandExpectSuccess("config", "set", "app-launch", "DOCKER_CONTAINER");
+
+    // apps launched via docker container should error out
+    String stdErr =
+        TestCommand.runCommandExpectExitCode(3, "app", "execute", "echo", "$GOOGLE_CLOUD_PROJECT");
+    assertThat(
+        "docker image not found error returned",
+        stdErr,
+        CoreMatchers.containsString("No such image: badimageid"));
+  }
+
+  @Test
+  @DisplayName("resource limit config throws error if exceeded")
+  void resourceLimit() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // create 2 resources
+
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name1 = "resourceLimit_1";
+    String bucketName1 = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources", "create", "gcs-bucket", "--name=" + name1, "--bucket-name=" + bucketName1);
+
+    // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
+    String name2 = "resourceLimit_2";
+    String bucketName2 = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources", "create", "gcs-bucket", "--name=" + name2, "--bucket-name=" + bucketName2);
+
+    // set the resource limit to 1
+    TestCommand.runCommandExpectSuccess("config", "set", "resource-limit", "--max=1");
+
+    // expect an error when listing the 2 resources created above
+    String stdErr = TestCommand.runCommandExpectExitCode(2, "resources", "list");
+    assertThat(
+        "error thrown when resource limit exceeded",
+        stdErr,
+        CoreMatchers.containsString("Total number of resources (2) exceeds the CLI limit (1)"));
+  }
+
+  @Test
+  @DisplayName("config server set and server set are equivalent")
+  void server() throws IOException {
+    // `terra server set --name=terra-verily-dev`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=terra-verily-dev");
+
+    // `terra config get-value server`
+    UFServer getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFServer.class, "config", "get-value", "server");
+    assertEquals("terra-verily-dev", getValue.name, "server set affects config get-value");
+
+    // `terra config list`
+    UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals("terra-verily-dev", config.serverName, "server set affects config list");
+
+    // `terra config set server --name=terra-dev`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=terra-dev");
+
+    // `terra config get-value server`
+    getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFServer.class, "config", "get-value", "server");
+    assertEquals("terra-dev", getValue.name, "config set server affects config get-value");
+
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals("terra-dev", config.serverName, "config set server affects config list");
+  }
+
+  @Test
+  @DisplayName("config workspace set and workspace set are equivalent")
+  void workspace() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace create`
+    UFWorkspace workspace2 =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
+
+    // `terra config get-value workspace`
+    UFWorkspace getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "config", "get-value", "workspace");
+    assertEquals(workspace2.id, getValue.id, "workspace create affects config get-value");
+
+    // `terra config list`
+    UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(workspace2.id, config.workspaceId, "workspace create affects config list");
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra config get-value workspace`
+    getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "config", "get-value", "workspace");
+    assertEquals(getWorkspaceId(), getValue.id, "workspace set affects config get-value");
+
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(getWorkspaceId(), config.workspaceId, "workspace set affects config list");
+
+    // `terra config set workspace --id=$id2`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace2.id);
+
+    // `terra config get-value workspace`
+    getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "config", "get-value", "workspace");
+    assertEquals(workspace2.id, getValue.id, "config set workspace affects config get-value");
+
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(workspace2.id, config.workspaceId, "confg set workspace affects config list");
+
+    // `terra workspace delete --workspace `
+    TestCommand.runCommandExpectSuccess("workspace", "delete");
+
+    // `terra config get-value workspace`
+    getValue =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "config", "get-value", "workspace");
+    assertNull(getValue, "workspace delete affects config get-value");
+
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(null, config.workspaceId, "workspace delete affects config list");
+  }
+
+  @Test
+  @DisplayName("config get-value and list always match")
+  void getValueList() throws IOException {
+    // toggle each config value and make sure config get-value and list always match.
+    // server and workspace config properties are not included here because they are covered by
+    // tests above.
+
+    // `terra config set browser MANUAL`
+    TestCommand.runCommandExpectSuccess("config", "set", "browser", "MANUAL");
+    // `terra config get-value browser`
+    BrowserLaunchOption browser =
+        TestCommand.runAndParseCommandExpectSuccess(
+            BrowserLaunchOption.class, "config", "get-value", "browser");
+    assertEquals(BrowserLaunchOption.MANUAL, browser, "get-value reflects set for browser");
+    // `terra config list`
+    UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(
+        BrowserLaunchOption.MANUAL, config.browserLaunchOption, "list reflects set for browser");
+
+    // `terra config set app-launch LOCAL_PROCESS`
+    TestCommand.runCommandExpectSuccess("config", "set", "app-launch", "LOCAL_PROCESS");
+    // `terra config get-value app-launch`
+    CommandRunnerOption appLaunch =
+        TestCommand.runAndParseCommandExpectSuccess(
+            CommandRunnerOption.class, "config", "get-value", "app-launch");
+    assertEquals(
+        CommandRunnerOption.LOCAL_PROCESS, appLaunch, "get-value reflects set for app-launch");
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(
+        CommandRunnerOption.LOCAL_PROCESS,
+        config.commandRunnerOption,
+        "list reflects set for app-launch");
+
+    // `terra config set image badimageid123`
+    String imageId = "badimageid123";
+    TestCommand.runCommandExpectSuccess("config", "set", "image", "--image=" + imageId);
+    // `terra config get-value image`
+    String image =
+        TestCommand.runAndParseCommandExpectSuccess(String.class, "config", "get-value", "image");
+    assertEquals(imageId, image, "get-value reflects set for image");
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(imageId, config.dockerImageId, "list reflects set for image");
+
+    // `terra config set resource-limit 3`
+    TestCommand.runCommandExpectSuccess("config", "set", "resource-limit", "--max=3");
+    // `terra config get-value resource-limit`
+    int resourceLimit =
+        TestCommand.runAndParseCommandExpectSuccess(
+            Integer.class, "config", "get-value", "resource-limit");
+    assertEquals(3, resourceLimit, "get-value reflects set for resource-limit");
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(3, config.resourcesCacheSize, "list reflects set for resource-limit");
+
+    // `terra config set logging --console --level=ERROR`
+    TestCommand.runCommandExpectSuccess("config", "set", "logging", "--console", "--level=ERROR");
+    // `terra config set logging --file --level=TRACE`
+    TestCommand.runCommandExpectSuccess("config", "set", "logging", "--file", "--level=TRACE");
+    // `terra config get-value logging`
+    UFLoggingConfig logging =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFLoggingConfig.class, "config", "get-value", "logging");
+    assertEquals(
+        Logger.LogLevel.ERROR,
+        logging.consoleLoggingLevel,
+        "get-value reflects set for console logging");
+    assertEquals(
+        Logger.LogLevel.TRACE, logging.fileLoggingLevel, "get-value reflects set for file logging");
+    // `terra config list`
+    config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
+    assertEquals(
+        Logger.LogLevel.ERROR, config.consoleLoggingLevel, "list reflects set for console logging");
+    assertEquals(
+        Logger.LogLevel.TRACE, config.fileLoggingLevel, "list reflects set for file logging");
+  }
+}

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -1,9 +1,5 @@
 package unit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 import bio.terra.cli.businessobject.Config.BrowserLaunchOption;
 import bio.terra.cli.businessobject.Config.CommandRunnerOption;
 import bio.terra.cli.serialization.userfacing.UFConfig;
@@ -13,12 +9,17 @@ import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.utils.Logger;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
-import java.io.IOException;
-import java.util.UUID;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Tests for the `terra config` commands. */
 @Tag("unit")
@@ -177,7 +178,7 @@ public class Config extends SingleWorkspaceUnit {
 
     // `terra config list`
     config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals(null, config.workspaceId, "workspace delete affects config list");
+    assertNull(config.workspaceId, "workspace delete affects config list");
   }
 
   @Test

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -1,5 +1,9 @@
 package unit;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import bio.terra.cli.businessobject.Config.BrowserLaunchOption;
 import bio.terra.cli.businessobject.Config.CommandRunnerOption;
 import bio.terra.cli.serialization.userfacing.UFConfig;
@@ -9,17 +13,12 @@ import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.utils.Logger;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
+import java.io.IOException;
+import java.util.UUID;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Tests for the `terra config` commands. */
 @Tag("unit")

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -31,7 +31,7 @@ public class Config extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // set the docker image id to an involid string
+    // set the docker image id to an invalid string
     TestCommand.runCommandExpectSuccess("config", "set", "image", "--image=badimageid");
 
     // `terra config set app-launch LOCAL_PROCESS`
@@ -140,7 +140,7 @@ public class Config extends SingleWorkspaceUnit {
     UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
     assertEquals(workspace2.id, config.workspaceId, "workspace create affects config list");
 
-    // `terra workspace set --id=$id`
+    // `terra workspace set --id=$id1`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
     // `terra config get-value workspace`
@@ -154,7 +154,7 @@ public class Config extends SingleWorkspaceUnit {
     assertEquals(getWorkspaceId(), config.workspaceId, "workspace set affects config list");
 
     // `terra config set workspace --id=$id2`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace2.id);
+    TestCommand.runCommandExpectSuccess("config", "set", "workspace", "--id=" + workspace2.id);
 
     // `terra config get-value workspace`
     getValue =
@@ -166,7 +166,7 @@ public class Config extends SingleWorkspaceUnit {
     config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
     assertEquals(workspace2.id, config.workspaceId, "confg set workspace affects config list");
 
-    // `terra workspace delete --workspace `
+    // `terra workspace delete`
     TestCommand.runCommandExpectSuccess("workspace", "delete");
 
     // `terra config get-value workspace`
@@ -214,7 +214,7 @@ public class Config extends SingleWorkspaceUnit {
         config.commandRunnerOption,
         "list reflects set for app-launch");
 
-    // `terra config set image badimageid123`
+    // `terra config set image --image=badimageid123`
     String imageId = "badimageid123";
     TestCommand.runCommandExpectSuccess("config", "set", "image", "--image=" + imageId);
     // `terra config get-value image`
@@ -225,7 +225,7 @@ public class Config extends SingleWorkspaceUnit {
     config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
     assertEquals(imageId, config.dockerImageId, "list reflects set for image");
 
-    // `terra config set resource-limit 3`
+    // `terra config set resource-limit --max=3`
     TestCommand.runCommandExpectSuccess("config", "set", "resource-limit", "--max=3");
     // `terra config get-value resource-limit`
     int resourceLimit =


### PR DESCRIPTION
- Added workspace as a config property.
  - `terra config set workspace` is identical to the existing `terra workspace set`. This is just for convenience, similar to how there are identical `terra config set server` and `terra server set`.
  - `terra config get-value workspace` returns the current workspace id.
  - The current workspace id is now included in the output of `terra config list`.
- Added tests for the `config` group of commands.
- Fixed a bug where the `gcloud` project config property was not being restored if it was previously unset. This happened when executing apps in the LOCAL_PROCESS mode only.