### PR TITLE
PF-871: Remove email lowercasing in tests that create private controlled resources.

### DIFF
--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.BeforeAll;
  * debugging a particular failure.
  */
 public class SingleWorkspaceUnit extends ClearContextUnit {
-  protected static final TestUsers workspaceCreator = TestUsers.chooseTestUserWithSpendAccess();;
+  protected static final TestUsers workspaceCreator = TestUsers.chooseTestUserWithSpendAccess();
   private static UUID workspaceId;
 
   protected static UUID getWorkspaceId() {

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -216,7 +216,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
             "--access=" + access,
             "--cloning=" + cloning,
             "--description=" + description,
-            "--email=" + workspaceCreator.email.toLowerCase(),
+            "--email=" + workspaceCreator.email,
             "--iam-roles=" + iamRole,
             "--location=" + location);
 

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -203,7 +203,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
             "--access=" + access,
             "--cloning=" + cloning,
             "--description=" + description,
-            "--email=" + workspaceCreator.email.toLowerCase(),
+            "--email=" + workspaceCreator.email,
             "--iam-roles=" + iamRole,
             "--location=" + location,
             "--storage=" + storage);


### PR DESCRIPTION
No longer need this once a casing bug is fixed in WSM (related PR is [here](https://github.com/DataBiosphere/terra-workspace-manager/pull/388)).