### PR TITLE
[PF-741] Run nightly tests against autopush

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -65,7 +65,7 @@ jobs:
             build/test-context/.terra/global-context.json
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name != 'workflow_dispatch'
+        if: always() && github.event_name == 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,6 +73,6 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           status: ${{ job.status }}
-          channel: "#platform-foundation-alerts"
+          channel: "@zloery"
           username: "CLI nightly test run"
           fields: job,took

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
-        testServer: ["", "-Pserver=terra-verily-autopush"]
+        testServer: ["-Pserver=terra-dev", "-Pserver=terra-verily-autopush"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,6 @@ jobs:
       - name: Run tests
         id: run_tests
         run: |
-          # default server is terra-dev
           echo "Running tests with options: ${{ matrix.testOptions }} ${{ matrix.testServer }}"
           ./gradlew runTestsWithTag ${{ matrix.testOptions }} ${{ matrix.testServer }}
       - name: Archive logs and context file
@@ -76,4 +75,4 @@ jobs:
           status: ${{ job.status }}
           channel: "#platform-foundation-alerts"
           username: "CLI nightly test run"
-          fields: repo,commit,job,took
+          fields: job,took

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -65,7 +65,7 @@ jobs:
             build/test-context/.terra/global-context.json
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name == 'workflow_dispatch'
+        if: always() && github.event_name != 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,6 +73,6 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           status: ${{ job.status }}
-          channel: "@zloery"
+          channel: "#platform-foundation-alerts"
           username: "CLI nightly test run"
           fields: job,took

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
+        testServer: ["", "-Pserver=terra-verily-autopush"]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -51,9 +52,9 @@ jobs:
       - name: Run tests
         id: run_tests
         run: |
-          # runs against the default server: terra-dev
-          echo "Running tests with options: ${{ matrix.testOptions }}"
-          ./gradlew runTestsWithTag ${{ matrix.testOptions }}
+          # default server is terra-dev
+          echo "Running tests with options: ${{ matrix.testOptions }} ${{ matrix.testServer }}"
+          ./gradlew runTestsWithTag ${{ matrix.testOptions }} ${{ matrix.testServer }}
       - name: Archive logs and context file
         id: archive_logs_and_context
         if: always()


### PR DESCRIPTION
This modifies the nightly tests to run against both dev and Verily's autopush environment.

I'm not sure if we want to change the notification policy (e.g. only notify for `dev` or something) - 6 is a lot of daily slack messages, even if they are going to an alert-only channel.