### PR TITLE
PF-435: Confirmation prompt for `delete` commands.

### DIFF
--- a/src/main/java/bio/terra/cli/apps/utils/DockerClientWrapper.java
+++ b/src/main/java/bio/terra/cli/apps/utils/DockerClientWrapper.java
@@ -2,7 +2,7 @@ package bio.terra.cli.apps.utils;
 
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -195,7 +195,7 @@ public class DockerClientWrapper {
     @Override
     public void onNext(Frame frame) {
       String logStr = new String(frame.getPayload(), StandardCharsets.UTF_8);
-      PrintStream out = Printer.getOut();
+      PrintStream out = UserIO.getOut();
       out.print(logStr);
       out.flush();
 

--- a/src/main/java/bio/terra/cli/apps/utils/LocalProcessLauncher.java
+++ b/src/main/java/bio/terra/cli/apps/utils/LocalProcessLauncher.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.apps.utils;
 
 import bio.terra.cli.exception.SystemException;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -63,11 +63,11 @@ public class LocalProcessLauncher {
 
   /** Stream standard out/err from the child process to the CLI console. */
   public void streamOutputForProcess() {
-    Runnable streamStdOut = () -> streamOutput(process.getInputStream(), Printer.getOut());
+    Runnable streamStdOut = () -> streamOutput(process.getInputStream(), UserIO.getOut());
     stdOutThread = new Thread(streamStdOut);
     stdOutThread.start();
 
-    Runnable streamStdErr = () -> streamOutput(process.getErrorStream(), Printer.getErr());
+    Runnable streamStdErr = () -> streamOutput(process.getErrorStream(), UserIO.getErr());
     stdErrThread = new Thread(streamStdErr);
     stdErrThread.start();
   }

--- a/src/main/java/bio/terra/cli/apps/utils/LocalProcessLauncher.java
+++ b/src/main/java/bio/terra/cli/apps/utils/LocalProcessLauncher.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +80,7 @@ public class LocalProcessLauncher {
    */
   private static void streamOutput(InputStream fromStream, PrintStream toStream) {
     try (BufferedReader bufferedReader =
-        new BufferedReader(new InputStreamReader(fromStream, Charset.forName("UTF-8")))) {
+        new BufferedReader(new InputStreamReader(fromStream, StandardCharsets.UTF_8))) {
 
       String line;
       while ((line = bufferedReader.readLine()) != null) {

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -8,7 +8,7 @@ import bio.terra.cli.command.app.passthrough.Nextflow;
 import bio.terra.cli.exception.PassthroughException;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Optional;
@@ -73,7 +73,7 @@ public class Main implements Runnable {
     // set the output and error streams to the defaults: stdout, stderr
     // save pointers to these streams in a singleton class, so we can access them throughout the
     // codebase without passing them around
-    Printer.setupPrinting(cmd);
+    UserIO.setupPrinting(cmd);
 
     // allow mixing options and parameters for all commands except the pass-through app commands.
     // this is because any options that follow the app command name should NOT be interpreted by the

--- a/src/main/java/bio/terra/cli/command/app/List.java
+++ b/src/main/java/bio/terra/cli/command/app/List.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.app;
 
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Arrays;
 import java.util.Comparator;
 import picocli.CommandLine;
@@ -18,7 +18,7 @@ public class List extends BaseCommand {
   @Override
   protected void execute() {
     java.util.List<String> returnValue =
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             Arrays.asList(PassThrough.values()),
             Comparator.comparing(PassThrough::name),
             Enum::toString);

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -19,7 +19,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing Terra group. */
   @Override
   protected void execute() {
-    if (!deletePromptOption.promptReturnedYes()) {
+    if (deletePromptOption.confirmationPromptReturnedNo()) {
       return;
     }
     Group group = Group.get(groupNameOption.name);

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -19,9 +19,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing Terra group. */
   @Override
   protected void execute() {
-    if (deletePromptOption.confirmationPromptReturnedNo()) {
-      return;
-    }
+    deletePromptOption.throwIfConfirmationPromptNegative();
     Group group = Group.get(groupNameOption.name);
     group.delete();
     formatOption.printReturnValue(new UFGroup(group), Delete::printText);

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.groups;
 
 import bio.terra.cli.businessobject.Group;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.DeletePrompt;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GroupName;
 import bio.terra.cli.serialization.userfacing.UFGroup;
@@ -11,12 +12,16 @@ import picocli.CommandLine.Command;
 /** This class corresponds to the third-level "terra groups delete" command. */
 @Command(name = "delete", description = "Delete an existing Terra group.")
 public class Delete extends BaseCommand {
+  @CommandLine.Mixin DeletePrompt deletePromptOption;
   @CommandLine.Mixin GroupName groupNameOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Delete an existing Terra group. */
   @Override
   protected void execute() {
+    if (!deletePromptOption.promptReturnedYes()) {
+      return;
+    }
     Group group = Group.get(groupNameOption.name);
     group.delete();
     formatOption.printReturnValue(new UFGroup(group), Delete::printText);

--- a/src/main/java/bio/terra/cli/command/groups/Delete.java
+++ b/src/main/java/bio/terra/cli/command/groups/Delete.java
@@ -19,7 +19,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing Terra group. */
   @Override
   protected void execute() {
-    deletePromptOption.throwIfConfirmationPromptNegative();
+    deletePromptOption.confirmOrThrow();
     Group group = Group.get(groupNameOption.name);
     group.delete();
     formatOption.printReturnValue(new UFGroup(group), Delete::printText);

--- a/src/main/java/bio/terra/cli/command/groups/List.java
+++ b/src/main/java/bio/terra/cli/command/groups/List.java
@@ -4,7 +4,7 @@ import bio.terra.cli.businessobject.Group;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFGroup;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -18,7 +18,7 @@ public class List extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        Printer.sortAndMap(Group.list(), Comparator.comparing(Group::getName), UFGroup::new),
+        UserIO.sortAndMap(Group.list(), Comparator.comparing(Group::getName), UFGroup::new),
         List::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/groups/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/groups/ListUsers.java
@@ -5,7 +5,7 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GroupName;
 import bio.terra.cli.serialization.userfacing.UFGroupMember;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import java.util.List;
 import picocli.CommandLine;
@@ -22,7 +22,7 @@ public class ListUsers extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             Group.get(groupNameOption.name).getMembers(),
             Comparator.comparing(Group.Member::getEmail),
             UFGroupMember::new),

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -21,7 +21,7 @@ public class Delete extends BaseCommand {
   /** Delete a resource from the workspace. */
   @Override
   protected void execute() {
-    deletePromptOption.throwIfConfirmationPromptNegative();
+    deletePromptOption.confirmOrThrow();
     workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     resource.delete();

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resources;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.DeletePrompt;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -12,14 +13,17 @@ import picocli.CommandLine;
 /** This class corresponds to the third-level "terra resources delete" command. */
 @CommandLine.Command(name = "delete", description = "Delete a resource from the workspace.")
 public class Delete extends BaseCommand {
+  @CommandLine.Mixin DeletePrompt deletePromptOption;
   @CommandLine.Mixin ResourceName resourceNameOption;
-
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Delete a resource from the workspace. */
   @Override
   protected void execute() {
+    if (!deletePromptOption.promptReturnedYes()) {
+      return;
+    }
     workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     resource.delete();

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -21,9 +21,7 @@ public class Delete extends BaseCommand {
   /** Delete a resource from the workspace. */
   @Override
   protected void execute() {
-    if (deletePromptOption.confirmationPromptReturnedNo()) {
-      return;
-    }
+    deletePromptOption.throwIfConfirmationPromptNegative();
     workspaceOption.overrideIfSpecified();
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     resource.delete();

--- a/src/main/java/bio/terra/cli/command/resources/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resources/Delete.java
@@ -21,7 +21,7 @@ public class Delete extends BaseCommand {
   /** Delete a resource from the workspace. */
   @Override
   protected void execute() {
-    if (!deletePromptOption.promptReturnedYes()) {
+    if (deletePromptOption.confirmationPromptReturnedNo()) {
       return;
     }
     workspaceOption.overrideIfSpecified();

--- a/src/main/java/bio/terra/cli/command/server/List.java
+++ b/src/main/java/bio/terra/cli/command/server/List.java
@@ -5,7 +5,7 @@ import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFServer;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -20,7 +20,7 @@ public class List extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        Printer.sortAndMap(Server.list(), Comparator.comparing(Server::getName), UFServer::new),
+        UserIO.sortAndMap(Server.list(), Comparator.comparing(Server::getName), UFServer::new),
         this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.shared;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.User;
 import bio.terra.cli.utils.Logger;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintStream;
 import java.util.concurrent.Callable;
@@ -39,8 +39,8 @@ public abstract class BaseCommand implements Callable<Integer> {
   public Integer call() {
     // pull the output streams from the singleton object setup by the top-level Main class
     // in the future, these streams could also be controlled by a global context property
-    OUT = Printer.getOut();
-    ERR = Printer.getErr();
+    OUT = UserIO.getOut();
+    ERR = UserIO.getErr();
 
     // read in the global context and setup logging
     Context.initializeFromDisk();

--- a/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.exception.UserActionableException;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
@@ -11,8 +11,7 @@ import picocli.CommandLine;
  * Command helper class that defines the --quiet flag for suppressing interactive user input, and
  * prompting the user for a `Y/N`=proceed/abort confirmation if the flag is not specified.
  *
- * <p>Commands that use this option should call {@link #throwIfConfirmationPromptNegative()} before
- * any business logic.
+ * <p>Commands that use this option should call {@link #confirmOrThrow()} before any business logic.
  *
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
@@ -25,12 +24,12 @@ public class DeletePrompt {
    * Helper method to generate an interactive confirmation prompt if the `--quiet` option is not
    * specified. Throws a {@link UserActionableException} if the prompt response is negative.
    */
-  public void throwIfConfirmationPromptNegative() {
+  public void confirmOrThrow() {
     boolean promptReturnedYes = true; // default to Y=yes if user input is suppressed
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     if (!quiet) {
       OUT.print("Are you sure you want to delete (y/N)? ");
-      Scanner reader = new Scanner(Printer.getIn(), StandardCharsets.UTF_8);
+      Scanner reader = new Scanner(UserIO.getIn(), StandardCharsets.UTF_8);
       String deletePrompt = reader.nextLine();
       promptReturnedYes =
           deletePrompt.equalsIgnoreCase("y") || deletePrompt.equalsIgnoreCase("yes");

--- a/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
@@ -1,0 +1,43 @@
+package bio.terra.cli.command.shared.options;
+
+import bio.terra.cli.utils.Printer;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+import picocli.CommandLine;
+
+/**
+ * Command helper class that defines the --quiet flag for suppressing interactive user input, and
+ * prompting the user for a `Y/N`=proceed/abort confirmation if the flag is not specified.
+ *
+ * <p>Commands that use this option should call {@link #promptReturnedYes()} before any business
+ * logic. e.g. if (!deletePromptOption.promptReturnedYes()) { return; }
+ *
+ * <p>This class is meant to be used as a @CommandLine.Mixin.
+ */
+public class DeletePrompt {
+
+  @CommandLine.Option(names = "--quiet", description = "Suppress interactive prompt and delete.")
+  private boolean quiet;
+
+  /**
+   * Helper method to generate an interactive confirmation prompt if the `--quiet` option is not
+   * specified.
+   */
+  public boolean promptReturnedYes() {
+    boolean promptReturnedYes = true; // default to Y=yes if user input is suppressed
+    PrintStream OUT = Printer.getOut();
+    if (!quiet) {
+      OUT.print("Are you sure you want to delete (y/N)? ");
+      Scanner reader = new Scanner(Printer.getIn(), StandardCharsets.UTF_8);
+      String deletePrompt = reader.nextLine();
+      promptReturnedYes =
+          deletePrompt.equalsIgnoreCase("y") || deletePrompt.equalsIgnoreCase("yes");
+    }
+
+    if (!promptReturnedYes) {
+      OUT.println("Aborting delete.");
+    }
+    return promptReturnedYes;
+  }
+}

--- a/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
@@ -23,7 +23,7 @@ public class DeletePrompt {
 
   /**
    * Helper method to generate an interactive confirmation prompt if the `--quiet` option is not
-   * specified.
+   * specified. Throws a {@link UserActionableException} if the prompt response is negative.
    */
   public void throwIfConfirmationPromptNegative() {
     boolean promptReturnedYes = true; // default to Y=yes if user input is suppressed

--- a/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
@@ -10,8 +10,8 @@ import picocli.CommandLine;
  * Command helper class that defines the --quiet flag for suppressing interactive user input, and
  * prompting the user for a `Y/N`=proceed/abort confirmation if the flag is not specified.
  *
- * <p>Commands that use this option should call {@link #promptReturnedYes()} before any business
- * logic. e.g. if (!deletePromptOption.promptReturnedYes()) { return; }
+ * <p>Commands that use this option should call {@link #confirmationPromptReturnedNo()} before any
+ * business logic. e.g. if (deletePromptOption.confirmationPromptReturnedNo()) { return; }
  *
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
@@ -24,7 +24,7 @@ public class DeletePrompt {
    * Helper method to generate an interactive confirmation prompt if the `--quiet` option is not
    * specified.
    */
-  public boolean promptReturnedYes() {
+  public boolean confirmationPromptReturnedNo() {
     boolean promptReturnedYes = true; // default to Y=yes if user input is suppressed
     PrintStream OUT = Printer.getOut();
     if (!quiet) {
@@ -38,6 +38,6 @@ public class DeletePrompt {
     if (!promptReturnedYes) {
       OUT.println("Aborting delete.");
     }
-    return promptReturnedYes;
+    return !promptReturnedYes;
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/DeletePrompt.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.command.shared.options;
 
+import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.utils.Printer;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -10,8 +11,8 @@ import picocli.CommandLine;
  * Command helper class that defines the --quiet flag for suppressing interactive user input, and
  * prompting the user for a `Y/N`=proceed/abort confirmation if the flag is not specified.
  *
- * <p>Commands that use this option should call {@link #confirmationPromptReturnedNo()} before any
- * business logic. e.g. if (deletePromptOption.confirmationPromptReturnedNo()) { return; }
+ * <p>Commands that use this option should call {@link #throwIfConfirmationPromptNegative()} before
+ * any business logic.
  *
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
@@ -24,7 +25,7 @@ public class DeletePrompt {
    * Helper method to generate an interactive confirmation prompt if the `--quiet` option is not
    * specified.
    */
-  public boolean confirmationPromptReturnedNo() {
+  public void throwIfConfirmationPromptNegative() {
     boolean promptReturnedYes = true; // default to Y=yes if user input is suppressed
     PrintStream OUT = Printer.getOut();
     if (!quiet) {
@@ -36,8 +37,7 @@ public class DeletePrompt {
     }
 
     if (!promptReturnedYes) {
-      OUT.println("Aborting delete.");
+      throw new UserActionableException("Delete aborted.");
     }
-    return !promptReturnedYes;
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/Format.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.utils.JacksonMapper;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import java.util.function.Consumer;
@@ -80,7 +80,7 @@ public class Format {
     // use Jackson to map the object to a JSON-formatted text block
     ObjectWriter objectWriter = JacksonMapper.getMapper().writerWithDefaultPrettyPrinter();
     try {
-      Printer.getOut().println(objectWriter.writeValueAsString(returnValue));
+      UserIO.getOut().println(objectWriter.writeValueAsString(returnValue));
     } catch (JsonProcessingException jsonEx) {
       throw new SystemException("Error JSON-formatting the command return value.", jsonEx);
     }
@@ -94,7 +94,7 @@ public class Format {
    */
   public static <T> void printText(T returnValue) {
     if (returnValue != null) {
-      Printer.getOut().println(returnValue.toString());
+      UserIO.getOut().println(returnValue.toString());
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
  * for this command.
  *
  * <p>Commands that use this option should call {@link #overrideIfSpecified()} before all other
- * logic.
+ * business logic.
  *
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */

--- a/src/main/java/bio/terra/cli/command/spend/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/spend/ListUsers.java
@@ -4,7 +4,7 @@ import bio.terra.cli.businessobject.SpendProfileUser;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFSpendProfileUser;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import java.util.List;
 import picocli.CommandLine;
@@ -22,7 +22,7 @@ public class ListUsers extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             SpendProfileUser.list(),
             Comparator.comparing(SpendProfileUser::getEmail),
             UFSpendProfileUser::new),

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.DeletePrompt;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -12,13 +13,16 @@ import picocli.CommandLine.Command;
 /** This class corresponds to the third-level "terra workspace delete" command. */
 @Command(name = "delete", description = "Delete an existing workspace.")
 public class Delete extends BaseCommand {
-
+  @CommandLine.Mixin DeletePrompt deletePromptOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
   /** Delete an existing workspace. */
   @Override
   protected void execute() {
+    if (!deletePromptOption.promptReturnedYes()) {
+      return;
+    }
     workspaceOption.overrideIfSpecified();
     Workspace workspaceToDelete = Context.requireWorkspace();
     workspaceToDelete.delete();

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -20,7 +20,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing workspace. */
   @Override
   protected void execute() {
-    if (!deletePromptOption.promptReturnedYes()) {
+    if (deletePromptOption.confirmationPromptReturnedNo()) {
       return;
     }
     workspaceOption.overrideIfSpecified();

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -20,7 +20,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing workspace. */
   @Override
   protected void execute() {
-    deletePromptOption.throwIfConfirmationPromptNegative();
+    deletePromptOption.confirmOrThrow();
     workspaceOption.overrideIfSpecified();
     Workspace workspaceToDelete = Context.requireWorkspace();
     workspaceToDelete.delete();

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -20,9 +20,7 @@ public class Delete extends BaseCommand {
   /** Delete an existing workspace. */
   @Override
   protected void execute() {
-    if (deletePromptOption.confirmationPromptReturnedNo()) {
-      return;
-    }
+    deletePromptOption.throwIfConfirmationPromptNegative();
     workspaceOption.overrideIfSpecified();
     Workspace workspaceToDelete = Context.requireWorkspace();
     workspaceToDelete.delete();

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -5,7 +5,7 @@ import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import java.util.Optional;
 import picocli.CommandLine;
@@ -39,7 +39,7 @@ public class List extends BaseCommand {
   @Override
   protected void execute() {
     formatOption.printReturnValue(
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             Workspace.list(offset, limit),
             Comparator.comparing(Workspace::getName),
             UFWorkspace::new),

--- a/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
@@ -5,7 +5,7 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import java.util.Comparator;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -22,7 +22,7 @@ public class ListUsers extends BaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     formatOption.printReturnValue(
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             WorkspaceUser.list(),
             Comparator.comparing(WorkspaceUser::getEmail),
             UFWorkspaceUser::new),

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
@@ -5,7 +5,7 @@ import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.Logger;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -57,7 +57,7 @@ public class UFConfig {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("[app-launch] app launch mode = " + browserLaunchOption);
     OUT.println("[browser] browser launch for login = " + commandRunnerOption);
     OUT.println("[image] docker image id = " + dockerImageId);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFGroup.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFGroup.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Group;
 import bio.terra.cli.service.SamService.GroupPolicy;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -38,9 +38,9 @@ public class UFGroup {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     List<String> policiesStr =
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             currentUserPolicies, Comparator.comparing(GroupPolicy::name), GroupPolicy::toString);
     OUT.println(name);
     OUT.println("  Email: " + email);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFGroupMember.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFGroupMember.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Group;
 import bio.terra.cli.service.SamService.GroupPolicy;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -36,10 +36,9 @@ public class UFGroupMember {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     List<String> policiesStr =
-        Printer.sortAndMap(
-            policies, Comparator.comparing(GroupPolicy::name), GroupPolicy::toString);
+        UserIO.sortAndMap(policies, Comparator.comparing(GroupPolicy::name), GroupPolicy::toString);
     OUT.println(email + ": " + String.join(", ", policiesStr));
   }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.ControlledResourceIamRole;
@@ -63,7 +63,7 @@ public abstract class UFResource {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("Name:         " + name);
     OUT.println("Description:  " + description);
     OUT.println("Stewardship:  " + stewardshipType);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Server;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -41,7 +41,7 @@ public class UFServer {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println(name + ": " + description);
   }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFSpendProfileUser.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFSpendProfileUser.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.SpendProfileUser;
 import bio.terra.cli.service.SpendProfileManagerService.SpendProfilePolicy;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -36,9 +36,9 @@ public class UFSpendProfileUser {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     List<String> policiesStr =
-        Printer.sortAndMap(
+        UserIO.sortAndMap(
             policies, Comparator.comparing(SpendProfilePolicy::name), SpendProfilePolicy::toString);
     OUT.println(email + ": " + String.join(", ", policiesStr));
   }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFUser.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFUser.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.User;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -38,7 +38,7 @@ public class UFUser {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("User email: " + email);
     OUT.println("Proxy group email: " + proxyGroupEmail);
     OUT.println("LOGGED " + (loggedIn ? "IN" : "OUT"));

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -45,7 +45,7 @@ public class UFWorkspace {
 
   /** Print out a workspace object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("Terra workspace id: " + id);
     OUT.println("Display name: " + name);
     OUT.println("Description: " + description);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.WorkspaceUser;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
@@ -35,7 +35,7 @@ public class UFWorkspaceUser {
 
   /** Print out this object in text format. */
   public void print() {
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     List<String> rolesStr = roles.stream().map(IamRole::toString).collect(Collectors.toList());
     OUT.println(email + ": " + String.join(",", rolesStr));
   }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFAiNotebook.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing.resources;
 
 import bio.terra.cli.businessobject.resources.AiNotebook;
 import bio.terra.cli.serialization.userfacing.UFResource;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.api.services.notebooks.v1.model.Instance;
@@ -55,7 +55,7 @@ public class UFAiNotebook extends UFResource {
   /** Print out this object in text format. */
   public void print() {
     super.print();
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("GCP project id:                " + projectId);
     OUT.println("AI Notebook instance location: " + location);
     OUT.println("AI Notebook instance id:       " + instanceId);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing.resources;
 
 import bio.terra.cli.businessobject.resources.BqDataset;
 import bio.terra.cli.serialization.userfacing.UFResource;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -36,7 +36,7 @@ public class UFBqDataset extends UFResource {
   /** Print out this object in text format. */
   public void print() {
     super.print();
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("GCP project id: " + projectId);
     OUT.println("Big Query dataset id: " + datasetId);
   }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFGcsBucket.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFGcsBucket.java
@@ -2,7 +2,7 @@ package bio.terra.cli.serialization.userfacing.resources;
 
 import bio.terra.cli.businessobject.resources.GcsBucket;
 import bio.terra.cli.serialization.userfacing.UFResource;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -33,7 +33,7 @@ public class UFGcsBucket extends UFResource {
   /** Print out this object in text format. */
   public void print() {
     super.print();
-    PrintStream OUT = Printer.getOut();
+    PrintStream OUT = UserIO.getOut();
     OUT.println("GCS bucket name: " + bucketName);
   }
 

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.service;
 
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.extensions.java6.auth.oauth2.AbstractPromptReceiver;
@@ -126,7 +126,7 @@ public final class GoogleOauth {
   private static class NoLaunchBrowser implements AuthorizationCodeInstalledApp.Browser {
     @Override
     public void browse(String url) {
-      PrintStream out = Printer.getOut();
+      PrintStream out = UserIO.getOut();
       out.println("Please open the following address in a browser on any machine:");
       out.println("  " + url);
     }

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Date;
 import java.util.List;
@@ -66,7 +66,7 @@ public final class GoogleOauth {
     // load client_secret.json file
     GoogleClientSecrets clientSecrets =
         GoogleClientSecrets.load(
-            JSON_FACTORY, new InputStreamReader(clientSecretFile, Charset.forName("UTF-8")));
+            JSON_FACTORY, new InputStreamReader(clientSecretFile, StandardCharsets.UTF_8));
 
     // setup the Google OAuth2 flow
     GoogleAuthorizationCodeFlow flow = getOAuth2Flow(scopes, clientSecrets, dataStoreDir);
@@ -145,7 +145,7 @@ public final class GoogleOauth {
     // load client_secret.json file
     GoogleClientSecrets clientSecrets =
         GoogleClientSecrets.load(
-            JSON_FACTORY, new InputStreamReader(clientSecretFile, Charset.forName("UTF-8")));
+            JSON_FACTORY, new InputStreamReader(clientSecretFile, StandardCharsets.UTF_8));
 
     // get a pointer to the credential datastore
     GoogleAuthorizationCodeFlow flow = getOAuth2Flow(scopes, clientSecrets, dataStoreDir);
@@ -175,7 +175,7 @@ public final class GoogleOauth {
     // load client_secret.json file
     GoogleClientSecrets clientSecrets =
         GoogleClientSecrets.load(
-            JSON_FACTORY, new InputStreamReader(clientSecretFile, Charset.forName("UTF-8")));
+            JSON_FACTORY, new InputStreamReader(clientSecretFile, StandardCharsets.UTF_8));
 
     // get a pointer to the credential datastore
     GoogleAuthorizationCodeFlow flow = getOAuth2Flow(scopes, clientSecrets, dataStoreDir);

--- a/src/main/java/bio/terra/cli/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/utils/FileUtils.java
@@ -5,7 +5,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.slf4j.Logger;
@@ -60,6 +60,6 @@ public class FileUtils {
     // create the file and any parent directories if they don't already exist
     createFile(outputFile);
 
-    return Files.write(outputFile.toPath(), fileContents.getBytes(Charset.forName("UTF-8")));
+    return Files.write(outputFile.toPath(), fileContents.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/src/main/java/bio/terra/cli/utils/Printer.java
+++ b/src/main/java/bio/terra/cli/utils/Printer.java
@@ -1,8 +1,9 @@
 package bio.terra.cli.utils;
 
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
@@ -20,16 +21,19 @@ public class Printer {
 
   private static final PrintStream DEFAULT_OUT_STREAM = System.out;
   private static final PrintStream DEFAULT_ERR_STREAM = System.err;
+  private static final InputStream DEFAULT_IN_STREAM = System.in;
 
   private final PrintStream out;
   private final PrintStream err;
+  private final InputStream in;
 
   private static Printer printer;
 
   /** Constructor that initializes the printer with the specified output streams. */
-  private Printer(PrintStream out, PrintStream err) {
+  private Printer(PrintStream out, PrintStream err, InputStream in) {
     this.out = out;
     this.err = err;
+    this.in = in;
   }
 
   /**
@@ -47,7 +51,7 @@ public class Printer {
    */
   public static void setupPrinting(CommandLine cmd) {
     if (printer == null) {
-      initialize(DEFAULT_OUT_STREAM, DEFAULT_ERR_STREAM);
+      initialize(DEFAULT_OUT_STREAM, DEFAULT_ERR_STREAM, DEFAULT_IN_STREAM);
     } else {
       logger.warn(
           "Printing setup called multiple times. This is expected when testing, not during normal operation.");
@@ -67,8 +71,9 @@ public class Printer {
    * @param standardOut stream to write standard out to
    * @param standardErr stream to write standard err to
    */
-  public static void initialize(PrintStream standardOut, PrintStream standardErr) {
-    printer = new Printer(standardOut, standardErr);
+  public static void initialize(
+      PrintStream standardOut, PrintStream standardErr, InputStream standardIn) {
+    printer = new Printer(standardOut, standardErr, standardIn);
   }
 
   /**
@@ -97,9 +102,22 @@ public class Printer {
     return printer.err;
   }
 
+  /**
+   * Utility method to get the input stream from the singleton.
+   *
+   * @return stream to read input from (e.g. stdin)
+   */
+  public static InputStream getIn() {
+    if (printer == null) {
+      logger.warn("Attempt to access printer input stream before setup.");
+      return DEFAULT_IN_STREAM;
+    }
+    return printer.in;
+  }
+
   /** Utility method to get a UTF-8 encoded character output stream from a raw byte stream. */
   private static PrintWriter getPrintWriter(PrintStream printStream) {
-    return new PrintWriter(printStream, true, Charset.forName("UTF-8"));
+    return new PrintWriter(printStream, true, StandardCharsets.UTF_8);
   }
 
   /** Utility method to sort and map a list's contents. */

--- a/src/main/java/bio/terra/cli/utils/UserIO.java
+++ b/src/main/java/bio/terra/cli/utils/UserIO.java
@@ -12,12 +12,12 @@ import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 /**
- * Singleton class for holding a reference to output streams (e.g. stdout, stderr). The purpose of
- * holding these references in a single place is so that we can write output throughout the codebase
- * without passing around the output streams from the top-level command classes.
+ * Singleton class for holding a reference to input and output streams (e.g. stdin, stdout, stderr).
+ * The purpose of holding these references in a single place is so that we can read/write in/output
+ * throughout the codebase without passing around the streams from the top-level command classes.
  */
-public class Printer {
-  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Printer.class);
+public class UserIO {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(UserIO.class);
 
   private static final PrintStream DEFAULT_OUT_STREAM = System.out;
   private static final PrintStream DEFAULT_ERR_STREAM = System.err;
@@ -27,10 +27,10 @@ public class Printer {
   private final PrintStream err;
   private final InputStream in;
 
-  private static Printer printer;
+  private static UserIO userIO;
 
   /** Constructor that initializes the printer with the specified output streams. */
-  private Printer(PrintStream out, PrintStream err, InputStream in) {
+  private UserIO(PrintStream out, PrintStream err, InputStream in) {
     this.out = out;
     this.err = err;
     this.in = in;
@@ -50,14 +50,14 @@ public class Printer {
    * @param cmd picocli top-level command line object that holds pointers to the output streams
    */
   public static void setupPrinting(CommandLine cmd) {
-    if (printer == null) {
+    if (userIO == null) {
       initialize(DEFAULT_OUT_STREAM, DEFAULT_ERR_STREAM, DEFAULT_IN_STREAM);
     } else {
       logger.warn(
           "Printing setup called multiple times. This is expected when testing, not during normal operation.");
     }
-    cmd.setOut(getPrintWriter(printer.out));
-    cmd.setErr(getPrintWriter(printer.err));
+    cmd.setOut(getPrintWriter(userIO.out));
+    cmd.setErr(getPrintWriter(userIO.err));
   }
 
   /**
@@ -73,7 +73,7 @@ public class Printer {
    */
   public static void initialize(
       PrintStream standardOut, PrintStream standardErr, InputStream standardIn) {
-    printer = new Printer(standardOut, standardErr, standardIn);
+    userIO = new UserIO(standardOut, standardErr, standardIn);
   }
 
   /**
@@ -82,11 +82,11 @@ public class Printer {
    * @return stream to write output (e.g. stdout)
    */
   public static PrintStream getOut() {
-    if (printer == null) {
+    if (userIO == null) {
       logger.warn("Attempt to access printer output stream before setup.");
       return DEFAULT_OUT_STREAM;
     }
-    return printer.out;
+    return userIO.out;
   }
 
   /**
@@ -95,11 +95,11 @@ public class Printer {
    * @return stream to write errors and running status (e.g. stderr)
    */
   public static PrintStream getErr() {
-    if (printer == null) {
+    if (userIO == null) {
       logger.warn("Attempt to access printer error stream before setup.");
       return DEFAULT_ERR_STREAM;
     }
-    return printer.err;
+    return userIO.err;
   }
 
   /**
@@ -108,11 +108,11 @@ public class Printer {
    * @return stream to read input from (e.g. stdin)
    */
   public static InputStream getIn() {
-    if (printer == null) {
+    if (userIO == null) {
       logger.warn("Attempt to access printer input stream before setup.");
       return DEFAULT_IN_STREAM;
     }
-    return printer.in;
+    return userIO.in;
   }
 
   /** Utility method to get a UTF-8 encoded character output stream from a raw byte stream. */

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -3,7 +3,7 @@ package harness;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.cli.command.Main;
-import bio.terra.cli.utils.Printer;
+import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +41,7 @@ public class TestCommand {
     // stderr from the console
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
-    Printer.initialize(
+    UserIO.initialize(
         new PrintStream(stdOut, true, StandardCharsets.UTF_8),
         new PrintStream(stdErr, true, StandardCharsets.UTF_8),
         stdIn);

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -7,6 +7,7 @@ import bio.terra.cli.utils.Printer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
@@ -36,9 +37,11 @@ public class TestCommand {
     // stderr from the console
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+    ByteArrayInputStream stdIn = new ByteArrayInputStream(new byte[1000]);
     Printer.initialize(
         new PrintStream(stdOut, true, StandardCharsets.UTF_8),
-        new PrintStream(stdErr, true, StandardCharsets.UTF_8));
+        new PrintStream(stdErr, true, StandardCharsets.UTF_8),
+        stdIn);
 
     // execute the command from the top-level Main class
     System.out.println("COMMAND: " + String.join(" ", args));

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -7,14 +7,16 @@ import bio.terra.cli.utils.Printer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Utility methods for executing commands and reading their outputs during testing. This class is
@@ -27,17 +29,18 @@ public class TestCommand {
   private TestCommand() {}
 
   /**
-   * Call the top-level Main class to execute a command. Return the exit code, standard out and
-   * standard error.
+   * Call the top-level Main class to execute a command with the provided standard input stream.
+   * Return the exit code, standard out and standard error. Specifying the standard input stream is
+   * useful for testing commands that use interactive prompts.
    *
+   * @param stdIn input stream with the contents of standard in, null if unspecified
    * @param args sub-commands and arguments (e.g. "auth", "status" for `terra auth status`).
    */
-  public static Result runCommand(String... args) {
+  public static Result runCommand(@Nullable InputStream stdIn, String... args) {
     // initialize the singleton Printer object with byte streams, to redirect the command stdout and
     // stderr from the console
     ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
     ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
-    ByteArrayInputStream stdIn = new ByteArrayInputStream(new byte[1000]);
     Printer.initialize(
         new PrintStream(stdOut, true, StandardCharsets.UTF_8),
         new PrintStream(stdErr, true, StandardCharsets.UTF_8),
@@ -47,10 +50,19 @@ public class TestCommand {
     System.out.println("COMMAND: " + String.join(" ", args));
     int exitCode = Main.runCommand(args);
 
-    // log the stdout and stderr to the console
+    // log the stdout, stdin and stderr to the console
     String stdOutStr = stdOut.toString(StandardCharsets.UTF_8);
     String stdErrStr = stdErr.toString(StandardCharsets.UTF_8);
+    System.out.println("STDOUT --------------");
     System.out.println(stdOutStr);
+    if (stdIn != null)
+      try {
+        System.out.println("STDIN --------------");
+        stdIn.reset();
+        System.out.println(new String(stdIn.readAllBytes(), StandardCharsets.UTF_8));
+      } catch (IOException ioEx) {
+        throw new RuntimeException("Error logging stdin to console", ioEx);
+      }
     if (!stdErrStr.isEmpty()) {
       System.out.println("STDERR --------------");
       System.out.println(stdErrStr);
@@ -58,6 +70,16 @@ public class TestCommand {
 
     // return a result object with all the command outputs
     return new Result(exitCode, stdOutStr, stdErrStr);
+  }
+
+  /**
+   * Call the top-level Main class to execute a command. Return the exit code, standard out and
+   * standard error.
+   *
+   * @param args sub-commands and arguments (e.g. "auth", "status" for `terra auth status`).
+   */
+  public static Result runCommand(String... args) {
+    return runCommand(null, args);
   }
 
   /**

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -48,6 +48,6 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspaceId);
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
   }
 }

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -73,7 +73,8 @@ public class CleanupTestUserWorkspaces {
             "Deleting workspace: id=" + workspace.id + ", testuser=" + testUser.email);
         if (!isDryRun) {
           // `terra workspace delete --workspace=$id`
-          TestCommand.runCommandExpectSuccess("workspace", "delete", "--workspace=" + workspace.id);
+          TestCommand.runCommandExpectSuccess(
+              "workspace", "delete", "--workspace=" + workspace.id, "--quiet");
           System.out.println(
               "Cleaned up workspace: id=" + workspace.id + ", testuser=" + testUser.email);
           deletedWorkspaces.add(workspace.id);

--- a/src/test/java/harness/utils/SamGroups.java
+++ b/src/test/java/harness/utils/SamGroups.java
@@ -23,7 +23,7 @@ public class SamGroups {
     for (Map.Entry<String, TestUsers> groupCreated : trackedGroups.entrySet()) {
       groupCreated.getValue().login();
       TestCommand.Result cmd =
-          TestCommand.runCommand("groups", "delete", "--name=" + groupCreated.getKey());
+          TestCommand.runCommand("groups", "delete", "--name=" + groupCreated.getKey(), "--quiet");
       if (cmd.exitCode == 0) {
         // log if a test didn't clean up a group
         System.out.println("group was not cleaned up by test: " + groupCreated.getKey());

--- a/src/test/java/unit/AiNotebookControlled.java
+++ b/src/test/java/unit/AiNotebookControlled.java
@@ -76,7 +76,8 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra notebooks delete --name=$name`
-    TestCommand.Result cmd = TestCommand.runCommand("resources", "delete", "--name=" + name);
+    TestCommand.Result cmd =
+        TestCommand.runCommand("resources", "delete", "--name=" + name, "--quiet");
     assertTrue(
         cmd.exitCode == 0
             || (cmd.exitCode == 1

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -77,7 +77,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         datasetId, describeResource.datasetId, "describe resource output matches dataset id");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -99,7 +99,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFBqDataset deletedDataset =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFBqDataset.class, "resources", "delete", "--name=" + name);
+            UFBqDataset.class, "resources", "delete", "--name=" + name, "--quiet");
 
     // check that the name, project id, and dataset id match
     assertEquals(name, deletedDataset.name, "delete output matches name");
@@ -156,7 +156,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -182,7 +182,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         CoreMatchers.containsString("Checking access is intended for REFERENCED resources only"));
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -260,7 +260,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -104,7 +104,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
         "describe resource output matches dataset id");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -129,7 +129,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFBqDataset deletedDataset =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFBqDataset.class, "resources", "delete", "--name=" + name);
+            UFBqDataset.class, "resources", "delete", "--name=" + name, "--quiet");
 
     // check that the name, project id, and dataset id match
     assertEquals(name, deletedDataset.name, "delete output matches name");
@@ -196,7 +196,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -222,7 +222,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     TestCommand.runCommandExpectSuccess("resources", "check-access", "--name=" + name);
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -283,7 +283,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     assertEquals(description, describeResource.description, "describe output matches description");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -167,7 +167,7 @@ public class Config extends SingleWorkspaceUnit {
     assertEquals(workspace2.id, config.workspaceId, "confg set workspace affects config list");
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
 
     // `terra config get-value workspace`
     getValue =

--- a/src/test/java/unit/DeletePrompt.java
+++ b/src/test/java/unit/DeletePrompt.java
@@ -1,0 +1,149 @@
+package unit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import harness.TestCommand;
+import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.SamGroups;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the confirmation prompt for delete commands. */
+@Tag("unit")
+public class DeletePrompt extends SingleWorkspaceUnit {
+  SamGroups trackedGroups = new SamGroups();
+
+  @Override
+  @BeforeEach
+  protected void setupEachTime() throws IOException {
+    super.setupEachTime();
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+  }
+
+  @Override
+  @AfterAll
+  protected void cleanupOnce() throws IOException {
+    // try to delete each group that was created by a method in this class
+    trackedGroups.deleteAllTrackedGroups();
+    super.cleanupOnce();
+  }
+
+  @Test
+  @DisplayName("y/yes proceeds")
+  void yesResponseProceeds() {
+    String resourceName = "yesResponseProceeds";
+    createAndDeleteBucketExpectSuccess(resourceName, "y");
+    createAndDeleteBucketExpectSuccess(resourceName, "Y");
+    createAndDeleteBucketExpectSuccess(resourceName, "yes");
+    createAndDeleteBucketExpectSuccess(resourceName, "YES");
+    createAndDeleteBucketExpectSuccess(resourceName, "yEs");
+  }
+
+  @Test
+  @DisplayName("anything other than y/yes aborts")
+  void noResponseAborts() {
+    String resourceName = "noResponseAborts";
+    String bucketName = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "create",
+        "gcs-bucket",
+        "--name=" + resourceName,
+        "--bucket-name=" + bucketName);
+
+    deleteResourceExpectAbort(resourceName, "n");
+    deleteResourceExpectAbort(resourceName, "N");
+    deleteResourceExpectAbort(resourceName, "no");
+    deleteResourceExpectAbort(resourceName, "NO");
+    deleteResourceExpectAbort(resourceName, "nO");
+    deleteResourceExpectAbort(resourceName, "YESWithTrailingCharacters");
+    deleteResourceExpectAbort(resourceName, "withLeadingCharactersYES");
+    deleteResourceExpectAbort(resourceName, "inMiddleYESCharacters");
+    deleteResourceExpectAbort(resourceName, "random characters");
+  }
+
+  @Test
+  @DisplayName("prompt response is checked for workspace delete")
+  void promptResponseCheckedByWorkspace() {
+    // `terra workspace delete`
+    ByteArrayInputStream stdIn = new ByteArrayInputStream("NO".getBytes(StandardCharsets.UTF_8));
+    TestCommand.Result cmd = TestCommand.runCommand(stdIn, "workspace", "delete");
+
+    // check the abort case for `workspace delete` to confirm the delete prompt option is supported
+    // and its helper method is called to abort if the prompt response is negative
+    expectAbort(cmd);
+  }
+
+  @Test
+  @DisplayName("prompt response is checked for groups delete")
+  void promptResponseCheckedByGroups() throws JsonProcessingException {
+    // `terra groups create --name=$name`
+    String name = SamGroups.randomGroupName();
+    TestCommand.runCommandExpectSuccess("groups", "create", "--name=" + name);
+
+    // track the group so we can clean it up after this test method runs
+    trackedGroups.trackGroup(name, workspaceCreator);
+
+    // `terra groups delete`
+    ByteArrayInputStream stdIn = new ByteArrayInputStream("NO".getBytes(StandardCharsets.UTF_8));
+    TestCommand.Result cmd = TestCommand.runCommand(stdIn, "groups", "delete", "--name=" + name);
+
+    // check the abort case for `groups delete` to confirm the delete prompt option is supported and
+    // its helper method is called to abort if the prompt response is negative
+    expectAbort(cmd);
+  }
+
+  /**
+   * Create a controlled GCS bucket resource and then delete it with the given prompt response.
+   * Expects the delete to succeed.
+   */
+  private void createAndDeleteBucketExpectSuccess(String resourceName, String promptResponse) {
+    String bucketName = UUID.randomUUID().toString();
+    TestCommand.runCommandExpectSuccess(
+        "resources",
+        "create",
+        "gcs-bucket",
+        "--name=" + resourceName,
+        "--bucket-name=" + bucketName);
+
+    ByteArrayInputStream stdIn =
+        new ByteArrayInputStream(promptResponse.getBytes(StandardCharsets.UTF_8));
+    TestCommand.Result cmd =
+        TestCommand.runCommand(stdIn, "resources", "delete", "--name=" + resourceName);
+    assertEquals(0, cmd.exitCode, "delete command returned successfully");
+  }
+
+  /**
+   * Try deleting a resource with the given prompt response. Expects the command to throw a user
+   * actionable exception because the prompt response was negative.
+   */
+  private void deleteResourceExpectAbort(String resourceName, String promptResponse) {
+    ByteArrayInputStream stdIn =
+        new ByteArrayInputStream(promptResponse.getBytes(StandardCharsets.UTF_8));
+    TestCommand.Result cmd =
+        TestCommand.runCommand(stdIn, "resources", "delete", "--name=" + resourceName);
+    expectAbort(cmd);
+  }
+
+  /** Expect a user actionable exception because the prompt response was negative. */
+  private void expectAbort(TestCommand.Result cmd) {
+    assertEquals(1, cmd.exitCode, "delete command threw a user actionable exception");
+    assertThat(
+        "output message says the delete was aborted",
+        cmd.stdErr,
+        CoreMatchers.containsString("Delete aborted"));
+  }
+}

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -67,7 +67,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         bucketName, describeResource.bucketName, "describe resource output matches bucket name");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -87,7 +87,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFGcsBucket deletedBucket =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "delete", "--name=" + name);
+            UFGcsBucket.class, "resources", "delete", "--name=" + name, "--quiet");
 
     // check that the name and bucket name match
     assertEquals(name, deletedBucket.name, "delete output matches name");
@@ -129,7 +129,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         bucketName, resolvedExcludePrefix, "exclude prefix resolve only includes bucket name");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -155,7 +155,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         CoreMatchers.containsString("Checking access is intended for REFERENCED resources only"));
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -234,7 +234,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -86,7 +86,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
         "describe resource output matches bucket name");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -109,7 +109,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resources delete --name=$name --format=json`
     UFGcsBucket deletedBucket =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resources", "delete", "--name=" + name);
+            UFGcsBucket.class, "resources", "delete", "--name=" + name, "--quiet");
 
     // check that the name and bucket name match
     assertEquals(name, deletedBucket.name, "delete output matches name");
@@ -157,7 +157,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
         "exclude prefix resolve only includes bucket name");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -181,7 +181,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     TestCommand.runCommandExpectSuccess("resources", "check-access", "--name=" + name);
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -230,7 +230,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     assertEquals(description, describeResource.description, "describe output matches description");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/Group.java
+++ b/src/test/java/unit/Group.java
@@ -96,7 +96,7 @@ public class Group extends ClearContextUnit {
     // `terra groups delete --name=$name`
     UFGroup groupDeleted =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGroup.class, "groups", "delete", "--name=" + name);
+            UFGroup.class, "groups", "delete", "--name=" + name, "--quiet");
 
     // check that the name and email match, and that the creator was an admin
     assertEquals(name, groupDeleted.name, "group name matches after delete");
@@ -126,7 +126,7 @@ public class Group extends ClearContextUnit {
     expectGroupNotFound(cmd);
 
     // `terra groups delete --name=$name`
-    cmd = TestCommand.runCommand("groups", "delete", "--name=" + badName);
+    cmd = TestCommand.runCommand("groups", "delete", "--name=" + badName, "--quiet");
     expectGroupNotFound(cmd);
 
     // `terra groups list-users --name=$name`
@@ -174,7 +174,7 @@ public class Group extends ClearContextUnit {
 
     // `terra groups delete --name=$name` as member
     groupMember.login();
-    TestCommand.runCommandExpectExitCode(2, "groups", "delete", "--name=" + name);
+    TestCommand.runCommandExpectExitCode(2, "groups", "delete", "--name=" + name, "--quiet");
 
     // `terra groups add-user --email=$email --policy=ADMIN` as member
     TestCommand.runCommandExpectExitCode(
@@ -196,7 +196,7 @@ public class Group extends ClearContextUnit {
 
     // `terra groups delete --name=$name` as admin
     groupCreator.login();
-    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -254,7 +254,7 @@ public class Group extends ClearContextUnit {
     expectListedMemberWithPolicies(name, groupCreator.email, GroupPolicy.ADMIN);
 
     // `terra groups delete --name=$name`
-    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("groups", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -96,7 +96,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
         CoreMatchers.containsString(ExternalGCSBuckets.getGsPath(bucketName)));
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -145,7 +145,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
         "gsutil says bucket size = 0");
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test
@@ -177,7 +177,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
             "\"id\": \"" + dataset.projectId + ":" + dataset.datasetId + "\""));
 
     // `terra resources delete --name=$name`
-    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("resources", "delete", "--name=" + name, "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -80,7 +80,7 @@ public class Workspace extends ClearContextUnit {
         "workspace gcp project matches that in list");
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
   }
 
   @Test
@@ -96,7 +96,8 @@ public class Workspace extends ClearContextUnit {
 
     // `terra workspace delete --format=json`
     UFWorkspace deleteWorkspace =
-        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "delete");
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "delete", "--quiet");
 
     // check the deleted workspace matches the created workspace
     assertEquals(createWorkspace.id, deleteWorkspace.id, "deleted workspace id matches created");
@@ -184,7 +185,7 @@ public class Workspace extends ClearContextUnit {
         "updated workspace description matches that in list");
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
   }
 
   @Test
@@ -243,13 +244,13 @@ public class Workspace extends ClearContextUnit {
         createWorkspace2.id, describeWorkspace.id, "describe matches set workspace id (2)");
 
     // `terra workspace delete` (workspace 2)
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
 
     // `terra workspace set` (workspace 1)
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + createWorkspace1.id);
 
     // `terra workspace delete` (workspace 1)
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
   }
 
   @Test

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -91,13 +91,13 @@ public class WorkspaceOverride extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace1.id);
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspace2.id);
 
     // `terra workspace delete`
-    TestCommand.runCommandExpectSuccess("workspace", "delete");
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
 
     ExternalGCSBuckets.getStorageClient().delete(externalBucket.getName());
     externalBucket = null;
@@ -212,14 +212,24 @@ public class WorkspaceOverride extends ClearContextUnit {
     TestCommand.runCommandExpectExitCode(1, "resources", "resolve", "--name=" + resourceNameBucket);
 
     // `terra delete --name=$resourceNameBucket --workspace=$id2`
-    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameBucket);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "delete", "--name=" + resourceNameBucket, "--quiet");
     TestCommand.runCommandExpectSuccess(
-        "resources", "delete", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+        "resources",
+        "delete",
+        "--name=" + resourceNameBucket,
+        "--workspace=" + workspace2.id,
+        "--quiet");
 
     // `terra delete --name=$resourceNameDataset --workspace=$id2`
-    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameDataset);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "delete", "--name=" + resourceNameDataset, "--quiet");
     TestCommand.runCommandExpectSuccess(
-        "resources", "delete", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+        "resources",
+        "delete",
+        "--name=" + resourceNameDataset,
+        "--workspace=" + workspace2.id,
+        "--quiet");
   }
 
   @Test
@@ -290,14 +300,24 @@ public class WorkspaceOverride extends ClearContextUnit {
     TestCommand.runCommandExpectExitCode(1, "resources", "resolve", "--name=" + resourceNameBucket);
 
     // `terra delete --name=$resourceNameBucket --workspace=$id2`
-    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameBucket);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "delete", "--name=" + resourceNameBucket, "--quiet");
     TestCommand.runCommandExpectSuccess(
-        "resources", "delete", "--name=" + resourceNameBucket, "--workspace=" + workspace2.id);
+        "resources",
+        "delete",
+        "--name=" + resourceNameBucket,
+        "--workspace=" + workspace2.id,
+        "--quiet");
 
     // `terra delete --name=$resourceNameDataset --workspace=$id2`
-    TestCommand.runCommandExpectExitCode(1, "resources", "delete", "--name=" + resourceNameDataset);
+    TestCommand.runCommandExpectExitCode(
+        1, "resources", "delete", "--name=" + resourceNameDataset, "--quiet");
     TestCommand.runCommandExpectSuccess(
-        "resources", "delete", "--name=" + resourceNameDataset, "--workspace=" + workspace2.id);
+        "resources",
+        "delete",
+        "--name=" + resourceNameDataset,
+        "--workspace=" + workspace2.id,
+        "--quiet");
   }
 
   @Test
@@ -385,7 +405,8 @@ public class WorkspaceOverride extends ClearContextUnit {
     // check the workspace 3 has been deleted, and workspace 1 has not
 
     // `terra workspace delete --workspace=$id3`
-    TestCommand.runCommandExpectSuccess("workspace", "delete", "--workspace=" + workspace3.id);
+    TestCommand.runCommandExpectSuccess(
+        "workspace", "delete", "--workspace=" + workspace3.id, "--quiet");
 
     // `terra workspace list`
     List<UFWorkspace> matchingWorkspaces = listWorkspacesWithId(workspace3.id);

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -10,7 +10,7 @@ if [[ "true" = "$isLoggedIn" ]]
 then
   currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Deleting the current workspace."
-  terra workspace delete
+  terra workspace delete --quiet
 else
   echo "No user is logged in. Skipping deleting the current workspace."
 fi


### PR DESCRIPTION
- Added a confirmation prompt for all `delete` commands: `groups delete`, `resources delete`, `workspace delete`.
  ```Are you sure you want to delete (y/N)?```
- Added an optional `--quiet` flag to suppress the interactive prompt.
- Updated all existing tests to use the `--quiet` flag. Added new tests for the interactive option.