### PR TITLE
PF-821: Script to cleanup test user owned workspaces.

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -8,11 +8,7 @@ on:
         default: 'true'
       terraserver:
         description: 'the server to cleanup (e.g. terra-dev)'
-        required: false
-        default: 'terra-dev'
-  push:
-    branches:
-      - '**'
+        required: true
 
 jobs:
   cleanup-test-user-workspaces:

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,0 +1,72 @@
+name: Run tests nightly
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - '**'
+
+inputs:
+  DRY_RUN:
+    description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
+    required: false
+    default: 'true'
+  TERRA_SERVER:
+    description: 'the server to cleanup (e.g. terra-dev)'
+    required: false
+    default: 'terra-dev'
+
+jobs:
+  cleanup-test-user-workspaces:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current code
+        id: checkout_code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+      - name: Set up AdoptOpenJDK 11
+        id: setup_jdk
+        uses: joschi/setup-jdk@v2
+        with:
+          java-version: 11
+      - name: Cache Gradle packages
+        id: cache_gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
+          restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+      - name: Grant execute permission for gradlew
+        id: allow_execute_gradle
+        run: chmod +x gradlew
+      - name: Render config
+        id: render_config
+        run: |
+          # this step does the equivalent of the tools/render-config.sh script.
+          # on local machines, the script fetches a SA from Vault.
+          # in GH actions, the SA key is stored in a GH repo secret.
+          # regardless of how it was fetched, tests expect these
+          # keys to be stored in rendered/
+          mkdir -p rendered
+          echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+          echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+        env:
+          TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
+          DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
+      - name: Run cleanup script
+        id: run_cleanup_script
+        run: |
+          echo "DRY_RUN: ${{ github.event.inputs.DRY_RUN }}"
+          echo "TERRA_SERVER: ${{ github.event.inputs.TERRA_SERVER }}"
+#          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
+      - name: Archive logs and context file
+        id: archive_logs_and_context
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: logs-and-context-[${{ matrix.testOptions }}]
+          path: |
+            build/test-context/.terra/logs/
+            build/test-context/.terra/global-context.json

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,4 +1,4 @@
-name: Cleanup test user workspaces (copypaste)
+name: Cleanup test user workspaces
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,4 +1,4 @@
-name: Run tests nightly
+name: Cleanup test user workspaces
 on:
   workflow_dispatch:
     inputs:
@@ -57,9 +57,17 @@ jobs:
       - name: Run cleanup script
         id: run_cleanup_script
         run: |
-          echo "DRY_RUN: ${{ github.event.inputs.DRY_RUN }}"
-          echo "TERRA_SERVER: ${{ github.event.inputs.TERRA_SERVER }}"
+          echo "dryrun: $DRY_RUN"
+          echo "terraserver: $TERRA_SERVER"
           ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
+          if [ "$DRY_RUN" == "true" ]; then
+            echo "do a dry run"
+          else
+            echo "do an actual run"
+          fi
+        env:
+          DRY_RUN: ${{ github.event.inputs.dryrun }}
+          TERRA_SERVER: ${{ github.event.inputs.terraserver }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -2,11 +2,11 @@ name: Run tests nightly
 on:
   workflow_dispatch:
     inputs:
-      DRY_RUN:
+      dryRun:
         description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
         required: false
         default: 'true'
-      TERRA_SERVER:
+      terraServer:
         description: 'the server to cleanup (e.g. terra-dev)'
         required: false
         default: 'terra-dev'

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,19 +1,18 @@
 name: Run tests nightly
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      DRY_RUN:
+        description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
+        required: false
+        default: 'true'
+      TERRA_SERVER:
+        description: 'the server to cleanup (e.g. terra-dev)'
+        required: false
+        default: 'terra-dev'
   push:
     branches:
       - '**'
-
-inputs:
-  DRY_RUN:
-    description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
-    required: false
-    default: 'true'
-  TERRA_SERVER:
-    description: 'the server to cleanup (e.g. terra-dev)'
-    required: false
-    default: 'terra-dev'
 
 jobs:
   cleanup-test-user-workspaces:
@@ -60,7 +59,7 @@ jobs:
         run: |
           echo "DRY_RUN: ${{ github.event.inputs.DRY_RUN }}"
           echo "TERRA_SERVER: ${{ github.event.inputs.TERRA_SERVER }}"
-#          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
+          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -2,11 +2,11 @@ name: Run tests nightly
 on:
   workflow_dispatch:
     inputs:
-      dryRun:
+      dryrun:
         description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
         required: false
         default: 'true'
-      terraServer:
+      terraserver:
         description: 'the server to cleanup (e.g. terra-dev)'
         required: false
         default: 'terra-dev'

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,4 +1,4 @@
-name: Cleanup test user workspaces
+name: Cleanup test user workspaces (placeholder)
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -2,11 +2,11 @@ name: Cleanup test user workspaces
 on:
   workflow_dispatch:
     inputs:
-      dryrun:
+      dry_run:
         description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
         required: false
         default: 'true'
-      terraserver:
+      terra_server:
         description: 'the server to cleanup (e.g. terra-dev)'
         required: true
 
@@ -56,13 +56,13 @@ jobs:
           echo "dryrun: $DRY_RUN"
           echo "terraserver: $TERRA_SERVER"
           if [ "$DRY_RUN" == "true" ]; then
-            ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
+            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PdryRun
           else
-            ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
+            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER
           fi
         env:
-          DRY_RUN: ${{ github.event.inputs.dryrun }}
-          TERRA_SERVER: ${{ github.event.inputs.terraserver }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TERRA_SERVER: ${{ github.event.inputs.terra_server }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -1,4 +1,4 @@
-name: Cleanup test user workspaces (placeholder)
+name: Cleanup test user workspaces (copypaste)
 on:
   workflow_dispatch:
     inputs:
@@ -55,11 +55,10 @@ jobs:
         run: |
           echo "dryrun: $DRY_RUN"
           echo "terraserver: $TERRA_SERVER"
-          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
           if [ "$DRY_RUN" == "true" ]; then
-            echo "do a dry run"
+            ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
           else
-            echo "do an actual run"
+            ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
           fi
         env:
           DRY_RUN: ${{ github.event.inputs.dryrun }}

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       dryrun:
-        description: 'true to do a dry run (i.e. don't actually try to delete anything), false otherwise.'
+        description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
         required: false
         default: 'true'
       terraserver:

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,15 +1,21 @@
-name: Run tests nightly
+name: Cleanup test user workspaces (copypaste)
 on:
-  workflow_dispatch: {}
-  schedule:
-    - cron: '0 5 * * *' # 5AM UTC = 12AM EST
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
+        required: false
+        default: 'true'
+      terraserver:
+        description: 'the server to cleanup (e.g. terra-dev)'
+        required: false
+        default: 'terra-dev'
+  push:
+    branches:
+      - '**'
 
 jobs:
-  tests-against-source-code-and-latest-install:
-    strategy:
-      matrix:
-        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
-      fail-fast: false
+  cleanup-test-user-workspaces:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
@@ -48,12 +54,20 @@ jobs:
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
-      - name: Run tests
-        id: run_tests
+      - name: Run cleanup script
+        id: run_cleanup_script
         run: |
-          # runs against the default server: terra-dev
-          echo "Running tests with options: ${{ matrix.testOptions }}"
-          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
+          echo "dryrun: $DRY_RUN"
+          echo "terraserver: $TERRA_SERVER"
+          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
+          if [ "$DRY_RUN" == "true" ]; then
+            echo "do a dry run"
+          else
+            echo "do an actual run"
+          fi
+        env:
+          DRY_RUN: ${{ github.event.inputs.dryrun }}
+          TERRA_SERVER: ${{ github.event.inputs.terraserver }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,11 +8,7 @@ on:
         default: 'true'
       terraserver:
         description: 'the server to cleanup (e.g. terra-dev)'
-        required: false
-        default: 'terra-dev'
-  push:
-    branches:
-      - '**'
+        required: true
 
 jobs:
   cleanup-test-user-workspaces:

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,17 +1,15 @@
-name: Cleanup test user workspaces (copypaste)
+name: Run tests nightly
 on:
-  workflow_dispatch:
-    inputs:
-      dryrun:
-        description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
-        required: false
-        default: 'true'
-      terraserver:
-        description: 'the server to cleanup (e.g. terra-dev)'
-        required: true
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 5 * * *' # 5AM UTC = 12AM EST
 
 jobs:
-  cleanup-test-user-workspaces:
+  tests-against-source-code-and-latest-install:
+    strategy:
+      matrix:
+        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
@@ -50,20 +48,12 @@ jobs:
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
-      - name: Run cleanup script
-        id: run_cleanup_script
+      - name: Run tests
+        id: run_tests
         run: |
-          echo "dryrun: $DRY_RUN"
-          echo "terraserver: $TERRA_SERVER"
-          ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
-          if [ "$DRY_RUN" == "true" ]; then
-            echo "do a dry run"
-          else
-            echo "do an actual run"
-          fi
-        env:
-          DRY_RUN: ${{ github.event.inputs.dryrun }}
-          TERRA_SERVER: ${{ github.event.inputs.terraserver }}
+          # runs against the default server: terra-dev
+          echo "Running tests with options: ${{ matrix.testOptions }}"
+          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,17 +1,15 @@
-name: test Cleanup test user workspaces
+name: Run tests nightly
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
-        required: false
-        default: 'true'
-      terra_server:
-        description: 'the server to cleanup (e.g. terra-dev)'
-        required: true
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 5 * * *' # 5AM UTC = 12AM EST
 
 jobs:
-  cleanup-test-user-workspaces:
+  tests-against-source-code-and-latest-install:
+    strategy:
+      matrix:
+        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
@@ -50,19 +48,12 @@ jobs:
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
-      - name: Run cleanup script
-        id: run_cleanup_script
+      - name: Run tests
+        id: run_tests
         run: |
-          echo "dryrun: $DRY_RUN"
-          echo "terraserver: $TERRA_SERVER"
-          if [ "$DRY_RUN" == "true" ]; then
-            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PdryRun
-          else
-            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER
-          fi
-        env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
-          TERRA_SERVER: ${{ github.event.inputs.terra_server }}
+          # runs against the default server: terra-dev
+          echo "Running tests with options: ${{ matrix.testOptions }}"
+          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,15 +1,17 @@
-name: Run tests nightly
+name: test Cleanup test user workspaces
 on:
-  workflow_dispatch: {}
-  schedule:
-    - cron: '0 5 * * *' # 5AM UTC = 12AM EST
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "true to do a dry run (i.e. don't actually try to delete anything), false otherwise."
+        required: false
+        default: 'true'
+      terra_server:
+        description: 'the server to cleanup (e.g. terra-dev)'
+        required: true
 
 jobs:
-  tests-against-source-code-and-latest-install:
-    strategy:
-      matrix:
-        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
-      fail-fast: false
+  cleanup-test-user-workspaces:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
@@ -48,12 +50,19 @@ jobs:
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
-      - name: Run tests
-        id: run_tests
+      - name: Run cleanup script
+        id: run_cleanup_script
         run: |
-          # runs against the default server: terra-dev
-          echo "Running tests with options: ${{ matrix.testOptions }}"
-          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
+          echo "dryrun: $DRY_RUN"
+          echo "terraserver: $TERRA_SERVER"
+          if [ "$DRY_RUN" == "true" ]; then
+            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PdryRun
+          else
+            ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER
+          fi
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          TERRA_SERVER: ${{ github.event.inputs.terra_server }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,29 @@ task runTestsWithTag(type: Test) {
     outputs.upToDateWhen { false } // force tests to always be re-run
 }
 
+// cleanup workspaces owned by test users.
+// 1) do a dry run (i.e. don't actually try to delete anything)
+//    ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
+// 2) try to delete each workspace owned by a test user
+//    ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
+task cleanupTestUserWorkspaces(type: JavaExec) {
+    classpath sourceSets.test.runtimeClasspath
+    main = "harness.utils.CleanupTestUserWorkspaces"
+
+    // override the default global context directory with a sub-directory of the gradle build directory
+    // this is so that the tests don't overwrite any context that exists on this same machine.
+    environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
+    mkdir "${project.buildDir}/test-context/"
+
+    // [required] specify the server to cleanup (e.g. -Pserver=terra-dev). no default value, force caller to specify this
+    systemProperty "TERRA_SERVER", project.findProperty("server")
+
+    // [optional] specify that this is a dry run (e.g. -PdryRun)
+    systemProperty "DRY_RUN", project.hasProperty("dryRun").toString()
+
+    dependsOn installDist
+}
+
 // automatic code formatting
 spotless {
     java {

--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ task cleanupTestUserWorkspaces(type: JavaExec) {
     // [optional] specify that this is a dry run (e.g. -PdryRun)
     systemProperty "DRY_RUN", project.hasProperty("dryRun").toString()
 
-    dependsOn installDist
+    dependsOn compileJava
 }
 
 // automatic code formatting

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -115,6 +115,13 @@ public enum TestUsers {
     return dataStoreFactory.getDataStore(StoredCredential.DEFAULT_DATA_STORE_ID);
   }
 
+  /** Returns true if the test user has access to the default WSM spend profile. */
+  public boolean hasSpendAccess() {
+    return spendEnabled.equals(SpendEnabled.CLI_TEST_USERS_GROUP)
+        || spendEnabled.equals(SpendEnabled.DIRECTLY)
+        || spendEnabled.equals(SpendEnabled.OWNER);
+  }
+
   /**
    * Randomly chooses a test user, who is anyone except for the given test user. Helpful e.g.
    * choosing a user that is not the workspace creator.

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -9,9 +9,11 @@ import harness.TestCommand;
 import harness.TestContext;
 import harness.TestUsers;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * This class implements a script to cleanup workspaces owned by test users. Tests are not supposed
@@ -28,6 +30,9 @@ import java.util.Optional;
  * defined, so it's easier to loop through them here.
  */
 public class CleanupTestUserWorkspaces {
+  private static List<UUID> deletedWorkspaces = new ArrayList<>();
+  private static List<UUID> failedWorkspaces = new ArrayList<>();
+
   /**
    * List all workspaces the test user has access to and try to delete each one that the test user
    * owns.
@@ -71,10 +76,13 @@ public class CleanupTestUserWorkspaces {
           TestCommand.runCommandExpectSuccess("workspace", "delete", "--workspace=" + workspace.id);
           System.out.println(
               "Cleaned up workspace: id=" + workspace.id + ", testuser=" + testUser.email);
+          deletedWorkspaces.add(workspace.id);
         }
       } catch (Throwable ex) {
         System.out.println(
             "Error deleting workspace: id=" + workspace.id + ", testuser=" + testUser.email);
+        ex.printStackTrace();
+        failedWorkspaces.add(workspace.id);
         continue;
       }
     }
@@ -111,5 +119,16 @@ public class CleanupTestUserWorkspaces {
                 System.out.println("Error cleaning up workspaces for testuser: " + testUser.email);
               }
             });
+
+    System.out.println("Deleted workspaces:");
+    deletedWorkspaces.forEach(
+        workspaceId -> {
+          System.out.println("  " + workspaceId);
+        });
+    System.out.println("Failed workspaces:");
+    failedWorkspaces.forEach(
+        workspaceId -> {
+          System.out.println("  " + workspaceId);
+        });
   }
 }

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -6,6 +6,7 @@ import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
 import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.type.TypeReference;
 import harness.TestCommand;
+import harness.TestContext;
 import harness.TestUsers;
 import java.io.IOException;
 import java.util.Arrays;
@@ -32,6 +33,8 @@ public class CleanupTestUserWorkspaces {
    * owns.
    */
   private static void deleteWorkspaces(TestUsers testUser, boolean isDryRun) throws IOException {
+    System.out.println("Deleting workspaces for testuser " + testUser.email);
+    TestContext.clearGlobalContextDir();
     testUser.login();
 
     // `terra workspace list`
@@ -75,6 +78,9 @@ public class CleanupTestUserWorkspaces {
         continue;
       }
     }
+
+    // `terra auth revoke`
+    TestCommand.runCommandExpectSuccess("auth", "revoke");
   }
 
   /**

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -1,0 +1,109 @@
+package harness.utils;
+
+import bio.terra.cli.exception.UserActionableException;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
+import bio.terra.workspace.model.IamRole;
+import com.fasterxml.jackson.core.type.TypeReference;
+import harness.TestCommand;
+import harness.TestUsers;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * This class implements a script to cleanup workspaces owned by test users. Tests are not supposed
+ * to leak workspaces, but if they do, the logging in this class should help track down any
+ * offenders. During development, in particular, workspace leaks are more likely, so this is a
+ * backup cleanup mechanism for those.
+ *
+ * <p>The main reason we don't want to leave workspaces around is because it increases the number of
+ * Google groups to which a test user belongs. There is a hard upper limit on the number of groups a
+ * user can belong to, so we want to make sure not to gradually approach the limit over time (e.g.
+ * as happened with william.thunderlord).
+ *
+ * <p>This script is written in Java, instead of Bash, because that's where the test users are
+ * defined, so it's easier to loop through them here.
+ */
+public class CleanupTestUserWorkspaces {
+  /**
+   * List all workspaces the test user has access to and try to delete each one that the test user
+   * owns.
+   */
+  private static void deleteWorkspaces(TestUsers testUser, boolean isDryRun) throws IOException {
+    testUser.login();
+
+    // `terra workspace list`
+    List<UFWorkspace> listWorkspaces =
+        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "workspace", "list");
+
+    List<UFWorkspaceUser> listWorkspaceUsers;
+    for (UFWorkspace workspace : listWorkspaces) {
+      try {
+        // `terra workspace list-users`
+        listWorkspaceUsers =
+            TestCommand.runAndParseCommandExpectSuccess(
+                new TypeReference<>() {}, "workspace", "list-users", "--workspace=" + workspace.id);
+
+        // find the user in the list
+        Optional<UFWorkspaceUser> workspaceUser =
+            listWorkspaceUsers.stream()
+                .filter(user -> user.email.equalsIgnoreCase(testUser.email))
+                .findAny();
+        // skip deleting if the test user is not an owner
+        if (workspaceUser.isEmpty() || !workspaceUser.get().roles.contains(IamRole.OWNER)) {
+          System.out.println(
+              "Skip deleting workspace because test user is not an owner: id="
+                  + workspace.id
+                  + ", testuser="
+                  + testUser.email);
+          continue;
+        }
+
+        System.out.println(
+            "Deleting workspace: id=" + workspace.id + ", testuser=" + testUser.email);
+        if (!isDryRun) {
+          // `terra workspace delete --workspace=$id`
+          TestCommand.runCommandExpectSuccess("workspace", "delete", "--workspace=" + workspace.id);
+          System.out.println(
+              "Cleaned up workspace: id=" + workspace.id + ", testuser=" + testUser.email);
+        }
+      } catch (Throwable ex) {
+        System.out.println(
+            "Error deleting workspace: id=" + workspace.id + ", testuser=" + testUser.email);
+        continue;
+      }
+    }
+  }
+
+  /**
+   * Loop through all test users with spend profile access and try to delete all workspaces they
+   * own.
+   */
+  public static void main(String... args) {
+    // (see the Gradle cleanupTestUserWorkspaces task for how these System properties get set from
+    // Gradle properties)
+    String server = System.getProperty("TERRA_SERVER");
+    if (server == null || server.isEmpty()) {
+      throw new UserActionableException("Specify the server to cleanup.");
+    }
+    TestCommand.runCommandExpectSuccess("server", "set", "--name", server);
+
+    boolean isDryRun = Boolean.parseBoolean(System.getProperty("DRY_RUN"));
+
+    System.out.println("TERRA_SERVER: " + server);
+    System.out.println("DRY_RUN: " + isDryRun);
+
+    Arrays.stream(TestUsers.values())
+        .filter(TestUsers::hasSpendAccess)
+        .forEach(
+            testUser -> {
+              try {
+                deleteWorkspaces(testUser, isDryRun);
+              } catch (IOException e) {
+                System.out.println("Error cleaning up workspaces for testuser: " + testUser.email);
+              }
+            });
+  }
+}


### PR DESCRIPTION
- Added a script to cleanup test user owned workspaces.
- Added an on-demand GitHub action to trigger the script. I made this on-demand because it can't be run concurrently with any tests. It will cause tests to fail as workspaces are deleted out from under them. We could run this at night, e.g. just after the nightly tests, but that could cause problems if someone decides to re-run the nightly GH action during the day (e.g. failed overnight, fix went in, and now re-run).