### PR TITLE
PF-890: Make WSM default spend profile a property of the server.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -37,6 +37,7 @@ public class Server {
   // (e.g. URLs, WSM single spend profile)
   private String samUri;
   private String workspaceManagerUri;
+  private String wsmDefaultSpendProfile;
   private String dataRepoUri;
 
   private static final String DEFAULT_SERVER_FILENAME = "verily-cli.json";
@@ -49,6 +50,7 @@ public class Server {
     this.description = configFromDisk.description;
     this.samUri = configFromDisk.samUri;
     this.workspaceManagerUri = configFromDisk.workspaceManagerUri;
+    this.wsmDefaultSpendProfile = configFromDisk.wsmDefaultSpendProfile;
     this.dataRepoUri = configFromDisk.dataRepoUri;
   }
 
@@ -167,6 +169,10 @@ public class Server {
 
   public String getWorkspaceManagerUri() {
     return workspaceManagerUri;
+  }
+
+  public String getWsmDefaultSpendProfile() {
+    return wsmDefaultSpendProfile;
   }
 
   public String getDataRepoUri() {

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
@@ -17,6 +17,7 @@ public class PDServer {
   public final String description;
   public final String samUri;
   public final String workspaceManagerUri;
+  public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
 
   /** Serialize an instance of the internal class to the disk format. */
@@ -25,6 +26,7 @@ public class PDServer {
     this.description = internalObj.getDescription();
     this.samUri = internalObj.getSamUri();
     this.workspaceManagerUri = internalObj.getWorkspaceManagerUri();
+    this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
   }
 
@@ -33,6 +35,7 @@ public class PDServer {
     this.description = builder.description;
     this.samUri = builder.samUri;
     this.workspaceManagerUri = builder.workspaceManagerUri;
+    this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
   }
 
@@ -42,6 +45,7 @@ public class PDServer {
     private String description;
     private String samUri;
     private String workspaceManagerUri;
+    private String wsmDefaultSpendProfile;
     private String dataRepoUri;
 
     public Builder name(String name) {
@@ -61,6 +65,11 @@ public class PDServer {
 
     public Builder workspaceManagerUri(String workspaceManagerUri) {
       this.workspaceManagerUri = workspaceManagerUri;
+      return this;
+    }
+
+    public Builder wsmDefaultSpendProfile(String wsmDefaultSpendProfile) {
+      this.wsmDefaultSpendProfile = wsmDefaultSpendProfile;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
@@ -19,6 +19,7 @@ public class UFServer {
   public final String description;
   public final String samUri;
   public final String workspaceManagerUri;
+  public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
 
   /** Serialize an instance of the internal class to the command format. */
@@ -27,6 +28,7 @@ public class UFServer {
     this.description = internalObj.getDescription();
     this.samUri = internalObj.getSamUri();
     this.workspaceManagerUri = internalObj.getWorkspaceManagerUri();
+    this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
   }
 
@@ -36,6 +38,7 @@ public class UFServer {
     this.description = builder.description;
     this.samUri = builder.samUri;
     this.workspaceManagerUri = builder.workspaceManagerUri;
+    this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
   }
 
@@ -51,6 +54,7 @@ public class UFServer {
     private String description;
     private String samUri;
     private String workspaceManagerUri;
+    private String wsmDefaultSpendProfile;
     private String dataRepoUri;
 
     public Builder name(String name) {
@@ -70,6 +74,11 @@ public class UFServer {
 
     public Builder workspaceManagerUri(String workspaceManagerUri) {
       this.workspaceManagerUri = workspaceManagerUri;
+      return this;
+    }
+
+    public Builder wsmDefaultSpendProfile(String wsmDefaultSpendProfile) {
+      this.wsmDefaultSpendProfile = wsmDefaultSpendProfile;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/SpendProfileManagerService.java
+++ b/src/main/java/bio/terra/cli/service/SpendProfileManagerService.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.service;
 
+import bio.terra.cli.businessobject.Context;
 import java.util.List;
 import org.broadinstitute.dsde.workbench.client.sam.model.AccessPolicyResponseEntry;
 import org.slf4j.Logger;
@@ -17,7 +18,6 @@ public class SpendProfileManagerService {
   // only one SAM resource used. in the future, if this varies per environment, move this resource
   // id into the server specification
   private static final String SPEND_PROFILE_RESOURCE_TYPE = "spend-profile";
-  private static final String WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID = "wm-default-spend-profile";
 
   /**
    * Factory method for class that talks to the SPM service. The user must be authenticated. Methods
@@ -56,7 +56,7 @@ public class SpendProfileManagerService {
   public void enableUserForDefaultSpendProfile(SpendProfilePolicy policy, String email) {
     samService.addUserToResourceOrInviteUser(
         SPEND_PROFILE_RESOURCE_TYPE,
-        WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID,
+        Context.getServer().getWsmDefaultSpendProfile(),
         policy.getSamPolicy(),
         email);
   }
@@ -69,7 +69,7 @@ public class SpendProfileManagerService {
   public void disableUserForDefaultSpendProfile(SpendProfilePolicy policy, String email) {
     samService.removeUserFromResource(
         SPEND_PROFILE_RESOURCE_TYPE,
-        WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID,
+        Context.getServer().getWsmDefaultSpendProfile(),
         policy.getSamPolicy(),
         email);
   }
@@ -81,6 +81,6 @@ public class SpendProfileManagerService {
    */
   public List<AccessPolicyResponseEntry> listUsersOfDefaultSpendProfile() {
     return samService.listPoliciesForResource(
-        SPEND_PROFILE_RESOURCE_TYPE, WSM_DEFAULT_SPEND_PROFILE_RESOURCE_ID);
+        SPEND_PROFILE_RESOURCE_TYPE, Context.getServer().getWsmDefaultSpendProfile());
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -189,7 +189,7 @@ public class WorkspaceManagerService {
           CreateWorkspaceRequestBody workspaceRequestBody = new CreateWorkspaceRequestBody();
           workspaceRequestBody.setId(workspaceId);
           workspaceRequestBody.setStage(WorkspaceStageModel.MC_WORKSPACE);
-          workspaceRequestBody.setSpendProfile("wm-default-spend-profile");
+          workspaceRequestBody.setSpendProfile(Context.getServer().getWsmDefaultSpendProfile());
           workspaceRequestBody.setDisplayName(displayName);
           workspaceRequestBody.setDescription(description);
 

--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,1 +1,1 @@
-[ "terra-dev.json", "terra-verily-dev.json", "mm-dev.json", "verily-cli.json", "wchamber-dev.json" ]
+[ "terra-dev.json", "terra-verily-dev.json", "terra-verily-autopush.json", "mm-dev.json", "verily-cli.json", "wchamber-dev.json" ]

--- a/src/main/resources/servers/mm-dev.json
+++ b/src/main/resources/servers/mm-dev.json
@@ -1,8 +1,9 @@
 {
   "name": "mm-dev",
-  "description": "(MM) Terra environment for development purposes.",
+  "description": "(mmedlock) Personal development environment",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.mmedlock.integ.envs.broadinstitute.org"
+  "workspaceManagerUri": "https://workspace.mmedlock.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/terra-dev.json
+++ b/src/main/resources/servers/terra-dev.json
@@ -1,8 +1,9 @@
 {
   "name": "terra-dev",
-  "description": "Terra environment for development purposes.",
+  "description": "Broad dev environment",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.dsde-dev.broadinstitute.org"
+  "workspaceManagerUri": "https://workspace.dsde-dev.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/terra-verily-autopush.json
+++ b/src/main/resources/servers/terra-verily-autopush.json
@@ -5,5 +5,5 @@
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://terra-autopush-sam.api.verily.com",
   "workspaceManagerUri": "http://terra-autopush-wsm.api.verily.com",
-  "wsmDefaultSpendProfile": "wm-default-spend-profile"
+  "wsmDefaultSpendProfile": "zloery-spend-profile"
 }

--- a/src/main/resources/servers/terra-verily-autopush.json
+++ b/src/main/resources/servers/terra-verily-autopush.json
@@ -1,0 +1,9 @@
+{
+  "name": "terra-verily-autopush",
+  "description": "Verily autopush environment",
+
+  "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
+  "samUri": "https://terra-autopush-sam.api.verily.com",
+  "workspaceManagerUri": "http://terra-autopush-wsm.api.verily.com",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
+}

--- a/src/main/resources/servers/terra-verily-dev.json
+++ b/src/main/resources/servers/terra-verily-dev.json
@@ -4,6 +4,6 @@
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam-dev.api.verily.com",
-  "workspaceManagerUri": "https://wsm-dev.api.verily.com",
+  "workspaceManagerUri": "https://terra-dev-workspace.api.verily.com",
   "wsmDefaultSpendProfile": "zloery-spend-profile"
 }

--- a/src/main/resources/servers/terra-verily-dev.json
+++ b/src/main/resources/servers/terra-verily-dev.json
@@ -1,8 +1,9 @@
 {
   "name": "terra-verily-dev",
-  "description": "Terra development environment deployed at Verily.",
+  "description": "Verily dev environment",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
-  "samUri": "https://terra-autopush-sam.api.verily.com",
-  "workspaceManagerUri": "http://terra-autopush-wsm.api.verily.com"
+  "samUri": "https://sam-dev.api.verily.com",
+  "workspaceManagerUri": "https://wsm-dev.api.verily.com",
+  "wsmDefaultSpendProfile": "zloery-spend-profile"
 }

--- a/src/main/resources/servers/verily-cli.json
+++ b/src/main/resources/servers/verily-cli.json
@@ -4,5 +4,6 @@
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.verilycli.integ.envs.broadinstitute.org"
+  "workspaceManagerUri": "https://workspace.verilycli.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/wchamber-dev.json
+++ b/src/main/resources/servers/wchamber-dev.json
@@ -1,8 +1,9 @@
 {
   "name": "wchamber-dev",
-  "description": "(wchamber) Terra environment for development purposes.",
+  "description": "(wchamber) Personal development environment",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.wchamber.integ.envs.broadinstitute.org"
+  "workspaceManagerUri": "https://workspace.wchamber.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/test/resources/testinputs/BadServer.json
+++ b/src/test/resources/testinputs/BadServer.json
@@ -4,5 +4,6 @@
 
   "dataRepoUri": "https://jade.datarepo-BADURL.broadinstitute.org",
   "samUri": "https://sam.dsde-BADURL.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.BADURL.integ.envs.broadinstitute.org"
+  "workspaceManagerUri": "https://workspace.BADURL.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "BAD-spend-profile"
 }


### PR DESCRIPTION
- Added a property to the server specification for the WSM default spend profile. Previously, this was hard-coded to "wm-default-spend-profile".
- Added a separate server specification for the Verily autopush environment, and updated the one for the Verily dev environment.

Eventually, there will be a spend profile manager service and users will want to specify a spend profile to use (e.g. on workspace create or as a CLI config property, etc.). When that time comes, this property will need to be removed. But for now, there is only a single hard-coded spend profile for each WSM deployment. This PR brings the CLI in-line with this association; the spend profile is now a property of the server.