### PR TITLE
PF-860, PF-868: Consolidate handling of SAM, WSM client exceptions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,11 @@ CLI installation on the same machine.
 - Run a single test by specifying the `--tests` option:
 `./gradlew runTestsWithTag -PtestTag=unit --tests "unit.Workspace.createFailsWithoutSpendAccess" --info`
 
+#### Override default server
+The tests run against the `terra-dev` server by default. You can run them against a different server
+by specifying the Gradle `server` property. e.g.:
+`./gradlew runTestsWithTag -PtestTag=unit -Pserver=verily-cli`
+
 #### Override context directory
 The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
 You can override this default by setting the `TERRA_CONTEXT_PARENT_DIR` environment variable to a valid directory.

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -155,8 +155,7 @@ public class Main implements Runnable {
         exitCode = USER_ACTIONABLE_EXIT_CODE;
         printPointerToLogFile = false;
       } else if (ex instanceof SystemException) {
-        errorMessage =
-            ex.getMessage() + (ex.getCause() != null ? ": " + ex.getCause().getMessage() : "");
+        errorMessage = ex.getMessage();
         formattedErrorMessage =
             systemAndUnexpectedErrorStyle.errorText("[ERROR] ").concat(errorMessage);
         exitCode = SYSTEM_EXIT_CODE;

--- a/src/main/java/bio/terra/cli/command/groups/Describe.java
+++ b/src/main/java/bio/terra/cli/command/groups/Describe.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra groups describe" command. */
-@Command(name = "describe", description = "Print the group email address.")
+@Command(name = "describe", description = "Describe the group.")
 public class Describe extends BaseCommand {
   @CommandLine.Mixin GroupName groupNameOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -235,7 +235,7 @@ public class SamService {
                 SamService::isRetryable,
                 (ex) -> isStatusCode(ex, HttpStatusCodes.STATUS_CODE_BAD_REQUEST),
                 () -> inviteUser(userEmail),
-                (ex) -> false),
+                (ex) -> false), // don't retry because inviteUser already includes retries
         "Error adding user to SAM group.");
   }
 
@@ -293,7 +293,7 @@ public class SamService {
                 SamService::isRetryable,
                 (ex) -> isStatusCode(ex, HttpStatusCodes.STATUS_CODE_BAD_REQUEST),
                 () -> inviteUser(userEmail),
-                (ex) -> false),
+                (ex) -> false), // don't retry because inviteUser already includes retries
         "Error adding user to SAM resource.");
   }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -134,24 +134,15 @@ public class WorkspaceManagerService {
    * @return the Workspace Manager version object
    */
   public SystemVersion getVersion() {
-    UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
-    try {
-      return HttpUtils.callWithRetries(
-          () -> unauthenticatedApi.serviceVersion(), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error getting Workspace Manager version", ex);
-    }
+    return callWithRetries(
+        new UnauthenticatedApi(apiClient)::serviceVersion,
+        "Error getting Workspace Manager version");
   }
 
   /** Call the Workspace Manager "/status" endpoint to get the status of the server. */
   public void getStatus() {
-    UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> unauthenticatedApi.serviceStatus(), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error getting Workspace Manager status", ex);
-    }
+    callWithRetries(
+        new UnauthenticatedApi(apiClient)::serviceStatus, "Error getting Workspace Manager status");
   }
 
   /**
@@ -163,13 +154,9 @@ public class WorkspaceManagerService {
    * @return the Workspace Manager workspace list object
    */
   public WorkspaceDescriptionList listWorkspaces(int offset, int limit) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      return HttpUtils.callWithRetries(
-          () -> workspaceApi.listWorkspaces(offset, limit), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error fetching list of workspaces", ex);
-    }
+    return callWithRetries(
+        () -> new WorkspaceApi(apiClient).listWorkspaces(offset, limit),
+        "Error fetching list of workspaces");
   }
 
   /**
@@ -186,51 +173,51 @@ public class WorkspaceManagerService {
    */
   public WorkspaceDescription createWorkspace(
       @Nullable String displayName, @Nullable String description) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      // create the Terra workspace object
-      UUID workspaceId = UUID.randomUUID();
-      CreateWorkspaceRequestBody workspaceRequestBody = new CreateWorkspaceRequestBody();
-      workspaceRequestBody.setId(workspaceId);
-      workspaceRequestBody.setStage(WorkspaceStageModel.MC_WORKSPACE);
-      workspaceRequestBody.setSpendProfile("wm-default-spend-profile");
-      workspaceRequestBody.setDisplayName(displayName);
-      workspaceRequestBody.setDescription(description);
+    return handleClientExceptions(
+        () -> {
+          // create the Terra workspace object
+          UUID workspaceId = UUID.randomUUID();
+          CreateWorkspaceRequestBody workspaceRequestBody = new CreateWorkspaceRequestBody();
+          workspaceRequestBody.setId(workspaceId);
+          workspaceRequestBody.setStage(WorkspaceStageModel.MC_WORKSPACE);
+          workspaceRequestBody.setSpendProfile("wm-default-spend-profile");
+          workspaceRequestBody.setDisplayName(displayName);
+          workspaceRequestBody.setDescription(description);
 
-      // make the create workspace request
-      HttpUtils.callWithRetries(
-          () -> workspaceApi.createWorkspace(workspaceRequestBody),
-          WorkspaceManagerService::isRetryable);
+          // make the create workspace request
+          WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
+          HttpUtils.callWithRetries(
+              () -> workspaceApi.createWorkspace(workspaceRequestBody),
+              WorkspaceManagerService::isRetryable);
 
-      // create the Google project that backs the Terra workspace object
-      UUID jobId = UUID.randomUUID();
-      CreateCloudContextRequest cloudContextRequest = new CreateCloudContextRequest();
-      cloudContextRequest.setCloudPlatform(CloudPlatform.GCP);
-      cloudContextRequest.setJobControl(new JobControl().id(jobId.toString()));
+          // create the Google project that backs the Terra workspace object
+          UUID jobId = UUID.randomUUID();
+          CreateCloudContextRequest cloudContextRequest = new CreateCloudContextRequest();
+          cloudContextRequest.setCloudPlatform(CloudPlatform.GCP);
+          cloudContextRequest.setJobControl(new JobControl().id(jobId.toString()));
 
-      // make the initial create context request
-      HttpUtils.callWithRetries(
-          () -> workspaceApi.createCloudContext(cloudContextRequest, workspaceId),
-          WorkspaceManagerService::isRetryable);
+          // make the initial create context request
+          HttpUtils.callWithRetries(
+              () -> workspaceApi.createCloudContext(cloudContextRequest, workspaceId),
+              WorkspaceManagerService::isRetryable);
 
-      // poll the result endpoint until the job is no longer RUNNING
-      CreateCloudContextResult createContextResult =
-          HttpUtils.pollWithRetries(
-              () -> workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString()),
-              (result) -> isDone(result.getJobReport()),
-              WorkspaceManagerService::isRetryable,
-              CREATE_WORKSPACE_MAXIMUM_RETRIES,
-              CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY);
-      logger.debug("create workspace context result: {}", createContextResult);
-      throwIfJobNotCompleted(
-          createContextResult.getJobReport(), createContextResult.getErrorReport());
+          // poll the result endpoint until the job is no longer RUNNING
+          CreateCloudContextResult createContextResult =
+              HttpUtils.pollWithRetries(
+                  () -> workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString()),
+                  (result) -> isDone(result.getJobReport()),
+                  WorkspaceManagerService::isRetryable,
+                  CREATE_WORKSPACE_MAXIMUM_RETRIES,
+                  CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY);
+          logger.debug("create workspace context result: {}", createContextResult);
+          throwIfJobNotCompleted(
+              createContextResult.getJobReport(), createContextResult.getErrorReport());
 
-      // call the get workspace endpoint to get the full description object
-      return HttpUtils.callWithRetries(
-          () -> workspaceApi.getWorkspace(workspaceId), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error creating a new workspace", ex);
-    }
+          // call the get workspace endpoint to get the full description object
+          return HttpUtils.callWithRetries(
+              () -> workspaceApi.getWorkspace(workspaceId), WorkspaceManagerService::isRetryable);
+        },
+        "Error creating a new workspace");
   }
 
   /**
@@ -241,23 +228,17 @@ public class WorkspaceManagerService {
    * @return the Workspace Manager workspace description object
    */
   public WorkspaceDescription getWorkspace(UUID workspaceId) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      // fetch the Terra workspace object
-      WorkspaceDescription workspaceWithContext =
-          HttpUtils.callWithRetries(
-              () -> workspaceApi.getWorkspace(workspaceId), WorkspaceManagerService::isRetryable);
-
-      String googleProjectId =
-          (workspaceWithContext.getGcpContext() == null)
-              ? null
-              : workspaceWithContext.getGcpContext().getProjectId();
-      logger.info(
-          "Workspace context: {}, project id: {}", workspaceWithContext.getId(), googleProjectId);
-      return workspaceWithContext;
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error fetching workspace", ex);
-    }
+    WorkspaceDescription workspaceWithContext =
+        callWithRetries(
+            () -> new WorkspaceApi(apiClient).getWorkspace(workspaceId),
+            "Error fetching workspace");
+    String googleProjectId =
+        (workspaceWithContext.getGcpContext() == null)
+            ? null
+            : workspaceWithContext.getGcpContext().getProjectId();
+    logger.info(
+        "Workspace context: {}, project id: {}", workspaceWithContext.getId(), googleProjectId);
+    return workspaceWithContext;
   }
 
   /**
@@ -267,13 +248,8 @@ public class WorkspaceManagerService {
    * @param workspaceId the id of the workspace to delete
    */
   public void deleteWorkspace(UUID workspaceId) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> workspaceApi.deleteWorkspace(workspaceId), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error deleting workspace", ex);
-    }
+    callWithRetries(
+        () -> new WorkspaceApi(apiClient).deleteWorkspace(workspaceId), "Error deleting workspace");
   }
 
   /**
@@ -285,17 +261,11 @@ public class WorkspaceManagerService {
    */
   public WorkspaceDescription updateWorkspace(
       UUID workspaceId, @Nullable String displayName, @Nullable String description) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      // update the Terra workspace object
-      UpdateWorkspaceRequestBody updateRequest =
-          new UpdateWorkspaceRequestBody().displayName(displayName).description(description);
-      return HttpUtils.callWithRetries(
-          () -> workspaceApi.updateWorkspace(updateRequest, workspaceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error updating workspace", ex);
-    }
+    UpdateWorkspaceRequestBody updateRequest =
+        new UpdateWorkspaceRequestBody().displayName(displayName).description(description);
+    return callWithRetries(
+        () -> new WorkspaceApi(apiClient).updateWorkspace(updateRequest, workspaceId),
+        "Error updating workspace");
   }
 
   /**
@@ -307,37 +277,21 @@ public class WorkspaceManagerService {
    * @param iamRole the role to assign
    */
   public void grantIamRole(UUID workspaceId, String userEmail, IamRole iamRole) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     GrantRoleRequestBody grantRoleRequestBody = new GrantRoleRequestBody().memberEmail(userEmail);
-    try {
-      // - try to grant the user an iam role
-      // - if this fails with a Bad Request error, it means the email is not found
-      // - so try to invite the user first, then retry granting them an iam role
-      HttpUtils.callAndHandleOneTimeErrorWithRetries(
-          () -> workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole),
-          WorkspaceManagerService::isRetryable,
-          WorkspaceManagerService::isBadRequest,
-          () -> SamService.fromContext().inviteUserNoRetries(userEmail),
-          SamService::isRetryable);
-    } catch (ApiException
-        | InterruptedException
-        | org.broadinstitute.dsde.workbench.client.sam.ApiException secondEx) {
-      throw new SystemException("Error granting IAM role on workspace.", secondEx);
-    }
-  }
-
-  /**
-   * Utility method that checks if an exception thrown by the WSM client is a bad request.
-   *
-   * @param ex exception to test
-   * @return true if the exception is a bad request
-   */
-  private static boolean isBadRequest(Exception ex) {
-    if (!(ex instanceof ApiException)) {
-      return false;
-    }
-    int statusCode = ((ApiException) ex).getCode();
-    return statusCode == HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
+    handleClientExceptions(
+        () -> {
+          // - try to grant the user an iam role
+          // - if this fails with a Bad Request error, it means the email is not found
+          // - so try to invite the user first, then retry granting them an iam role
+          HttpUtils.callAndHandleOneTimeErrorWithRetries(
+              () ->
+                  new WorkspaceApi(apiClient).grantRole(grantRoleRequestBody, workspaceId, iamRole),
+              WorkspaceManagerService::isRetryable,
+              (ex) -> isStatusCode(ex, HttpStatusCodes.STATUS_CODE_BAD_REQUEST),
+              () -> SamService.fromContext().inviteUser(userEmail),
+              (ex) -> false);
+        },
+        "Error granting IAM role on workspace.");
   }
 
   /**
@@ -349,14 +303,9 @@ public class WorkspaceManagerService {
    * @param iamRole the role to remove
    */
   public void removeIamRole(UUID workspaceId, String userEmail, IamRole iamRole) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> workspaceApi.removeRole(workspaceId, iamRole, userEmail),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error removing IAM role on workspace", ex);
-    }
+    callWithRetries(
+        () -> new WorkspaceApi(apiClient).removeRole(workspaceId, iamRole, userEmail),
+        "Error removing IAM role on workspace");
   }
 
   /**
@@ -367,13 +316,9 @@ public class WorkspaceManagerService {
    * @return a list of roles and the users that have them
    */
   public RoleBindingList getRoles(UUID workspaceId) {
-    WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
-    try {
-      return HttpUtils.callWithRetries(
-          () -> workspaceApi.getRoles(workspaceId), WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error fetching users and their IAM roles for workspace", ex);
-    }
+    return callWithRetries(
+        () -> new WorkspaceApi(apiClient).getRoles(workspaceId),
+        "Error fetching users and their IAM roles for workspace");
   }
 
   /**
@@ -388,44 +333,48 @@ public class WorkspaceManagerService {
    * @throws SystemException if the number of resources in the workspace > the specified limit
    */
   public List<ResourceDescription> enumerateAllResources(UUID workspaceId, int limit) {
-    ResourceApi resourceApi = new ResourceApi(apiClient);
-    try {
-      // poll the enumerate endpoint until no results are returned, or we hit the limit
-      List<ResourceDescription> allResources = new ArrayList<>();
-      int numResultsReturned = 0;
-      do {
-        int offset = allResources.size();
-        ResourceList result =
-            HttpUtils.callWithRetries(
-                () ->
-                    resourceApi.enumerateResources(
-                        workspaceId, offset, MAX_RESOURCES_PER_ENUMERATE_REQUEST, null, null),
-                WorkspaceManagerService::isRetryable);
+    return handleClientExceptions(
+        () -> {
+          // poll the enumerate endpoint until no results are returned, or we hit the limit
+          List<ResourceDescription> allResources = new ArrayList<>();
+          int numResultsReturned = 0;
+          do {
+            int offset = allResources.size();
+            ResourceList result =
+                HttpUtils.callWithRetries(
+                    () ->
+                        new ResourceApi(apiClient)
+                            .enumerateResources(
+                                workspaceId,
+                                offset,
+                                MAX_RESOURCES_PER_ENUMERATE_REQUEST,
+                                null,
+                                null),
+                    WorkspaceManagerService::isRetryable);
 
-        // add all fetched resources to the running list
-        numResultsReturned = result.getResources().size();
-        logger.debug("Called enumerate endpoints, fetched {} resources", numResultsReturned);
-        allResources.addAll(result.getResources());
+            // add all fetched resources to the running list
+            numResultsReturned = result.getResources().size();
+            logger.debug("Called enumerate endpoints, fetched {} resources", numResultsReturned);
+            allResources.addAll(result.getResources());
 
-        // if we have fetched more than the limit, then throw an exception
-        if (allResources.size() > limit) {
-          throw new SystemException(
-              "Total number of resources ("
-                  + allResources.size()
-                  + ") exceeds the CLI limit ("
-                  + limit
-                  + ")");
-        }
+            // if we have fetched more than the limit, then throw an exception
+            if (allResources.size() > limit) {
+              throw new SystemException(
+                  "Total number of resources ("
+                      + allResources.size()
+                      + ") exceeds the CLI limit ("
+                      + limit
+                      + ")");
+            }
 
-        // if this fetch returned less than the maximum allowed per request, then that indicates
-        // there are no more
-      } while (numResultsReturned >= MAX_RESOURCES_PER_ENUMERATE_REQUEST);
+            // if this fetch returned less than the maximum allowed per request, then that indicates
+            // there are no more
+          } while (numResultsReturned >= MAX_RESOURCES_PER_ENUMERATE_REQUEST);
 
-      logger.debug("Fetched total number of resources: {}", allResources.size());
-      return allResources;
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error enumerating resources in the workspace.", ex);
-    }
+          logger.debug("Fetched total number of resources: {}", allResources.size());
+          return allResources;
+        },
+        "Error enumerating resources in the workspace.");
   }
 
   /**
@@ -438,14 +387,9 @@ public class WorkspaceManagerService {
    * @return true if access is allowed
    */
   public boolean checkAccess(UUID workspaceId, UUID resourceId) {
-    ResourceApi resourceApi = new ResourceApi(apiClient);
-    try {
-      return HttpUtils.callWithRetries(
-          () -> resourceApi.checkReferenceAccess(workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error checking access to resource.", ex);
-    }
+    return callWithRetries(
+        () -> new ResourceApi(apiClient).checkReferenceAccess(workspaceId, resourceId),
+        "Error checking access to resource.");
   }
 
   /**
@@ -468,15 +412,11 @@ public class WorkspaceManagerService {
                     .description(createParams.resourceFields.description)
                     .cloningInstructions(createParams.resourceFields.cloningInstructions))
             .bucket(new GcpGcsBucketAttributes().bucketName(createParams.bucketName));
-
-    try {
-      ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
-      return HttpUtils.callWithRetries(
-          () -> referencedGcpResourceApi.createBucketReference(createRequest, workspaceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error creating referenced GCS bucket in the workspace.", ex);
-    }
+    return callWithRetries(
+        () ->
+            new ReferencedGcpResourceApi(apiClient)
+                .createBucketReference(createRequest, workspaceId),
+        "Error creating referenced GCS bucket in the workspace.");
   }
 
   /**
@@ -502,16 +442,11 @@ public class WorkspaceManagerService {
                 new GcpBigQueryDatasetAttributes()
                     .projectId(createParams.projectId)
                     .datasetId(createParams.datasetId));
-
-    try {
-      ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
-      return HttpUtils.callWithRetries(
-          () -> referencedGcpResourceApi.createBigQueryDatasetReference(createRequest, workspaceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error creating referenced Big Query dataset in the workspace.", ex);
-    }
+    return callWithRetries(
+        () ->
+            new ReferencedGcpResourceApi(apiClient)
+                .createBigQueryDatasetReference(createRequest, workspaceId),
+        "Error creating referenced Big Query dataset in the workspace.");
   }
 
   /**
@@ -533,29 +468,31 @@ public class WorkspaceManagerService {
             .aiNotebookInstance(fromCLIObject(createParams))
             .jobControl(new JobControl().id(jobId));
 
-    try {
-      ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
-      // Start the AI notebook creation job.
-      HttpUtils.callWithRetries(
-          () -> controlledGcpResourceApi.createAiNotebookInstance(createRequest, workspaceId),
-          WorkspaceManagerService::isRetryable);
+    return handleClientExceptions(
+        () -> {
+          ControlledGcpResourceApi controlledGcpResourceApi =
+              new ControlledGcpResourceApi(apiClient);
+          // Start the AI notebook creation job.
+          HttpUtils.callWithRetries(
+              () -> controlledGcpResourceApi.createAiNotebookInstance(createRequest, workspaceId),
+              WorkspaceManagerService::isRetryable);
 
-      // Poll the result endpoint until the job is no longer RUNNING.
-      CreatedControlledGcpAiNotebookInstanceResult createResult =
-          HttpUtils.pollWithRetries(
-              () -> controlledGcpResourceApi.getCreateAiNotebookInstanceResult(workspaceId, jobId),
-              (result) -> isDone(result.getJobReport()),
-              WorkspaceManagerService::isRetryable,
-              // Creating an AI notebook instance should take less than ~10 minutes.
-              60,
-              Duration.ofSeconds(10));
-      logger.debug("Create controlled AI notebook result {}", createResult);
-      throwIfJobNotCompleted(createResult.getJobReport(), createResult.getErrorReport());
-      return createResult.getAiNotebookInstance();
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error creating controlled AI Notebook instance in the workspace.", ex);
-    }
+          // Poll the result endpoint until the job is no longer RUNNING.
+          CreatedControlledGcpAiNotebookInstanceResult createResult =
+              HttpUtils.pollWithRetries(
+                  () ->
+                      controlledGcpResourceApi.getCreateAiNotebookInstanceResult(
+                          workspaceId, jobId),
+                  (result) -> isDone(result.getJobReport()),
+                  WorkspaceManagerService::isRetryable,
+                  // Creating an AI notebook instance should take less than ~10 minutes.
+                  60,
+                  Duration.ofSeconds(10));
+          logger.debug("Create controlled AI notebook result {}", createResult);
+          throwIfJobNotCompleted(createResult.getJobReport(), createResult.getErrorReport());
+          return createResult.getAiNotebookInstance();
+        },
+        "Error creating controlled AI Notebook instance in the workspace.");
   }
 
   /**
@@ -626,15 +563,12 @@ public class WorkspaceManagerService {
                     .defaultStorageClass(createParams.defaultStorageClass)
                     .lifecycle(new GcpGcsBucketLifecycle().rules(lifecycleRules))
                     .location(createParams.location));
-
-    try {
-      ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
-      return HttpUtils.callWithRetries(
-          () -> controlledGcpResourceApi.createBucket(createRequest, workspaceId).getGcpBucket(),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error creating controlled GCS bucket in the workspace.", ex);
-    }
+    return callWithRetries(
+        () ->
+            new ControlledGcpResourceApi(apiClient)
+                .createBucket(createRequest, workspaceId)
+                .getGcpBucket(),
+        "Error creating controlled GCS bucket in the workspace.");
   }
 
   /**
@@ -706,19 +640,12 @@ public class WorkspaceManagerService {
                 new GcpBigQueryDatasetCreationParameters()
                     .datasetId(createParams.datasetId)
                     .location(createParams.location));
-
-    try {
-      ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
-      return HttpUtils.callWithRetries(
-          () ->
-              controlledGcpResourceApi
-                  .createBigQueryDataset(createRequest, workspaceId)
-                  .getBigQueryDataset(),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error creating controlled Big Query dataset in the workspace.", ex);
-    }
+    return callWithRetries(
+        () ->
+            new ControlledGcpResourceApi(apiClient)
+                .createBigQueryDataset(createRequest, workspaceId)
+                .getBigQueryDataset(),
+        "Error creating controlled Big Query dataset in the workspace.");
   }
 
   /**
@@ -752,14 +679,10 @@ public class WorkspaceManagerService {
    * @param resourceId the resource id
    */
   public void deleteReferencedGcsBucket(UUID workspaceId, UUID resourceId) {
-    ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> referencedGcpResourceApi.deleteBucketReference(workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error deleting referenced GCS bucket in the workspace.", ex);
-    }
+    callWithRetries(
+        () ->
+            new ReferencedGcpResourceApi(apiClient).deleteBucketReference(workspaceId, resourceId),
+        "Error deleting referenced GCS bucket in the workspace.");
   }
 
   /**
@@ -771,15 +694,11 @@ public class WorkspaceManagerService {
    * @param resourceId the resource id
    */
   public void deleteReferencedBigQueryDataset(UUID workspaceId, UUID resourceId) {
-    ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> referencedGcpResourceApi.deleteBigQueryDatasetReference(workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error deleting referenced Big Query dataset in the workspace.", ex);
-    }
+    callWithRetries(
+        () ->
+            new ReferencedGcpResourceApi(apiClient)
+                .deleteBigQueryDatasetReference(workspaceId, resourceId),
+        "Error deleting referenced Big Query dataset in the workspace.");
   }
 
   /**
@@ -798,29 +717,28 @@ public class WorkspaceManagerService {
     var deleteRequest =
         new DeleteControlledGcpAiNotebookInstanceRequest()
             .jobControl(new JobControl().id(asyncJobId));
-    try {
-      // make the initial delete request
-      HttpUtils.callWithRetries(
-          () ->
-              controlledGcpResourceApi.deleteAiNotebookInstance(
-                  deleteRequest, workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-
-      // poll the result endpoint until the job is no longer RUNNING
-      DeleteControlledGcpAiNotebookInstanceResult deleteResult =
-          HttpUtils.pollWithRetries(
+    handleClientExceptions(
+        () -> {
+          // make the initial delete request
+          HttpUtils.callWithRetries(
               () ->
-                  controlledGcpResourceApi.getDeleteAiNotebookInstanceResult(
-                      workspaceId, asyncJobId),
-              (result) -> isDone(result.getJobReport()),
+                  controlledGcpResourceApi.deleteAiNotebookInstance(
+                      deleteRequest, workspaceId, resourceId),
               WorkspaceManagerService::isRetryable);
-      logger.debug("delete controlled AI notebook instance result: {}", deleteResult);
 
-      throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error deleting controlled AI Notebook instance in the workspace.", ex);
-    }
+          // poll the result endpoint until the job is no longer RUNNING
+          DeleteControlledGcpAiNotebookInstanceResult deleteResult =
+              HttpUtils.pollWithRetries(
+                  () ->
+                      controlledGcpResourceApi.getDeleteAiNotebookInstanceResult(
+                          workspaceId, asyncJobId),
+                  (result) -> isDone(result.getJobReport()),
+                  WorkspaceManagerService::isRetryable);
+          logger.debug("delete controlled AI notebook instance result: {}", deleteResult);
+
+          throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());
+        },
+        "Error deleting controlled AI Notebook instance in the workspace.");
   }
 
   /**
@@ -838,24 +756,24 @@ public class WorkspaceManagerService {
     String asyncJobId = UUID.randomUUID().toString();
     DeleteControlledGcpGcsBucketRequest deleteRequest =
         new DeleteControlledGcpGcsBucketRequest().jobControl(new JobControl().id(asyncJobId));
-    try {
-      // make the initial delete request
-      HttpUtils.callWithRetries(
-          () -> controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-
-      // poll the result endpoint until the job is no longer RUNNING
-      DeleteControlledGcpGcsBucketResult deleteResult =
-          HttpUtils.pollWithRetries(
-              () -> controlledGcpResourceApi.getDeleteBucketResult(workspaceId, asyncJobId),
-              (result) -> isDone(result.getJobReport()),
+    handleClientExceptions(
+        () -> {
+          // make the initial delete request
+          HttpUtils.callWithRetries(
+              () -> controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId),
               WorkspaceManagerService::isRetryable);
-      logger.debug("delete controlled gcs bucket result: {}", deleteResult);
 
-      throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException("Error deleting controlled GCS bucket in the workspace.", ex);
-    }
+          // poll the result endpoint until the job is no longer RUNNING
+          DeleteControlledGcpGcsBucketResult deleteResult =
+              HttpUtils.pollWithRetries(
+                  () -> controlledGcpResourceApi.getDeleteBucketResult(workspaceId, asyncJobId),
+                  (result) -> isDone(result.getJobReport()),
+                  WorkspaceManagerService::isRetryable);
+          logger.debug("delete controlled gcs bucket result: {}", deleteResult);
+
+          throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());
+        },
+        "Error deleting controlled GCS bucket in the workspace.");
   }
 
   /**
@@ -867,15 +785,10 @@ public class WorkspaceManagerService {
    * @param resourceId the resource id
    */
   public void deleteControlledBigQueryDataset(UUID workspaceId, UUID resourceId) {
-    ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
-    try {
-      HttpUtils.callWithRetries(
-          () -> controlledGcpResourceApi.deleteBigQueryDataset(workspaceId, resourceId),
-          WorkspaceManagerService::isRetryable);
-    } catch (ApiException | InterruptedException ex) {
-      throw new SystemException(
-          "Error deleting controlled Big Query dataset in the workspace.", ex);
-    }
+    callWithRetries(
+        () ->
+            new ControlledGcpResourceApi(apiClient).deleteBigQueryDataset(workspaceId, resourceId),
+        "Error deleting controlled Big Query dataset in the workspace.");
   }
 
   /** Helper method that checks a JobReport's status and returns false if it's still RUNNING. */
@@ -907,6 +820,21 @@ public class WorkspaceManagerService {
   }
 
   /**
+   * Utility method that checks if an exception thrown by the WSM client matches the given HTTP
+   * status code.
+   *
+   * @param ex exception to test
+   * @return true if the exception status code matches
+   */
+  private static boolean isStatusCode(Exception ex, int statusCode) {
+    if (!(ex instanceof ApiException)) {
+      return false;
+    }
+    int exceptionStatusCode = ((ApiException) ex).getCode();
+    return statusCode == exceptionStatusCode;
+  }
+
+  /**
    * Utility method that checks if an exception thrown by the WSM client is retryable.
    *
    * @param ex exception to test
@@ -923,5 +851,73 @@ public class WorkspaceManagerService {
         || statusCode == HttpStatus.SC_BAD_GATEWAY
         || statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE
         || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT;
+  }
+
+  /**
+   * Execute a function that includes hitting WSM endpoints. Retry if the function throws an {@link
+   * #isRetryable} exception. If an exception is thrown by the WSM client or the retries, make sure
+   * the HTTP status code and error message are logged.
+   *
+   * @param makeRequest function with no return value
+   * @param errorMsg error message for the the {@link SystemException} that wraps any exceptions
+   *     thrown by the WSM client or the retries
+   */
+  private void callWithRetries(
+      HttpUtils.RunnableWithCheckedException<ApiException> makeRequest, String errorMsg) {
+    handleClientExceptions(
+        () -> HttpUtils.callWithRetries(makeRequest, WorkspaceManagerService::isRetryable),
+        errorMsg);
+  }
+
+  /**
+   * Execute a function that includes hitting WSM endpoints. Retry if the function throws an {@link
+   * #isRetryable} exception. If an exception is thrown by the WSM client or the retries, make sure
+   * the HTTP status code and error message are logged.
+   *
+   * @param makeRequest function with a return value
+   * @param errorMsg error message for the the {@link SystemException} that wraps any exceptions
+   *     thrown by the WSM client or the retries
+   */
+  private <T> T callWithRetries(
+      HttpUtils.SupplierWithCheckedException<T, ApiException> makeRequest, String errorMsg) {
+    return handleClientExceptions(
+        () -> HttpUtils.callWithRetries(makeRequest, WorkspaceManagerService::isRetryable),
+        errorMsg);
+  }
+
+  /**
+   * Execute a function that includes hitting WSM endpoints. If an exception is thrown by the WSM
+   * client or the retries, make sure the HTTP status code and error message are logged.
+   *
+   * @param makeRequest function with no return value
+   * @param errorMsg error message for the the {@link SystemException} that wraps any exceptions
+   *     thrown by the WSM client or the retries
+   */
+  private void handleClientExceptions(
+      HttpUtils.RunnableWithCheckedException<ApiException> makeRequest, String errorMsg) {
+    handleClientExceptions(
+        () -> {
+          makeRequest.run();
+          return null;
+        },
+        errorMsg);
+  }
+
+  /**
+   * Execute a function that includes hitting WSM endpoints. If an exception is thrown by the WSM
+   * client or the retries, make sure the HTTP status code and error message are logged.
+   *
+   * @param makeRequest function with a return value
+   * @param errorMsg error message for the the {@link SystemException} that wraps any exceptions
+   *     thrown by the WSM client or the retries
+   */
+  private <T> T handleClientExceptions(
+      HttpUtils.SupplierWithCheckedException<T, ApiException> makeRequest, String errorMsg) {
+    try {
+      return makeRequest.makeRequest();
+    } catch (ApiException | InterruptedException ex) {
+      // TODO (PF-868): include status code and http response in exception
+      throw new SystemException(errorMsg, ex);
+    }
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -148,11 +148,7 @@ public class WorkspaceManagerService {
     UnauthenticatedApi unauthenticatedApi = new UnauthenticatedApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            unauthenticatedApi.serviceStatus();
-            return null;
-          },
-          WorkspaceManagerService::isRetryable);
+          () -> unauthenticatedApi.serviceStatus(), WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error getting Workspace Manager status", ex);
     }
@@ -274,11 +270,7 @@ public class WorkspaceManagerService {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            workspaceApi.deleteWorkspace(workspaceId);
-            return null;
-          },
-          WorkspaceManagerService::isRetryable);
+          () -> workspaceApi.deleteWorkspace(workspaceId), WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error deleting workspace", ex);
     }
@@ -322,16 +314,10 @@ public class WorkspaceManagerService {
       // - if this fails with a Bad Request error, it means the email is not found
       // - so try to invite the user first, then retry granting them an iam role
       HttpUtils.callAndHandleOneTimeErrorWithRetries(
-          () -> {
-            workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole);
-            return null;
-          },
+          () -> workspaceApi.grantRole(grantRoleRequestBody, workspaceId, iamRole),
           WorkspaceManagerService::isRetryable,
           WorkspaceManagerService::isBadRequest,
-          () -> {
-            SamService.fromContext().inviteUserNoRetries(userEmail);
-            return null;
-          },
+          () -> SamService.fromContext().inviteUserNoRetries(userEmail),
           SamService::isRetryable);
     } catch (ApiException
         | InterruptedException
@@ -366,10 +352,7 @@ public class WorkspaceManagerService {
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            workspaceApi.removeRole(workspaceId, iamRole, userEmail);
-            return null;
-          },
+          () -> workspaceApi.removeRole(workspaceId, iamRole, userEmail),
           WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error removing IAM role on workspace", ex);
@@ -772,10 +755,7 @@ public class WorkspaceManagerService {
     ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            referencedGcpResourceApi.deleteBucketReference(workspaceId, resourceId);
-            return null;
-          },
+          () -> referencedGcpResourceApi.deleteBucketReference(workspaceId, resourceId),
           WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException("Error deleting referenced GCS bucket in the workspace.", ex);
@@ -794,10 +774,7 @@ public class WorkspaceManagerService {
     ReferencedGcpResourceApi referencedGcpResourceApi = new ReferencedGcpResourceApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            referencedGcpResourceApi.deleteBigQueryDatasetReference(workspaceId, resourceId);
-            return null;
-          },
+          () -> referencedGcpResourceApi.deleteBigQueryDatasetReference(workspaceId, resourceId),
           WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException(
@@ -824,11 +801,9 @@ public class WorkspaceManagerService {
     try {
       // make the initial delete request
       HttpUtils.callWithRetries(
-          () -> {
-            controlledGcpResourceApi.deleteAiNotebookInstance(
-                deleteRequest, workspaceId, resourceId);
-            return null;
-          },
+          () ->
+              controlledGcpResourceApi.deleteAiNotebookInstance(
+                  deleteRequest, workspaceId, resourceId),
           WorkspaceManagerService::isRetryable);
 
       // poll the result endpoint until the job is no longer RUNNING
@@ -866,10 +841,7 @@ public class WorkspaceManagerService {
     try {
       // make the initial delete request
       HttpUtils.callWithRetries(
-          () -> {
-            controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId);
-            return null;
-          },
+          () -> controlledGcpResourceApi.deleteBucket(deleteRequest, workspaceId, resourceId),
           WorkspaceManagerService::isRetryable);
 
       // poll the result endpoint until the job is no longer RUNNING
@@ -898,10 +870,7 @@ public class WorkspaceManagerService {
     ControlledGcpResourceApi controlledGcpResourceApi = new ControlledGcpResourceApi(apiClient);
     try {
       HttpUtils.callWithRetries(
-          () -> {
-            controlledGcpResourceApi.deleteBigQueryDataset(workspaceId, resourceId);
-            return null;
-          },
+          () -> controlledGcpResourceApi.deleteBigQueryDataset(workspaceId, resourceId),
           WorkspaceManagerService::isRetryable);
     } catch (ApiException | InterruptedException ex) {
       throw new SystemException(

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -291,7 +291,7 @@ public class WorkspaceManagerService {
               WorkspaceManagerService::isRetryable,
               (ex) -> isStatusCode(ex, HttpStatusCodes.STATUS_CODE_BAD_REQUEST),
               () -> SamService.fromContext().inviteUser(userEmail),
-              (ex) -> false);
+              (ex) -> false); // don't retry because inviteUser already includes retries
         },
         "Error granting IAM role on workspace.");
   }

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -382,7 +382,7 @@ public class HttpUtils {
    */
   @FunctionalInterface
   public interface SupplierWithCheckedException<T, E extends Exception> {
-    T makeRequest() throws E;
+    T makeRequest() throws E, InterruptedException;
   }
 
   /**
@@ -391,6 +391,6 @@ public class HttpUtils {
    */
   @FunctionalInterface
   public interface RunnableWithCheckedException<E extends Exception> {
-    void run() throws E;
+    void run() throws E, InterruptedException;
   }
 }

--- a/src/test/java/unit/ClientExceptionHandling.java
+++ b/src/test/java/unit/ClientExceptionHandling.java
@@ -1,0 +1,86 @@
+package unit;
+
+import static harness.utils.ExternalBQDatasets.randomDatasetId;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import harness.TestCommand;
+import harness.TestUsers;
+import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.SamGroups;
+import java.io.IOException;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for handling exceptions thrown by Terra services. */
+@Tag("unit")
+public class ClientExceptionHandling extends SingleWorkspaceUnit {
+  SamGroups trackedGroups = new SamGroups();
+
+  @Override
+  @AfterAll
+  protected void cleanupOnce() throws IOException {
+    super.cleanupOnce();
+
+    // try to delete each group that was created by a method in this class
+    trackedGroups.deleteAllTrackedGroups();
+  }
+
+  @Test
+  @DisplayName(
+      "try to create a group twice, check that the output includes the CLI and SAM error messages")
+  void samDuplicateGroup() throws IOException {
+    TestUsers testUser = TestUsers.chooseTestUser();
+    testUser.login();
+
+    // `terra groups create --name=$name`
+    String name = SamGroups.randomGroupName();
+    TestCommand.runCommandExpectSuccess("groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up in case this test method fails
+    trackedGroups.trackGroup(name, testUser);
+
+    // try to create another group with the same name
+    String stdErr = TestCommand.runCommandExpectExitCode(2, "groups", "create", "--name=" + name);
+    assertThat(
+        "stderr includes the CLI error message",
+        stdErr,
+        CoreMatchers.containsString("Error creating SAM group"));
+    assertThat(
+        "stderr includes the SAM error message",
+        stdErr,
+        CoreMatchers.containsString("A resource of this type and name already exists"));
+  }
+
+  @Test
+  @DisplayName(
+      "try to create a BQ controlled resource twice, check that the output includes the CLI and WSM error messages")
+  void wsmDuplicateResource() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id --format=json`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+
+    // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
+    String name = "listDescribeReflectCreate";
+    String datasetId = randomDatasetId();
+    TestCommand.runCommandExpectSuccess(
+        "resources", "create", "bq-dataset", "--name=" + name, "--dataset-id=" + datasetId);
+
+    // try to create another resource with the same name
+    String stdErr =
+        TestCommand.runCommandExpectExitCode(
+            2, "resources", "create", "bq-dataset", "--name=" + name, "--dataset-id=" + datasetId);
+    assertThat(
+        "stderr includes the CLI error message",
+        stdErr,
+        CoreMatchers.containsString(
+            "Error creating controlled Big Query dataset in the workspace"));
+    assertThat(
+        "stderr includes the WSM error message",
+        stdErr,
+        CoreMatchers.containsString("A BigQuery dataset with ID " + datasetId + " already exists"));
+  }
+}


### PR DESCRIPTION
- Consolidated handling of exceptions thrown by the client or retires into one place each for SAM and WSM. This removed a lot of boilerplate try/catch/wrap and re-throw logic in the methods of these classes.
  - Added logic to try and parse the `ErrorReport` returned by SAM and WSM in the response body when an error occurs.
  - Added logging so we always have the status code, response body, and exception message for SAM and WSM client exceptions, even if they're in an unexpected format or property.
  - Wrote two unit tests to make sure the SAM and WSM error message gets written out to the user.
- Overloaded some of the `HttpUtils` methods that do retries to also accept lambdas that don't return a value. This removed boilerplate `() -> { something...; return null; }` when we wanted to do retries around a function with a `void` return.
- Modified the `SupplierWithCheckedException` and `RunnableWithCheckedException` functional interfaces to also throw an `InterruptedException`. This lets us nest calls to the `HttpUtils` methods that do reties/handle one-time errors/poll.