### PR TITLE
PF-856: WSM `/status` changes. Tests for `server` commands.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         // terra libraries
         crlGoogleNotebooks="0.5.0"
         samClient = "0.1-9435410-SNAP"
-        workspaceManagerClient = "0.254.40-SNAPSHOT"
+        workspaceManagerClient = "0.254.41-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library
@@ -103,8 +103,7 @@ dependencies {
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.12:${samClient}"
     implementation "bio.terra.cloud-resource-lib:google-notebooks:${crlGoogleNotebooks}"
     implementation "bio.terra:datarepo-client:${dataRepoClient}"
-    // TODO (PF-853): put back to bio.terra:workspace-manager-client once WSM change goes in
-    implementation "bio.terra:client:${workspaceManagerClient}"
+    implementation "bio.terra:workspace-manager-client:${workspaceManagerClient}"
 
     compile "io.swagger.core.v3:swagger-annotations:${swaggerAnnotations}"
     compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         // terra libraries
         crlGoogleNotebooks="0.5.0"
         samClient = "0.1-9435410-SNAP"
-        workspaceManagerClient = "0.23.0-SNAPSHOT"
+        workspaceManagerClient = "0.254.40-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library
@@ -103,7 +103,8 @@ dependencies {
     implementation "org.broadinstitute.dsde.workbench:sam-client_2.12:${samClient}"
     implementation "bio.terra.cloud-resource-lib:google-notebooks:${crlGoogleNotebooks}"
     implementation "bio.terra:datarepo-client:${dataRepoClient}"
-    implementation "bio.terra:workspace-manager-client:${workspaceManagerClient}"
+    // TODO (PF-853): put back to bio.terra:workspace-manager-client once WSM change goes in
+    implementation "bio.terra:client:${workspaceManagerClient}"
 
     compile "io.swagger.core.v3:swagger-annotations:${swaggerAnnotations}"
     compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -98,12 +98,13 @@ public class Server {
       logger.error("Error getting SAM status.", ex);
     }
 
-    bio.terra.workspace.model.SystemStatus wsmStatus = null;
+    boolean wsmStatusIsOk = true;
     try {
-      wsmStatus = new WorkspaceManagerService(null).getStatus();
-      logger.info("WSM status: {}", wsmStatus);
+      new WorkspaceManagerService(null).getStatus();
+      logger.info("WSM status: {}", wsmStatusIsOk);
     } catch (Exception ex) {
       logger.error("Error getting WSM status.", ex);
+      wsmStatusIsOk = false;
     }
 
     RepositoryStatusModel tdrStatus = null;
@@ -115,7 +116,7 @@ public class Server {
     }
 
     return (samStatus != null && samStatus.getOk())
-        && (wsmStatus != null && wsmStatus.isOk())
+        && (wsmStatusIsOk)
         && (tdrStatus != null && tdrStatus.isOk());
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -116,7 +116,7 @@ public class Server {
     }
 
     return (samStatus != null && samStatus.getOk())
-        && (wsmStatusIsOk)
+        && wsmStatusIsOk
         && (tdrStatus != null && tdrStatus.isOk());
   }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -61,7 +61,6 @@ import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceList;
 import bio.terra.workspace.model.RoleBindingList;
-import bio.terra.workspace.model.SystemStatus;
 import bio.terra.workspace.model.SystemVersion;
 import bio.terra.workspace.model.UpdateWorkspaceRequestBody;
 import bio.terra.workspace.model.WorkspaceDescription;
@@ -170,11 +169,15 @@ public class WorkspaceManagerService {
    *
    * @return the Workspace Manager status object
    */
-  public SystemStatus getStatus() {
+  public void getStatus() {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     try {
-      return HttpUtils.callWithRetries(
-          () -> unauthenticatedApi.serviceStatus(), WorkspaceManagerService::isRetryable);
+      HttpUtils.callWithRetries(
+          () -> {
+            unauthenticatedApi.serviceStatus();
+            return null;
+          },
+          WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error getting Workspace Manager status", ex);
     }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -164,11 +164,7 @@ public class WorkspaceManagerService {
     }
   }
 
-  /**
-   * Call the Workspace Manager "/status" endpoint to get the status of the server.
-   *
-   * @return the Workspace Manager status object
-   */
+  /** Call the Workspace Manager "/status" endpoint to get the status of the server. */
   public void getStatus() {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     try {

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -127,10 +127,12 @@ public class TestCommand {
 
   /**
    * Helper method to get the absolute path to a file in the test/resources/testinputs directory.
+   *
+   * @param filename name of a file in the test/resources/testinputs directory
    */
-  public static Path getPathFromFileName(String name) {
+  public static Path getPathForTestInput(String filename) {
     Path filePath =
-        Path.of(TestCommand.class.getClassLoader().getResource("testinputs/" + name).getPath())
+        Path.of(TestCommand.class.getClassLoader().getResource("testinputs/" + filename).getPath())
             .toAbsolutePath();
     return filePath;
   }

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -122,5 +123,15 @@ public class TestCommand {
     private <T> T readObjectFromStdOut(TypeReference<T> objectType) throws JsonProcessingException {
       return objectMapper.readValue(stdOut, objectType);
     }
+  }
+
+  /**
+   * Helper method to get the absolute path to a file in the test/resources/testinputs directory.
+   */
+  public static Path getPathFromFileName(String name) {
+    Path filePath =
+        Path.of(TestCommand.class.getClassLoader().getResource("testinputs/" + name).getPath())
+            .toAbsolutePath();
+    return filePath;
   }
 }

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -59,11 +59,12 @@ public class Server extends ClearContextUnit {
   }
 
   @Test
-  @DisplayName(
-      "server set takes a file path (intended to help debugging without recompiling, not for normal operation)")
+  @DisplayName("server set takes a file path")
   void serverSetTakesFile() throws JsonProcessingException {
+    // NOTE: this feature is intended to help debugging without requiring a recompile, not for
+    // normal operation
     // `terra server set --name=$filepath`
-    Path serverFilePath = TestCommand.getPathFromFileName("BadServer.json");
+    Path serverFilePath = TestCommand.getPathForTestInput("BadServer.json");
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverFilePath.toString());
 
     // `terra status`

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -36,10 +36,16 @@ public class Server extends ClearContextUnit {
     assertEquals(serverName1, status.server.name, "status reflects server set");
 
     // `terra server list`
+    // NOTE: there is a JSON output for the terra server list command, but it doesn't flag the
+    // current server. the text output puts a "*" next to the current server. that's the reason I'm
+    // checking the text output here.
     TestCommand.Result cmd = TestCommand.runCommand("server", "list");
     assertEquals(0, cmd.exitCode, "server list returned successfully");
+    // the regex below matches the starred server, which indicates it's the current one (e.g. " *
+    // terra-dev")
+    String asteriskAtStartOfLine = "(?s).*\\*\\s+";
     assertTrue(
-        cmd.stdOut.matches("(?s).*\\*\\s+" + serverName1 + ".*"),
+        cmd.stdOut.matches(asteriskAtStartOfLine + serverName1 + ".*"),
         "server list flags correct current server (1)");
 
     // `terra server set --name=$serverName2`
@@ -54,7 +60,7 @@ public class Server extends ClearContextUnit {
     cmd = TestCommand.runCommand("server", "list");
     assertEquals(0, cmd.exitCode, "server list returned successfully");
     assertTrue(
-        cmd.stdOut.matches("(?s).*\\*\\s+" + serverName2 + ".*"),
+        cmd.stdOut.matches(asteriskAtStartOfLine + serverName2 + ".*"),
         "server list flags correct current server (2)");
   }
 

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -1,0 +1,86 @@
+package unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.cli.serialization.userfacing.UFStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import harness.TestCommand;
+import harness.baseclasses.ClearContextUnit;
+import java.nio.file.Path;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra server` commands. */
+@Tag("unit")
+public class Server extends ClearContextUnit {
+  @Test
+  @DisplayName("server status succeeds")
+  void serverStatusSucceeds() throws JsonProcessingException {
+    // `terra server status`
+    String statusMsg =
+        TestCommand.runAndParseCommandExpectSuccess(String.class, "server", "status");
+    assertEquals("OKAY", statusMsg, "server status returns successfully");
+  }
+
+  @Test
+  @DisplayName("status, server list reflect server set")
+  void statusListReflectSet() throws JsonProcessingException {
+    // `terra server set --name=$serverName1`
+    String serverName1 = "terra-verily-dev";
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName1);
+
+    // `terra status`
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(serverName1, status.server.name, "status reflects server set");
+
+    // `terra server list`
+    TestCommand.Result cmd = TestCommand.runCommand("server", "list");
+    assertEquals(0, cmd.exitCode, "server list returned successfully");
+    assertTrue(
+        cmd.stdOut.matches("(?s).*\\*\\s+" + serverName1 + ".*"),
+        "server list flags correct current server (1)");
+
+    // `terra server set --name=$serverName2`
+    String serverName2 = "terra-dev";
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName2);
+
+    // `terra status`
+    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(serverName2, status.server.name, "status reflects server set");
+
+    // `terra server list`
+    cmd = TestCommand.runCommand("server", "list");
+    assertEquals(0, cmd.exitCode, "server list returned successfully");
+    assertTrue(
+        cmd.stdOut.matches("(?s).*\\*\\s+" + serverName2 + ".*"),
+        "server list flags correct current server (2)");
+  }
+
+  @Test
+  @DisplayName(
+      "server set takes a file path (intended to help debugging without recompiling, not for normal operation)")
+  void serverSetTakesFile() throws JsonProcessingException {
+    // `terra server set --name=$filepath`
+    Path serverFilePath = TestCommand.getPathFromFileName("BadServer.json");
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverFilePath.toString());
+
+    // `terra status`
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals("bad-server", status.server.name, "status reflects server set");
+
+    // `terra server status`
+    String statusMsg =
+        TestCommand.runAndParseCommandExpectSuccess(String.class, "server", "status");
+    assertEquals("ERROR CONNECTING", statusMsg, "server status returns error");
+
+    // `terra server set --name=terra-dev`
+    String serverName = "terra-dev";
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName);
+
+    // `terra status`
+    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(serverName, status.server.name, "status reflects server set");
+  }
+}

--- a/src/test/resources/testinputs/BadServer.json
+++ b/src/test/resources/testinputs/BadServer.json
@@ -1,0 +1,8 @@
+{
+  "name": "bad-server",
+  "description": "Server definition with invalid URLs.",
+
+  "dataRepoUri": "https://jade.datarepo-BADURL.broadinstitute.org",
+  "samUri": "https://sam.dsde-BADURL.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.BADURL.integ.envs.broadinstitute.org"
+}

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -26,7 +26,7 @@ docker pull $defaultDockerImage
 
 echo "Setting the server to its current value, to pull any changes"
 currentServer=$(terra config get-value server)
-terra config set server $currentServer
+terra config set server --name=$currentServer
 
 echo "Making all 'tools' scripts executable"
 chmod a+x tools/*


### PR DESCRIPTION
- Bumped the WSM client library to a version that includes recent changes to the `/status` endpoint.
- Changed the WSM `/status` endpoint call to no longer expect a return object.

- Added tests for the `server` group of commands.
- Fixed a bug in the `local-dev.sh` setup script when setting the current server.