### PR TITLE
PF-839 remove Google JupyterLab extensions metadata.

### DIFF
--- a/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
@@ -294,12 +294,6 @@ public class AiNotebook extends BaseCommand {
   /** Create the metadata to put on the AI Notebook instance. */
   private Map<String, String> defaultMetadata(UUID workspaceID) {
     return ImmutableMap.<String, String>builder()
-        // The metadata installed-extensions causes the AI Notebooks setup to install some
-        // Google JupyterLab extensions. Found by manual inspection of what is created with the
-        // cloud console GUI.
-        .put(
-            "installed-extensions",
-            "jupyterlab_bigquery-latest.tar.gz,jupyterlab_gcsfilebrowser-latest.tar.gz,jupyterlab_gcpscheduler-latest.tar.gz")
         // Set additional Terra context as metadata on the VM instance.
         .put("terra-workspace-id", workspaceID.toString())
         .put("terra-cli-server", Context.getServer().getName())


### PR DESCRIPTION
The Google JupyterLab extensions expect projects editor permissions. We're not granting those to users or SAs within workspace projects. Until there is a fully managed AI Notebook service offered by Google, we probably won't be able to use these extensions. Removing them for now.
See also https://broadworkbench.atlassian.net/browse/PF-839