### PR TITLE
PF-889: Remove cloud platform scope from login flow.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -10,14 +10,14 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -54,16 +54,15 @@ public class User {
   private ServiceAccountCredentials petSACredentials;
 
   // these are the same scopes requested by Terra service swagger pages
-  private static final List<String> USER_SCOPES =
-      Collections.unmodifiableList(Arrays.asList("openid", "email", "profile"));
+  @VisibleForTesting
+  public static final List<String> USER_SCOPES = ImmutableList.of("openid", "email", "profile");
 
   // these are the same scopes requested by Terra service swagger pages, plus the cloud platform
   // scope. pet SAs need the cloud platform scope to talk to GCP directly (e.g. to check the status
   // of an AI notebook)
-  public static final List<String> PET_SA_SCOPES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform"));
+  private static final List<String> PET_SA_SCOPES =
+      ImmutableList.of(
+          "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform");
 
   // google OAuth client secret file
   // (https://developers.google.com/adwords/api/docs/guides/authentication#create_a_client_id_and_client_secret)

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -10,7 +10,6 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
-import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
@@ -54,8 +53,8 @@ public class User {
   private UserCredentials userCredentials;
   private ServiceAccountCredentials petSACredentials;
 
-  @VisibleForTesting
-  public static final List<String> SCOPES =
+  // these are the same scopes requested by Terra service swagger pages
+  private static final List<String> SCOPES =
       Collections.unmodifiableList(Arrays.asList("openid", "email", "profile"));
 
   // google OAuth client secret file

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -56,9 +56,7 @@ public class User {
 
   @VisibleForTesting
   public static final List<String> SCOPES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform"));
+      Collections.unmodifiableList(Arrays.asList("openid", "email", "profile"));
 
   // google OAuth client secret file
   // (https://developers.google.com/adwords/api/docs/guides/authentication#create_a_client_id_and_client_secret)

--- a/src/main/java/bio/terra/cli/businessobject/resources/AiNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resources/AiNotebook.java
@@ -123,7 +123,8 @@ public class AiNotebook extends Resource {
             .location(location)
             .instanceId(instanceId)
             .build();
-    GoogleAiNotebooks notebooks = new GoogleAiNotebooks(Context.requireUser().getUserCredentials());
+    GoogleAiNotebooks notebooks =
+        new GoogleAiNotebooks(Context.requireUser().getPetSACredentials());
     try {
       return Optional.of(notebooks.get(instanceName));
     } catch (Exception ex) {

--- a/src/main/java/bio/terra/cli/businessobject/resources/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resources/BqDataset.java
@@ -73,9 +73,12 @@ public class BqDataset extends Resource {
   public static BqDataset addReferenced(CreateBqDatasetParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference
+    // call WSM to add the reference. use the pet SA credentials instead of the end user's
+    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
+    // scope to perform its access check before adding the reference. note that this means a user
+    // cannot add a reference unless their pet SA has access to it.
     GcpBigQueryDatasetResource addedResource =
-        WorkspaceManagerService.fromContext()
+        WorkspaceManagerService.fromContextForPetSa()
             .createReferencedBigQueryDataset(Context.requireWorkspace().getId(), createParams);
     logger.info("Created BQ dataset: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/businessobject/resources/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resources/GcsBucket.java
@@ -65,9 +65,12 @@ public class GcsBucket extends Resource {
   public static GcsBucket addReferenced(CreateGcsBucketParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference
+    // call WSM to add the reference. use the pet SA credentials instead of the end user's
+    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
+    // scope to perform its access check before adding the reference. note that this means a user
+    // cannot add a reference unless their pet SA has access to it.
     GcpGcsBucketResource addedResource =
-        WorkspaceManagerService.fromContext()
+        WorkspaceManagerService.fromContextForPetSa()
             .createReferencedGcsBucket(Context.requireWorkspace().getId(), createParams);
     logger.info("Created GCS bucket: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/command/notebooks/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Start.java
@@ -22,7 +22,8 @@ public class Start extends BaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     InstanceName instanceName = instanceOption.toInstanceName();
-    GoogleAiNotebooks notebooks = new GoogleAiNotebooks(Context.requireUser().getUserCredentials());
+    GoogleAiNotebooks notebooks =
+        new GoogleAiNotebooks(Context.requireUser().getPetSACredentials());
     notebooks.start(instanceName);
     OUT.println("Notebook instance starting. It may take a few minutes before it is available");
   }

--- a/src/main/java/bio/terra/cli/command/notebooks/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebooks/Stop.java
@@ -22,7 +22,8 @@ public class Stop extends BaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     InstanceName instanceName = instanceOption.toInstanceName();
-    GoogleAiNotebooks notebooks = new GoogleAiNotebooks(Context.requireUser().getUserCredentials());
+    GoogleAiNotebooks notebooks =
+        new GoogleAiNotebooks(Context.requireUser().getPetSACredentials());
     notebooks.stop(instanceName);
     OUT.println("Notebook instance stopped");
   }

--- a/src/main/java/bio/terra/cli/command/resources/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/resources/CheckAccess.java
@@ -26,42 +26,18 @@ public class CheckAccess extends BaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
-    boolean userHasAccess = resource.checkAccess(Resource.CheckAccessCredentials.USER);
-    boolean proxyGroupHasAccess = resource.checkAccess(Resource.CheckAccessCredentials.PET_SA);
-
-    CheckAccess.CheckAccessReturnValue checkAccessReturnValue =
-        new CheckAccess.CheckAccessReturnValue(userHasAccess, proxyGroupHasAccess);
-    formatOption.printReturnValue(checkAccessReturnValue, this::printText);
-  }
-
-  /** POJO class for printing out this command's output. */
-  private static class CheckAccessReturnValue {
-    // true if the user's email has acccess
-    public final boolean userHasAccess;
-
-    // true if the user's proxy group has access
-    public final boolean proxyGroupHasAccess;
-
-    public CheckAccessReturnValue(boolean userHasAccess, boolean proxyGroupHasAccess) {
-      this.userHasAccess = userHasAccess;
-      this.proxyGroupHasAccess = proxyGroupHasAccess;
-    }
+    boolean proxyGroupHasAccess = resource.checkAccess();
+    formatOption.printReturnValue(proxyGroupHasAccess, this::printText);
   }
 
   /** Print this command's output in text format. */
-  public void printText(CheckAccess.CheckAccessReturnValue returnValue) {
+  public void printText(boolean returnValue) {
     User currentUser = Context.requireUser();
-    OUT.println(
-        "User ("
-            + currentUser.getEmail()
-            + ") DOES "
-            + (returnValue.userHasAccess ? "" : "NOT ")
-            + "have access to this resource.");
     OUT.println(
         "User's pet SA in their proxy group ("
             + currentUser.getProxyGroupEmail()
             + ") DOES "
-            + (returnValue.proxyGroupHasAccess ? "" : "NOT ")
+            + (returnValue ? "" : "NOT ")
             + "have access to this resource.");
   }
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
@@ -59,10 +59,10 @@ public class UFAiNotebook extends UFResource {
     OUT.println("GCP project id:                " + projectId);
     OUT.println("AI Notebook instance location: " + location);
     OUT.println("AI Notebook instance id:       " + instanceId);
-    OUT.println("Instance name: " + instanceName == null ? "(undefined)" : instanceName);
-    OUT.println("State:         " + state == null ? "(undefined)" : state);
-    OUT.println("Proxy URL:     " + proxyUri == null ? "(undefined)" : proxyUri);
-    OUT.println("Create time:   " + createTime == null ? "(undefined)" : createTime);
+    OUT.println("Instance name: " + (instanceName == null ? "(undefined)" : instanceName));
+    OUT.println("State:         " + (state == null ? "(undefined)" : state));
+    OUT.println("Proxy URL:     " + (proxyUri == null ? "(undefined)" : proxyUri));
+    OUT.println("Create time:   " + (createTime == null ? "(undefined)" : createTime));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -122,10 +122,19 @@ public class WorkspaceManagerService {
   }
 
   /**
+   * Factory method for class that talks to WSM. Pulls the current server and user from the context.
+   * Uses the pet SA's credentials.
+   */
+  public static WorkspaceManagerService fromContextForPetSa() {
+    return new WorkspaceManagerService(
+        Context.requireUser().getPetSaAccessToken(), Context.getServer());
+  }
+
+  /**
    * Constructor for class that talks to WSM. If the access token is null, only unauthenticated
    * endpoints can be called.
    */
-  public WorkspaceManagerService(@Nullable AccessToken accessToken, Server server) {
+  private WorkspaceManagerService(@Nullable AccessToken accessToken, Server server) {
     this.apiClient = new ApiClient();
 
     this.apiClient.setBasePath(server.getWorkspaceManagerUri());

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -123,7 +123,11 @@ public class WorkspaceManagerService {
 
   /**
    * Factory method for class that talks to WSM. Pulls the current server and user from the context.
-   * Uses the pet SA's credentials.
+   * Uses the pet SA credentials instead of the end user credentials. This is useful for when an
+   * endpoint needs to be called with a cloud platform scope. The CLI does not request any cloud
+   * platform scopes from the end user when they login to the CLI, but it does grant the full
+   * cloud-platform scope to the pet SA credentials. The WSM endpoints to create and check access to
+   * referenced resources currently use this.
    */
   public static WorkspaceManagerService fromContextForPetSa() {
     return new WorkspaceManagerService(

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -12,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -44,13 +45,10 @@ public enum TestUsers {
   // name of the group that includes CLI test users and has spend profile access
   public static final String CLI_TEST_USERS_GROUP_NAME = "cli-test-users";
 
-  // these are the same scopes requested by Terra service swagger pages, plus the cloud platform
-  // scope. test users need the cloud platform scope to talk to GCP directly (e.g. to check the
+  // test users need the cloud platform scope when they talk to GCP directly (e.g. to check the
   // lifecycle property of a GCS bucket, which is not stored as WSM metadata)
-  public static final List<String> SCOPES =
-      Collections.unmodifiableList(
-          Arrays.asList(
-              "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform"));
+  public static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
 
   TestUsers(String email, SpendEnabled spendEnabled) {
     this.email = email;
@@ -73,9 +71,10 @@ public enum TestUsers {
    * @return global context object, populated with the user's credentials
    */
   public void login() throws IOException {
-    // get domain-wide delegated credentials for this user
+    // get domain-wide delegated credentials for this user. use the same scopes that are requested
+    // of CLI users when they login.
     System.out.println("Logging in test user: " + email);
-    GoogleCredentials delegatedUserCredential = getCredentials();
+    GoogleCredentials delegatedUserCredential = getCredentials(User.USER_SCOPES);
 
     // use the domain-wide delegated credential to build a stored credential for the test user
     StoredCredential dwdStoredCredential = new StoredCredential();
@@ -95,8 +94,19 @@ public enum TestUsers {
     User.login();
   }
 
+  /**
+   * Get domain-wide delegated Google credentials for this user that include the cloud-platform
+   * scope. This is useful for when the test user needs to talk directly to GCP, instead of to WSM
+   * or another Terra service.
+   */
+  public GoogleCredentials getCredentialsWithCloudPlatformScope() throws IOException {
+    List<String> scopesWithCloudPlatform = new ArrayList<>(User.USER_SCOPES);
+    scopesWithCloudPlatform.add(CLOUD_PLATFORM_SCOPE);
+    return getCredentials(scopesWithCloudPlatform);
+  }
+
   /** Get domain-wide delegated Google credentials for this user. */
-  public GoogleCredentials getCredentials() throws IOException {
+  private GoogleCredentials getCredentials(List<String> scopes) throws IOException {
     // get a credential for the test-user SA
     Path jsonKey = Path.of("rendered", "test-user-account.json");
     if (!jsonKey.toFile().exists()) {
@@ -107,10 +117,9 @@ public enum TestUsers {
     }
     GoogleCredentials serviceAccountCredential =
         ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
-            .createScoped(SCOPES);
+            .createScoped(scopes);
 
     // use the test-user SA to get a domain-wide delegated credential for the test user
-    System.out.println("Logging in test user: " + email);
     GoogleCredentials delegatedUserCredential = serviceAccountCredential.createDelegated(email);
     delegatedUserCredential.refreshIfExpired();
     return delegatedUserCredential;

--- a/src/test/java/harness/TestUsers.java
+++ b/src/test/java/harness/TestUsers.java
@@ -44,6 +44,14 @@ public enum TestUsers {
   // name of the group that includes CLI test users and has spend profile access
   public static final String CLI_TEST_USERS_GROUP_NAME = "cli-test-users";
 
+  // these are the same scopes requested by Terra service swagger pages, plus the cloud platform
+  // scope. test users need the cloud platform scope to talk to GCP directly (e.g. to check the
+  // lifecycle property of a GCS bucket, which is not stored as WSM metadata)
+  public static final List<String> SCOPES =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform"));
+
   TestUsers(String email, SpendEnabled spendEnabled) {
     this.email = email;
     this.spendEnabled = spendEnabled;
@@ -99,7 +107,7 @@ public enum TestUsers {
     }
     GoogleCredentials serviceAccountCredential =
         ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
-            .createScoped(User.SCOPES);
+            .createScoped(SCOPES);
 
     // use the test-user SA to get a domain-wide delegated credential for the test user
     System.out.println("Logging in test user: " + email);

--- a/src/test/java/harness/utils/Auth.java
+++ b/src/test/java/harness/utils/Auth.java
@@ -1,0 +1,22 @@
+package harness.utils;
+
+import bio.terra.cli.serialization.userfacing.UFAuthStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import harness.TestCommand;
+
+/** Utility methods for working with `terra auth` commands. */
+public class Auth {
+  /**
+   * Calls `terra auth status` to get the proxy group email for the current user. Throws an
+   * exception if there is no logged in user.
+   */
+  public static String getProxyGroupEmail() throws JsonProcessingException {
+    // `terra auth status --format=json`
+    UFAuthStatus authStatus =
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    if (!authStatus.loggedIn) {
+      throw new RuntimeException("Error getting proxy group email because user is not logged in.");
+    }
+    return authStatus.proxyGroupEmail;
+  }
+}

--- a/src/test/java/harness/utils/ExternalBQDatasets.java
+++ b/src/test/java/harness/utils/ExternalBQDatasets.java
@@ -42,13 +42,13 @@ public class ExternalBQDatasets {
   }
 
   /**
-   * Grant a given user reader access to a dataset. This method uses SA credentials to set IAM
-   * policy on a bucket in an external (to WSM) project.
+   * Grant a given user or group reader access to a dataset. This method uses SA credentials to set
+   * IAM policy on a bucket in an external (to WSM) project.
    */
-  public static void grantReadAccess(Dataset dataset, Acl.Entity user) throws IOException {
+  public static void grantReadAccess(Dataset dataset, Acl.Entity userOrGroup) throws IOException {
     BigQuery bigQuery = getBQClient();
     ArrayList<Acl> acls = new ArrayList<>(dataset.getAcl());
-    acls.add(Acl.of(user, Acl.Role.READER));
+    acls.add(Acl.of(userOrGroup, Acl.Role.READER));
     bigQuery.update(dataset.toBuilder().setAcl(acls).build());
   }
 

--- a/src/test/java/harness/utils/ExternalBQDatasets.java
+++ b/src/test/java/harness/utils/ExternalBQDatasets.java
@@ -45,10 +45,10 @@ public class ExternalBQDatasets {
    * Grant a given user reader access to a dataset. This method uses SA credentials to set IAM
    * policy on a bucket in an external (to WSM) project.
    */
-  public static void grantReadAccess(Dataset dataset, String email) throws IOException {
+  public static void grantReadAccess(Dataset dataset, Acl.Entity user) throws IOException {
     BigQuery bigQuery = getBQClient();
     ArrayList<Acl> acls = new ArrayList<>(dataset.getAcl());
-    acls.add(Acl.of(new Acl.User(email), Acl.Role.READER));
+    acls.add(Acl.of(user, Acl.Role.READER));
     bigQuery.update(dataset.toBuilder().setAcl(acls).build());
   }
 

--- a/src/test/java/harness/utils/ExternalGCSBuckets.java
+++ b/src/test/java/harness/utils/ExternalGCSBuckets.java
@@ -47,31 +47,32 @@ public class ExternalGCSBuckets {
   }
 
   /**
-   * Grant a given user object viewer access to a bucket. This method uses SA credentials to set IAM
-   * policy on a bucket in an external (to WSM) project.
+   * Grant a given user or group object viewer access to a bucket. This method uses SA credentials
+   * to set IAM policy on a bucket in an external (to WSM) project.
    */
-  public static void grantReadAccess(Bucket bucket, Identity user) throws IOException {
-    grantAccess(bucket, user, StorageRoles.objectViewer());
+  public static void grantReadAccess(Bucket bucket, Identity userOrGroup) throws IOException {
+    grantAccess(bucket, userOrGroup, StorageRoles.objectViewer());
   }
 
   /**
-   * Grant a given user admin access to a bucket. This method uses SA credentials to set IAM policy
-   * on a bucket in an external (to WSM) project.
-   */
-  public static void grantWriteAccess(Bucket bucket, Identity user) throws IOException {
-    grantAccess(bucket, user, StorageRoles.admin());
-  }
-
-  /**
-   * Helper method to grant a given user roles on a bucket. This method uses SA credentials to set
+   * Grant a given user or group admin access to a bucket. This method uses SA credentials to set
    * IAM policy on a bucket in an external (to WSM) project.
    */
-  private static void grantAccess(Bucket bucket, Identity user, Role... roles) throws IOException {
+  public static void grantWriteAccess(Bucket bucket, Identity userOrGroup) throws IOException {
+    grantAccess(bucket, userOrGroup, StorageRoles.admin());
+  }
+
+  /**
+   * Helper method to grant a given user or group roles on a bucket. This method uses SA credentials
+   * to set IAM policy on a bucket in an external (to WSM) project.
+   */
+  private static void grantAccess(Bucket bucket, Identity userOrGroup, Role... roles)
+      throws IOException {
     Storage storage = getStorageClient();
     Policy currentPolicy = storage.getIamPolicy(bucket.getName());
     Policy.Builder updatedPolicyBuilder = currentPolicy.toBuilder();
     for (Role role : roles) {
-      updatedPolicyBuilder.addIdentity(role, user);
+      updatedPolicyBuilder.addIdentity(role, userOrGroup);
     }
     storage.setIamPolicy(bucket.getName(), updatedPolicyBuilder.build());
   }

--- a/src/test/java/harness/utils/ExternalGCSBuckets.java
+++ b/src/test/java/harness/utils/ExternalGCSBuckets.java
@@ -50,13 +50,8 @@ public class ExternalGCSBuckets {
    * Grant a given user object viewer access to a bucket. This method uses SA credentials to set IAM
    * policy on a bucket in an external (to WSM) project.
    */
-  public static void grantReadAccess(Bucket bucket, String email) throws IOException {
-    grantAccess(
-        bucket,
-        Identity.user(email),
-        // TODO (PF-717): revisit this once we're calling WSM endpoints for check-access
-        StorageRoles.objectViewer(),
-        StorageRoles.legacyBucketReader());
+  public static void grantReadAccess(Bucket bucket, Identity user) throws IOException {
+    grantAccess(bucket, user, StorageRoles.objectViewer());
   }
 
   /**

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -235,7 +235,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     Dataset createdDatasetOnCloud =
-        ExternalBQDatasets.getBQClient(workspaceCreator.getCredentials())
+        ExternalBQDatasets.getBQClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
             .getDataset(DatasetId.of(workspace.googleProjectId, datasetId));
     assertNotNull(createdDatasetOnCloud, "looking up dataset via BQ API succeeded");
     assertEquals(

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -7,9 +7,11 @@ import static unit.BqDatasetControlled.listOneDatasetResourceWithName;
 
 import bio.terra.cli.serialization.userfacing.resources.UFBqDataset;
 import bio.terra.workspace.model.CloningInstructionsEnum;
+import com.google.cloud.bigquery.Acl;
 import com.google.cloud.bigquery.Dataset;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.Auth;
 import harness.utils.ExternalBQDatasets;
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +34,11 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
   protected void setupOnce() throws IOException {
     super.setupOnce();
     externalDataset = ExternalBQDatasets.createDataset();
-    ExternalBQDatasets.grantReadAccess(externalDataset, workspaceCreator.email);
+    ExternalBQDatasets.grantReadAccess(externalDataset, new Acl.User(workspaceCreator.email));
+
+    // grant the user's proxy group access to the dataset so that it will pass WSM's access check
+    // when adding it as a referenced resource
+    ExternalBQDatasets.grantReadAccess(externalDataset, new Acl.Group(Auth.getProxyGroupEmail()));
   }
 
   @AfterAll

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -206,7 +206,8 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     Bucket createdBucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentials()).get(bucketName);
+        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
+            .get(bucketName);
     assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         location, createdBucketOnCloud.getLocation(), "bucket location matches create input");
@@ -306,7 +307,8 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
 
     // check the updated storage class from GCS directly
     Bucket bucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentials()).get(bucketName);
+        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
+            .get(bucketName);
     assertNotNull(bucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         newStorage.toString(),
@@ -362,7 +364,8 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
 
     // check the storage class from GCS directly
     Bucket bucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentials()).get(bucketName);
+        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
+            .get(bucketName);
     assertNotNull(bucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         newStorage.toString(),

--- a/src/test/java/unit/GcsBucketLifecycle.java
+++ b/src/test/java/unit/GcsBucketLifecycle.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import bio.terra.cli.serialization.userfacing.UFAuthStatus;
 import com.google.api.client.util.DateTime;
 import com.google.cloud.Identity;
 import com.google.cloud.storage.Bucket;
@@ -13,6 +12,7 @@ import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.StorageClass;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.Auth;
 import harness.utils.ExternalGCSBuckets;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -39,14 +39,10 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
     super.setupOnce();
     externalBucket = ExternalGCSBuckets.createBucket();
 
-    // `terra auth status --format=json`
-    UFAuthStatus authStatus =
-        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
-
     // grant the user's proxy group write access to the bucket, so we can test calling `terra gsutil
     // lifecycle` with the same JSON format used for creating controlled bucket resources with
     // lifecycle rules
-    ExternalGCSBuckets.grantWriteAccess(externalBucket, Identity.group(authStatus.proxyGroupEmail));
+    ExternalGCSBuckets.grantWriteAccess(externalBucket, Identity.group(Auth.getProxyGroupEmail()));
   }
 
   @Override

--- a/src/test/java/unit/GcsBucketLifecycle.java
+++ b/src/test/java/unit/GcsBucketLifecycle.java
@@ -446,7 +446,8 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
   private List<? extends BucketInfo.LifecycleRule> getLifecycleRulesFromCloud(String bucketName)
       throws IOException {
     Bucket createdBucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentials()).get(bucketName);
+        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
+            .get(bucketName);
     assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
 
     List<? extends BucketInfo.LifecycleRule> lifecycleRules =

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -7,9 +7,11 @@ import static unit.GcsBucketControlled.listOneBucketResourceWithName;
 
 import bio.terra.cli.serialization.userfacing.resources.UFGcsBucket;
 import bio.terra.workspace.model.CloningInstructionsEnum;
+import com.google.cloud.Identity;
 import com.google.cloud.storage.Bucket;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.Auth;
 import harness.utils.ExternalGCSBuckets;
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +34,11 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
   protected void setupOnce() throws IOException {
     super.setupOnce();
     externalBucket = ExternalGCSBuckets.createBucket();
-    ExternalGCSBuckets.grantReadAccess(externalBucket, workspaceCreator.email);
+    ExternalGCSBuckets.grantReadAccess(externalBucket, Identity.user(workspaceCreator.email));
+
+    // grant the user's proxy group access to the bucket so that it will pass WSM's access check
+    // when adding it as a referenced resource
+    ExternalGCSBuckets.grantReadAccess(externalBucket, Identity.group(Auth.getProxyGroupEmail()));
   }
 
   @AfterAll


### PR DESCRIPTION
- Removed the cloud-platform scope from the CLI login flow. Previously, this was needed to create cloud resources on behalf of the user, while the WSM controlled resource endpoints were under development. Now that the CLI always goes through WSM, we don't want to request this scope any more.
- This additional scope was causing logins with Google/Verily corporate emails (i.e. `@google.com`, `@verily.com`) to fail, because there is a corporate policy against granting the cloud-platform scope. This change fixes this.
- Test users still need the cloud-platform scope when they talk to GCP directly (e.g. to query resource properties that are not stored as WSM metadata). Changed the tests to use the same scopes as CLI users, except when they are talking to the cloud directly. In those cases, they use the CLI scopes + cloud-platform.

See also write-up [here](https://docs.google.com/document/d/1m_-UZCaZlzZ48nUF0BdBXghVaD6aSUqXr9XbioXeTYc/edit?resourcekey=0-2GAc8iE2sRjpb_tW-UBJSQ#).