### PR TITLE
PF-797: Tests for `group` and `spend` commands.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,27 +177,9 @@ The CLI only uses the test users defined in the `TestUsers` enum class. The list
 - Have permission to use the default WSM spend profile directly on the SAM resource.
 - Do not have permission to use the default WSM spend profile.
 
-Below is the script used to setup the initial set of test users on the SAM dev instance.
-```
-# create the cli-test-users SAM group and add it as a user on the spend profile
-terra groups create cli-test-users
-terra spend enable --policy=user $(terra groups describe cli-test-users)
-
-# penelope is an owner on both the cli-test-users group and the spend profile resource
-terra groups add-user --group=cli-test-users --policy=admin Penelope.TwilightsHammer@test.firecloud.org
-terra spend enable --policy=owner Penelope.TwilightsHammer@test.firecloud.org
-
-# john and lily are members of the cli-test-users group
-terra groups add-user --group=cli-test-users --policy=member John.Whiteclaw@test.firecloud.org
-terra groups add-user --group=cli-test-users --policy=member Lily.Shadowmoon@test.firecloud.org
-
-# brooklyn and noah are users of the spend profile resource
-terra spend enable --policy=user Brooklyn.Thunderlord@test.firecloud.org
-terra spend enable --policy=user Noah.Frostwolf@test.firecloud.org
-
-# ethan has no spend profile access
-# do nothing: Ethan.Bonechewer@test.firecloud.org
-```
+The script to setup the initial set of test users on the SAM dev instance is in `tools/setup-test-users.sh`.
+Note that the current testing setup uses pre-defined users in the `test.firecloud.org` domain. There would be
+some refactoring involved in varying this domain also.
 
 You can see the available test users on the users admin [page](https://admin.google.com/ac/users) with a
 `test.firecloud.org` GSuite account.

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -41,6 +41,9 @@ public enum TestUsers {
   public final String email;
   public final SpendEnabled spendEnabled;
 
+  // name of the group that includes CLI test users and has spend profile access
+  public static final String CLI_TEST_USERS_GROUP_NAME = "cli-test-users";
+
   TestUsers(String email, SpendEnabled spendEnabled) {
     this.email = email;
     this.spendEnabled = spendEnabled;
@@ -132,10 +135,18 @@ public enum TestUsers {
     return chooseTestUser(Set.of(SpendEnabled.values()));
   }
 
-  /** Randomly chooses a test user with spend profile access. */
+  /** Randomly chooses a test user with spend profile access, but without owner privileges. */
   public static TestUsers chooseTestUserWithSpendAccess() {
     return chooseTestUser(
         Set.of(new SpendEnabled[] {SpendEnabled.CLI_TEST_USERS_GROUP, SpendEnabled.DIRECTLY}));
+  }
+
+  /**
+   * Randomly chooses a test user who is a spend profile admin and an admin of the SAM cli-testers
+   * group.
+   */
+  public static TestUsers chooseTestUserWithOwnerAccess() {
+    return chooseTestUser(Set.of(SpendEnabled.OWNER));
   }
 
   /** Randomly chooses a test user without spend profile access. */

--- a/src/test/java/harness/utils/SamGroups.java
+++ b/src/test/java/harness/utils/SamGroups.java
@@ -1,0 +1,46 @@
+package harness.utils;
+
+import harness.TestCommand;
+import harness.TestUsers;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Utility class for tracking groups created by a test class, and then trying to delete them all at
+ * the end.
+ */
+public class SamGroups {
+  // keep a map of groups created by tests, so we can try to clean them up
+  // group name -> test user that created it
+  private Map<String, TestUsers> trackedGroups = new HashMap<>();
+
+  private static final Random RANDOM = new Random();
+
+  /** Try to delete each group that was tracked here. */
+  public void deleteAllTrackedGroups() throws IOException {
+    for (Map.Entry<String, TestUsers> groupCreated : trackedGroups.entrySet()) {
+      groupCreated.getValue().login();
+      TestCommand.Result cmd =
+          TestCommand.runCommand("groups", "delete", "--name=" + groupCreated.getKey());
+      if (cmd.exitCode == 0) {
+        System.out.println("group was not cleaned up by test: " + groupCreated.getKey());
+      }
+    }
+  }
+
+  /** Add a group to be tracked. */
+  public void trackGroup(String name, TestUsers admin) {
+    trackedGroups.put(name, admin);
+  }
+
+  /** Helper method to generate a random group name. */
+  public static String randomGroupName() {
+    return "terraCLI_" + RANDOM.nextInt(Integer.MAX_VALUE);
+  }
+
+  public Map<String, TestUsers> getTrackedGroups() {
+    return trackedGroups;
+  }
+}

--- a/src/test/java/harness/utils/SamGroups.java
+++ b/src/test/java/harness/utils/SamGroups.java
@@ -25,6 +25,7 @@ public class SamGroups {
       TestCommand.Result cmd =
           TestCommand.runCommand("groups", "delete", "--name=" + groupCreated.getKey());
       if (cmd.exitCode == 0) {
+        // log if a test didn't clean up a group
         System.out.println("group was not cleaned up by test: " + groupCreated.getKey());
       }
     }

--- a/src/test/java/unit/Group.java
+++ b/src/test/java/unit/Group.java
@@ -1,0 +1,318 @@
+package unit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.cli.serialization.userfacing.UFGroup;
+import bio.terra.cli.serialization.userfacing.UFGroupMember;
+import bio.terra.cli.service.SamService.GroupPolicy;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import harness.TestCommand;
+import harness.TestUsers;
+import harness.baseclasses.ClearContextUnit;
+import harness.utils.SamGroups;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra group` commands. */
+@Tag("unit")
+public class Group extends ClearContextUnit {
+  SamGroups trackedGroups = new SamGroups();
+
+  @AfterAll
+  void cleanupOnce() throws IOException {
+    // try to delete each group that was created by a method in this class
+    trackedGroups.deleteAllTrackedGroups();
+  }
+
+  @Test
+  @DisplayName("list, describe, list-users reflect creating and deleting a group")
+  void listDescribeUsersReflectCreateDelete() throws IOException {
+    TestUsers testUser = TestUsers.chooseTestUser();
+    testUser.login();
+
+    // `terra groups create --name=$name`
+    String name = SamGroups.randomGroupName();
+    UFGroup groupCreated =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGroup.class, "groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up in case this test method fails
+    trackedGroups.trackGroup(name, testUser);
+
+    // check that the name and email match
+    assertEquals(name, groupCreated.name, "group name matches after create");
+    assertThat(
+        "group email contains the name", groupCreated.email, CoreMatchers.containsString(name));
+    assertThat(
+        "group creator is an admin", groupCreated.currentUserPolicies.contains(GroupPolicy.ADMIN));
+
+    // `terra groups list-users --name=$name`
+    // check that the group creator is included in the list and is an admin
+    expectListedMemberWithPolicies(name, testUser.email, GroupPolicy.ADMIN);
+
+    // `terra groups list`
+    List<UFGroup> groupList =
+        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "groups", "list");
+
+    // check that the listed group matches the created one
+    Optional<UFGroup> matchedGroup =
+        groupList.stream().filter(listedGroup -> listedGroup.name.equals(name)).findAny();
+    assertTrue(matchedGroup.isPresent(), "group appears in list after create");
+    assertEquals(name, matchedGroup.get().name, "group name matches list output after create");
+    assertEquals(
+        groupCreated.email,
+        matchedGroup.get().email,
+        "group email matches list output after create");
+    assertTrue(
+        matchedGroup.get().currentUserPolicies.contains(GroupPolicy.ADMIN),
+        "group policies for current user matches list output after create");
+
+    // `terra groups describe --name=$name`
+    UFGroup groupDescribed =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGroup.class, "groups", "describe", "--name=" + name);
+
+    // check that the described group matches the created one
+    assertEquals(name, groupDescribed.name, "group name matches describe output after create");
+    assertEquals(
+        groupCreated.email,
+        groupDescribed.email,
+        "group email matches describe output after create");
+    assertTrue(
+        groupDescribed.currentUserPolicies.contains(GroupPolicy.ADMIN),
+        "group policies for current user matches describe output after create");
+
+    // `terra groups delete --name=$name`
+    UFGroup groupDeleted =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGroup.class, "groups", "delete", "--name=" + name);
+
+    // check that the name and email match, and that the creator was an admin
+    assertEquals(name, groupDeleted.name, "group name matches after delete");
+    assertThat(
+        "group email contained the name", groupDeleted.email, CoreMatchers.containsString(name));
+    assertThat(
+        "group creator was an admin", groupDeleted.currentUserPolicies.contains(GroupPolicy.ADMIN));
+
+    // `terra groups list`
+    groupList =
+        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "groups", "list");
+
+    // check that the group is not included in the list output
+    matchedGroup =
+        groupList.stream().filter(listedGroup -> listedGroup.name.equals(name)).findAny();
+    assertTrue(matchedGroup.isEmpty(), "group does not appear in list after delete");
+  }
+
+  @Test
+  @DisplayName("describe, delete, list-users, add-user, remove-user all fail with invalid group")
+  void invalidGroup() throws IOException {
+    TestUsers.chooseTestUser().login();
+    String badName = "terraCLI_nonexistentGroup";
+
+    // `terra groups describe --name=$name`
+    TestCommand.Result cmd = TestCommand.runCommand("groups", "describe", "--name=" + badName);
+    expectGroupNotFound(cmd);
+
+    // `terra groups delete --name=$name`
+    cmd = TestCommand.runCommand("groups", "delete", "--name=" + badName);
+    expectGroupNotFound(cmd);
+
+    // `terra groups list-users --name=$name`
+    cmd = TestCommand.runCommand("groups", "list-users", "--name=" + badName);
+    expectGroupNotFound(cmd);
+
+    // `terra groups add-user --name=$name`
+    cmd =
+        TestCommand.runCommand(
+            "groups",
+            "add-user",
+            "--name=" + badName,
+            "--email=" + TestUsers.chooseTestUser().email,
+            "--policy=MEMBER");
+    expectGroupNotFound(cmd);
+
+    // `terra groups remove-user --name=$name`
+    cmd =
+        TestCommand.runCommand(
+            "groups",
+            "remove-user",
+            "--name=" + badName,
+            "--email=" + TestUsers.chooseTestUser().email,
+            "--policy=MEMBER");
+    expectGroupNotFound(cmd);
+  }
+
+  @Test
+  @DisplayName("only an admin, not a member, can modify a group")
+  void onlyAdminCanModifyGroup() throws IOException {
+    TestUsers groupCreator = TestUsers.chooseTestUser();
+    groupCreator.login();
+
+    // `terra groups create --name=$name`
+    String name = SamGroups.randomGroupName();
+    TestCommand.runCommandExpectSuccess("groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up in case this test method fails
+    trackedGroups.trackGroup(name, groupCreator);
+
+    // `terra groups add-user --name=$name`
+    TestUsers groupMember = TestUsers.chooseTestUserWhoIsNot(groupCreator);
+    TestCommand.runCommandExpectSuccess(
+        "groups", "add-user", "--name=" + name, "--email=" + groupMember.email, "--policy=MEMBER");
+
+    // `terra groups delete --name=$name` as member
+    groupMember.login();
+    TestCommand.runCommandExpectExitCode(2, "groups", "delete", "--name=" + name);
+
+    // `terra groups add-user --email=$email --policy=ADMIN` as member
+    TestCommand.runCommandExpectExitCode(
+        2,
+        "groups",
+        "add-user",
+        "--name=" + name,
+        "--email=" + groupMember.email,
+        "--policy=ADMIN");
+
+    // `terra groups remove-user --email=$email --policy=OWNER` as member
+    TestCommand.runCommandExpectExitCode(
+        2,
+        "groups",
+        "remove-user",
+        "--name=" + name,
+        "--email=" + groupMember.email,
+        "--policy=MEMBER");
+
+    // `terra groups delete --name=$name` as admin
+    groupCreator.login();
+    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("list-users reflects adding and removing a user")
+  void listUsersReflectsAddRemove() throws IOException {
+    TestUsers groupCreator = TestUsers.chooseTestUser();
+    groupCreator.login();
+
+    // `terra groups create --name=$name`
+    String name = SamGroups.randomGroupName();
+    TestCommand.runCommandExpectSuccess("groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up in case this test method fails
+    trackedGroups.trackGroup(name, groupCreator);
+
+    // `terra groups add-user --name=$name --email=$email --policy=MEMBER`
+    TestUsers groupMember = TestUsers.chooseTestUserWhoIsNot(groupCreator);
+    TestCommand.runCommandExpectSuccess(
+        "groups", "add-user", "--name=" + name, "--email=" + groupMember.email, "--policy=MEMBER");
+
+    // check that group member is included in the list-users output with one policy
+    expectListedMemberWithPolicies(name, groupMember.email, GroupPolicy.MEMBER);
+
+    // `terra groups add-user --name=$name --email=$email --policy=ADMIN`
+    TestCommand.runCommandExpectSuccess(
+        "groups", "add-user", "--name=" + name, "--email=" + groupMember.email, "--policy=ADMIN");
+
+    // check that group member is included in the list-users output with two policies
+    expectListedMemberWithPolicies(name, groupMember.email, GroupPolicy.MEMBER, GroupPolicy.ADMIN);
+
+    // `terra groups remove-user --name=$name --email=$email --policy=MEMBER`
+    TestCommand.runCommandExpectSuccess(
+        "groups",
+        "remove-user",
+        "--name=" + name,
+        "--email=" + groupMember.email,
+        "--policy=MEMBER");
+
+    // check that group member is included in the list-users output with one policy
+    expectListedMemberWithPolicies(name, groupMember.email, GroupPolicy.ADMIN);
+
+    // `terra groups remove-user --name=$name --email=$email --policy=ADMIN`
+    TestCommand.runCommandExpectSuccess(
+        "groups",
+        "remove-user",
+        "--name=" + name,
+        "--email=" + groupMember.email,
+        "--policy=ADMIN");
+
+    // check that group member is no longer included in the list-users output
+    Optional<UFGroupMember> listedGroupMember = listMembersWithEmail(name, groupMember.email);
+    assertTrue(listedGroupMember.isEmpty(), "test user is no longer included in members list");
+
+    // check that the group creator is included in the list-users output
+    expectListedMemberWithPolicies(name, groupCreator.email, GroupPolicy.ADMIN);
+
+    // `terra groups delete --name=$name`
+    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name);
+  }
+
+  @Test
+  @DisplayName("cli-testers group includes the appropriate test users")
+  void cliTestersGroupMembership() throws IOException {
+    TestUsers groupAdmin = TestUsers.chooseTestUserWithOwnerAccess();
+    groupAdmin.login();
+
+    List<TestUsers> expectedGroupMembers =
+        Arrays.asList(TestUsers.values()).stream()
+            .filter(
+                testUser ->
+                    testUser.spendEnabled.equals(TestUsers.SpendEnabled.CLI_TEST_USERS_GROUP))
+            .collect(Collectors.toList());
+    for (TestUsers expectedGroupMember : expectedGroupMembers) {
+      // check that the test user is included in the list-users output
+      expectListedMemberWithPolicies(
+          TestUsers.CLI_TEST_USERS_GROUP_NAME, expectedGroupMember.email, GroupPolicy.MEMBER);
+    }
+  }
+
+  /** Helper method to check that a command returned a group not found error. */
+  private static void expectGroupNotFound(TestCommand.Result cmd) {
+    assertEquals(1, cmd.exitCode, "specifying a nonexistent group threw a UserActionableException");
+    assertThat(
+        "error message indicates group not found",
+        cmd.stdErr,
+        CoreMatchers.containsString("No group found with this name"));
+  }
+
+  /**
+   * Helper method to check that a group member is included in the list with the specified policies.
+   */
+  private static void expectListedMemberWithPolicies(
+      String group, String email, GroupPolicy... policies) throws JsonProcessingException {
+    Optional<UFGroupMember> groupMember = listMembersWithEmail(group, email);
+    assertTrue(groupMember.isPresent(), "test user is in members list");
+    assertEquals(
+        policies.length,
+        groupMember.get().policies.size(),
+        "test user has the right number of policies");
+    assertTrue(
+        groupMember.get().policies.containsAll(Arrays.asList(policies)),
+        "test user has the right policies");
+  }
+
+  /**
+   * Helper method to call `terra groups list-users` and filter the results on the specified user
+   * email.
+   */
+  static Optional<UFGroupMember> listMembersWithEmail(String group, String email)
+      throws JsonProcessingException {
+    // `terra groups list-users --format=json`
+    List<UFGroupMember> listGroupMembers =
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "groups", "list-users", "--name=" + group);
+
+    // find the user in the list
+    return listGroupMembers.stream().filter(user -> user.email.equalsIgnoreCase(email)).findAny();
+  }
+}

--- a/src/test/java/unit/Group.java
+++ b/src/test/java/unit/Group.java
@@ -260,6 +260,8 @@ public class Group extends ClearContextUnit {
   @Test
   @DisplayName("cli-testers group includes the appropriate test users")
   void cliTestersGroupMembership() throws IOException {
+    // NOTE: this test is checking that test users and spend access are setup as expected for CLI
+    // testing. it's not really testing CLI functionality specifically.
     TestUsers groupAdmin = TestUsers.chooseTestUserWithOwnerAccess();
     groupAdmin.login();
 

--- a/src/test/java/unit/Group.java
+++ b/src/test/java/unit/Group.java
@@ -185,7 +185,7 @@ public class Group extends ClearContextUnit {
         "--email=" + groupMember.email,
         "--policy=ADMIN");
 
-    // `terra groups remove-user --email=$email --policy=OWNER` as member
+    // `terra groups remove-user --email=$email --policy=MEMBER` as member
     TestCommand.runCommandExpectExitCode(
         2,
         "groups",

--- a/src/test/java/unit/SpendProfileUser.java
+++ b/src/test/java/unit/SpendProfileUser.java
@@ -1,0 +1,197 @@
+package unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.cli.serialization.userfacing.UFGroup;
+import bio.terra.cli.serialization.userfacing.UFSpendProfileUser;
+import bio.terra.cli.service.SpendProfileManagerService.SpendProfilePolicy;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import harness.TestCommand;
+import harness.TestUsers;
+import harness.baseclasses.ClearContextUnit;
+import harness.utils.SamGroups;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra spend` commands. */
+@Tag("unit")
+public class SpendProfileUser extends ClearContextUnit {
+  // only an owner on the spend profile can disable emails
+  TestUsers spendProfileOwner = TestUsers.chooseTestUserWithOwnerAccess();
+
+  SamGroups trackedGroups = new SamGroups();
+
+  @AfterAll
+  void cleanupOnce() throws IOException, InterruptedException {
+    spendProfileOwner.login();
+
+    // try to disable spend for each group that was created by a method in this class
+    for (Map.Entry<String, TestUsers> groupNameToCreator :
+        trackedGroups.getTrackedGroups().entrySet()) {
+      UFGroup groupInfo =
+          TestCommand.runAndParseCommandExpectSuccess(
+              UFGroup.class, "groups", "describe", "--name=" + groupNameToCreator.getKey());
+      TestCommand.runCommand("spend", "disable", "--email=" + groupInfo.email, "--policy=USER");
+      TestCommand.runCommand("spend", "disable", "--email=" + groupInfo.email, "--policy=OWNER");
+    }
+
+    // then try to delete the groups
+    trackedGroups.deleteAllTrackedGroups();
+  }
+
+  @Test
+  @DisplayName("list-users reflects enabling and disabling users")
+  void listUsersReflectsEnableDisable() throws IOException {
+    // get an email to try and add
+    String testEmail = generateSamGroupForEmail();
+
+    // use a test user that is an owner to grant spend access to the test email
+    TestUsers spendProfileOwner = TestUsers.chooseTestUserWithOwnerAccess();
+    spendProfileOwner.login();
+
+    // `terra spend enable --email=$testEmail --policy=USER`
+    TestCommand.runCommandExpectSuccess("spend", "enable", "--email=" + testEmail, "--policy=USER");
+
+    // check that the test email is included in the list-users output
+    expectListedUserWithPolicies(testEmail, SpendProfilePolicy.USER);
+
+    // `terra spend disable --email=$testEmail --policy=USER`
+    TestCommand.runCommandExpectSuccess(
+        "spend", "disable", "--email=" + testEmail, "--policy=USER");
+
+    // check that the test email is not included in the list-users output
+    Optional<UFSpendProfileUser> listUsersOutput = listUsersWithEmail(testEmail);
+    assertTrue(
+        listUsersOutput.isEmpty(),
+        "user is not included in the test-users output after having their spend access disabled");
+  }
+
+  @Test
+  @DisplayName("only users who are an admin on the spend profile can enable and disable others")
+  void onlyAdminCanEnableDisable() throws IOException {
+    // get an email to try and add
+    String testEmail = generateSamGroupForEmail();
+
+    // check that none of the test users can enable this email
+    for (TestUsers testUser : TestUsers.values()) {
+      if (testUser.spendEnabled.equals(TestUsers.SpendEnabled.OWNER)) {
+        continue;
+      }
+      testUser.login();
+
+      // `terra spend enable --email=$testEmail --policy=USER`
+      TestCommand.runCommandExpectExitCode(
+          2, "spend", "enable", "--email=" + testEmail, "--policy=USER");
+    }
+
+    // use a test user that is an owner to grant spend access to the test email
+    TestUsers spendProfileOwner = TestUsers.chooseTestUserWithOwnerAccess();
+    spendProfileOwner.login();
+    TestCommand.runCommandExpectSuccess("spend", "enable", "--email=" + testEmail, "--policy=USER");
+
+    // check that none of the test users can disable this email
+    for (TestUsers testUser : TestUsers.values()) {
+      if (testUser.spendEnabled.equals(TestUsers.SpendEnabled.OWNER)) {
+        continue;
+      }
+      testUser.login();
+
+      // `terra spend disable --email=$testEmail --policy=USER`
+      TestCommand.runCommandExpectExitCode(
+          2, "spend", "disable", "--email=" + testEmail, "--policy=USER");
+    }
+
+    // use a test user that is an owner to remove spend access for the test email
+    spendProfileOwner.login();
+    TestCommand.runCommandExpectSuccess(
+        "spend", "disable", "--email=" + testEmail, "--policy=USER");
+  }
+
+  @Test
+  @DisplayName("spend profile includes cli-testers group and the appropriate test users")
+  void testUsersSpendProfileMembership() throws IOException {
+    // only an owner on the spend profile can list enabled users
+    TestUsers spendProfileOwner = TestUsers.chooseTestUserWithOwnerAccess();
+    spendProfileOwner.login();
+
+    // check that the cli-testers group is included in the list-users output
+    UFGroup cliTestersGroup =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGroup.class, "groups", "describe", "--name=" + TestUsers.CLI_TEST_USERS_GROUP_NAME);
+    expectListedUserWithPolicies(cliTestersGroup.email, SpendProfilePolicy.USER);
+
+    // check that each test user who is enabled on the spend profile directly, is included in the
+    // list-users output
+    List<TestUsers> expectedSpendUsers =
+        Arrays.asList(TestUsers.values()).stream()
+            .filter(testUser -> testUser.spendEnabled.equals(TestUsers.SpendEnabled.DIRECTLY))
+            .collect(Collectors.toList());
+    for (TestUsers expectedSpendUser : expectedSpendUsers) {
+      expectListedUserWithPolicies(expectedSpendUser.email, SpendProfilePolicy.USER);
+    }
+  }
+
+  /**
+   * Helper method to check that a spend profile user is included in the list with the specified
+   * policies.
+   */
+  private static void expectListedUserWithPolicies(String email, SpendProfilePolicy... policies)
+      throws JsonProcessingException {
+    Optional<UFSpendProfileUser> spendUser = listUsersWithEmail(email);
+    assertTrue(spendUser.isPresent(), "test user is in spend users list");
+    assertEquals(
+        policies.length,
+        spendUser.get().policies.size(),
+        "test user has the right number of policies");
+    assertTrue(
+        spendUser.get().policies.containsAll(Arrays.asList(policies)),
+        "test user has the right policies");
+  }
+
+  /**
+   * Helper method to call `terra spend list-users` and filter the results on the specified user
+   * email.
+   */
+  static Optional<UFSpendProfileUser> listUsersWithEmail(String email)
+      throws JsonProcessingException {
+    // `terra spend list-users --format=json`
+    List<UFSpendProfileUser> listSpendUsers =
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "spend", "list-users");
+
+    // find the user in the list
+    return listSpendUsers.stream().filter(user -> user.email.equalsIgnoreCase(email)).findAny();
+  }
+
+  /**
+   * Create a SAM group, so we can use its generated email. This is a workaround to our current use
+   * of hard-coded test users. We don't want to use the CLI test users here because then this test
+   * could not be run simultaneously with other tests.
+   *
+   * @return the generated group's email
+   */
+  private String generateSamGroupForEmail() throws IOException {
+    String name = SamGroups.randomGroupName();
+    spendProfileOwner.login();
+
+    // `terra groups create --name=$name`
+    UFGroup groupCreated =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGroup.class, "groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up in case this test method fails
+    trackedGroups.trackGroup(name, spendProfileOwner);
+
+    return groupCreated.email;
+  }
+}

--- a/src/test/java/unit/SpendProfileUser.java
+++ b/src/test/java/unit/SpendProfileUser.java
@@ -120,6 +120,8 @@ public class SpendProfileUser extends ClearContextUnit {
   @Test
   @DisplayName("spend profile includes cli-testers group and the appropriate test users")
   void testUsersSpendProfileMembership() throws IOException {
+    // NOTE: this test is checking that test users and spend access are setup as expected for CLI
+    // testing. it's not really testing CLI functionality specifically.
     // only an owner on the spend profile can list enabled users
     TestUsers spendProfileOwner = TestUsers.chooseTestUserWithOwnerAccess();
     spendProfileOwner.login();

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+## This script sets up users for running CLI tests. It only needs to be run once per SAM instance.
+## Keep this script in sync with the harness.TestUsers class in the src/test/java directory.
+## Dependencies: jq
+## Usage: ./setup-test-users.sh
+
+terra=/Users/marikomedlock/Workspaces/terra-cli/build/install/terra-cli/bin/terra
+
+# create the cli-test-users SAM group and add it as a user on the spend profile
+echo
+echo "Creating the SAM group for CLI test users."
+groupName="cli-test-users"
+$terra groups create --name=$groupName
+groupEmail=$($terra groups describe --name=$groupName --format=json | jq -r .email)
+
+echo
+echo "Granting the SAM group USER access to the spend profile."
+$terra spend enable --policy=USER --email=$groupEmail
+
+# penelope is an owner on both the cli-test-users group and the spend profile resource
+echo
+echo "Adding Penelope.TwilightsHammer as an ADMIN of the SAM group."
+$terra groups add-user --name=$groupName --policy=ADMIN --email=Penelope.TwilightsHammer@test.firecloud.org
+
+echo
+echo "Granting Penelope.TwilightsHammer OWNER access to the spend profile."
+$terra spend enable --policy=OWNER --email=Penelope.TwilightsHammer@test.firecloud.org
+
+# john and lily are members of the cli-test-users group
+echo
+echo "Adding John.Whiteclaw as a MEMBER of the SAM group."
+$terra groups add-user --name=$groupName --policy=MEMBER --email=John.Whiteclaw@test.firecloud.org
+echo
+echo "Adding Lily.Shadowmoon as a MEMBER of the SAM group."
+$terra groups add-user --name=$groupName --policy=MEMBER --email=Lily.Shadowmoon@test.firecloud.org
+
+# brooklyn and noah are users of the spend profile resource
+echo
+echo "Granting Brooklyn.Thunderlord USER access to the spend profile."
+$terra spend enable --policy=USER --email=Brooklyn.Thunderlord@test.firecloud.org
+echo
+echo "Granting Noah.Frostwolf USER access to the spend profile."
+$terra spend enable --policy=USER --email=Noah.Frostwolf@test.firecloud.org
+
+# ethan has no spend profile access
+# do nothing: Ethan.Bonechewer@test.firecloud.org


### PR DESCRIPTION
- Tests for the `group` commands, which manage SAM groups.
- Tests for the `spend` commands, which manage access to the WSM default spend profile.
- For testing the `spend` commands, I didn't want to use any of the test users, because that could cause problems if tests get run simultaneously. Instead, I generate a SAM group, use its accompanying email in the tests, then delete the group. This is just a workaround until we have a way to generate test users and clean them up in SAM afterwards.