### PR TITLE
PF-887: Allow setting the workspace id without logging in first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,10 @@ However, `docker pull` [may use](https://cloud.google.com/container-registry/doc
 covers to pull the default Docker image from GCR. This is the reason for the `gcloud` requirement for install.
 
 #### Login
-1. Use a Google account that is not a Google/Verily corporate account.
-2. `terra auth login` launches an OAuth flow that pops out a browser window with a warning login
+1. `terra auth login` launches an OAuth flow that pops out a browser window with a warning login
 page ("! Google hasn't verified this app"). This shows up because the CLI is not yet a Google-verified
 app. Click through the warnings ("Advanced" -> "Go to ... (unsafe)") to complete the login.
-3. If the machine where you're running the CLI does not have a browser available to it, then use the
+2. If the machine where you're running the CLI does not have a browser available to it, then use the
 manual login flow by setting the browser flag `terra config set browser MANUAL`. See the [Authentication](#authentication)
 section below for more details.
 

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -159,8 +159,8 @@ public class Context {
    * of the global context directory.
    *
    * @param user
-   * @return absolute path to the pet SA key file for the given user and workspace
-   * @throws UserActionableException if the current user or workspace is not defined
+   * @return absolute path to the pet SA key file for the given user and current workspace
+   * @throws UserActionableException if the current workspace is not defined
    */
   public static Path getPetSaKeyFile(User user) {
     return Context.getPetSaKeyDir(user).resolve(requireWorkspace().getId().toString());

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -151,7 +151,19 @@ public class Context {
    * @throws UserActionableException if the current user or workspace is not defined
    */
   public static Path getPetSaKeyFile() {
-    return Context.getPetSaKeyDir(requireUser()).resolve(requireWorkspace().getId().toString());
+    return getPetSaKeyFile(requireUser());
+  }
+
+  /**
+   * Get the pet SA key file for a user and the current workspace. This is stored in a sub-directory
+   * of the global context directory.
+   *
+   * @param user
+   * @return absolute path to the pet SA key file for the given user and workspace
+   * @throws UserActionableException if the current user or workspace is not defined
+   */
+  public static Path getPetSaKeyFile(User user) {
+    return Context.getPetSaKeyDir(user).resolve(requireWorkspace().getId().toString());
   }
 
   /**
@@ -202,11 +214,7 @@ public class Context {
   }
 
   public static Optional<Workspace> getWorkspace() {
-    if (useOverrideWorkspace) {
-      return Optional.ofNullable(overrideWorkspace);
-    } else {
-      return Optional.ofNullable(currentWorkspace);
-    }
+    return Optional.ofNullable(useOverrideWorkspace ? overrideWorkspace : currentWorkspace);
   }
 
   public static Workspace requireWorkspace() {

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -288,11 +288,7 @@ public class User {
   }
 
   public String getPetSaEmail() {
-    if (petSACredentials == null) {
-      return null;
-    } else {
-      return petSACredentials.getClientEmail();
-    }
+    return petSACredentials == null ? null : petSACredentials.getClientEmail();
   }
 
   public UserCredentials getUserCredentials() {

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -113,6 +113,8 @@ public class Workspace {
    * @param id workspace id
    */
   public static Workspace load(UUID id) {
+    // a user can set the workspace without being logged in. in that case, we can't request the
+    // metadata from WSM without valid credentials. so just save the workspace id for loading later.
     if (Context.getUser().isEmpty()) {
       Workspace loadedWorkspace = new Workspace(id, Context.getServer().getName());
       Context.setWorkspace(loadedWorkspace);

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -37,6 +37,10 @@ public class Workspace {
   // list of resources (controlled & referenced)
   private List<Resource> resources;
 
+  // true if the workspace metadata was fetched. false when a user sets the workspace without being
+  // logged in; in that case, we can't request the metadata from WSM without valid credentials.
+  private boolean isLoaded;
+
   /** Build an instance of this class from the WSM client library WorkspaceDescription object. */
   private Workspace(WorkspaceDescription wsmObject) {
     this.id = wsmObject.getId();
@@ -47,6 +51,7 @@ public class Workspace {
     this.serverName = Context.getServer().getName();
     this.userEmail = Context.requireUser().getEmail();
     this.resources = new ArrayList<>();
+    this.isLoaded = true;
   }
 
   /** Build an instance of this class from the serialized format on disk. */
@@ -61,6 +66,18 @@ public class Workspace {
         configFromDisk.resources.stream()
             .map(PDResource::deserializeToInternal)
             .collect(Collectors.toList());
+    this.isLoaded = configFromDisk.isLoaded;
+  }
+
+  /**
+   * Build an instance of this class from just the workspace id and server name. This is used when a
+   * user sets the workspace without being logged in.
+   */
+  private Workspace(UUID id, String serverName) {
+    this.id = id;
+    this.serverName = serverName;
+    this.resources = new ArrayList<>();
+    this.isLoaded = false;
   }
 
   /**
@@ -96,6 +113,12 @@ public class Workspace {
    * @param id workspace id
    */
   public static Workspace load(UUID id) {
+    if (Context.getUser().isEmpty()) {
+      Workspace loadedWorkspace = new Workspace(id, Context.getServer().getName());
+      Context.setWorkspace(loadedWorkspace);
+      return loadedWorkspace;
+    }
+
     // call WSM to fetch the existing workspace object and backing Google context
     WorkspaceDescription loadedWorkspace = WorkspaceManagerService.fromContext().getWorkspace(id);
     logger.info("Loaded workspace: {}", loadedWorkspace);
@@ -242,5 +265,9 @@ public class Workspace {
 
   public List<Resource> getResources() {
     return Collections.unmodifiableList(resources);
+  }
+
+  public boolean getIsLoaded() {
+    return isLoaded;
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -47,9 +47,11 @@ public abstract class BaseCommand implements Callable<Integer> {
     Logger.setupLogging(
         Context.getConfig().getConsoleLoggingLevel(), Context.getConfig().getFileLoggingLevel());
 
-    // do the login flow if required
     if (requiresLogin()) {
+      // load existing credentials, prompt for login if they don't exist or are expired
       User.login();
+    } else if (Context.getUser().isPresent()) {
+      Context.requireUser().loadExistingCredentials();
     }
 
     // execute the command

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -15,6 +15,12 @@ public class Set extends BaseCommand {
   @CommandLine.Option(names = "--id", required = true, description = "workspace id")
   private UUID id;
 
+  @CommandLine.Option(
+      names = "--suppress-login",
+      hidden = true,
+      description = "Suppress login and skip fetching the workspace metadata.")
+  private boolean suppressLogin;
+
   @CommandLine.Mixin Format formatOption;
 
   /** Load an existing workspace. */
@@ -28,5 +34,15 @@ public class Set extends BaseCommand {
   private void printText(UFWorkspace returnValue) {
     OUT.println("Workspace successfully loaded.");
     returnValue.print();
+  }
+
+  /**
+   * Typical usage (--suppress-login not specified) requires login because we use the user's
+   * credentials to fetch the workspace metadata from WSM. If the --suppress-login flag is specified
+   * and the user is not already logged in, then we skip the login prompt and metadata fetch for
+   * now.
+   */
+  protected boolean requiresLogin() {
+    return !suppressLogin;
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -16,10 +16,10 @@ public class Set extends BaseCommand {
   private UUID id;
 
   @CommandLine.Option(
-      names = "--suppress-login",
+      names = "--defer-login",
       hidden = true,
       description = "Suppress login and skip fetching the workspace metadata.")
-  private boolean suppressLogin;
+  private boolean deferLogin;
 
   @CommandLine.Mixin Format formatOption;
 
@@ -37,12 +37,12 @@ public class Set extends BaseCommand {
   }
 
   /**
-   * Typical usage (--suppress-login not specified) requires login because we use the user's
-   * credentials to fetch the workspace metadata from WSM. If the --suppress-login flag is specified
+   * Typical usage (--defer-login not specified) requires login because we use the user's
+   * credentials to fetch the workspace metadata from WSM. If the --defer-login flag is specified
    * and the user is not already logged in, then we skip the login prompt and metadata fetch for
    * now.
    */
   protected boolean requiresLogin() {
-    return !suppressLogin;
+    return !deferLogin;
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -18,7 +18,7 @@ public class Set extends BaseCommand {
   @CommandLine.Option(
       names = "--defer-login",
       hidden = true,
-      description = "Suppress login and skip fetching the workspace metadata.")
+      description = "Defer login and skip fetching the workspace metadata.")
   private boolean deferLogin;
 
   @CommandLine.Mixin Format formatOption;
@@ -39,8 +39,8 @@ public class Set extends BaseCommand {
   /**
    * Typical usage (--defer-login not specified) requires login because we use the user's
    * credentials to fetch the workspace metadata from WSM. If the --defer-login flag is specified
-   * and the user is not already logged in, then we skip the login prompt and metadata fetch for
-   * now.
+   * and the user is not already logged in, then we skip the login prompt and fetch the metadata the
+   * next time the user logs in.
    */
   protected boolean requiresLogin() {
     return !deferLogin;

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
@@ -24,6 +24,7 @@ public class PDWorkspace {
   public final String serverName;
   public final String userEmail;
   public final List<PDResource> resources;
+  public final boolean isLoaded;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDWorkspace(Workspace internalObj) {
@@ -37,6 +38,7 @@ public class PDWorkspace {
         internalObj.getResources().stream()
             .map(Resource::serializeToDisk)
             .collect(Collectors.toList());
+    this.isLoaded = internalObj.getIsLoaded();
   }
 
   private PDWorkspace(PDWorkspace.Builder builder) {
@@ -47,6 +49,7 @@ public class PDWorkspace {
     this.serverName = builder.serverName;
     this.userEmail = builder.userEmail;
     this.resources = builder.resources;
+    this.isLoaded = builder.isLoaded;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -58,6 +61,7 @@ public class PDWorkspace {
     private String serverName;
     private String userEmail;
     private List<PDResource> resources;
+    private boolean isLoaded;
 
     public Builder id(UUID id) {
       this.id = id;
@@ -91,6 +95,11 @@ public class PDWorkspace {
 
     public Builder resources(List<PDResource> resources) {
       this.resources = resources;
+      return this;
+    }
+
+    public Builder isLoaded(boolean isLoaded) {
+      this.isLoaded = isLoaded;
       return this;
     }
 

--- a/src/test/java/unit/WorkspaceSetDeferLogin.java
+++ b/src/test/java/unit/WorkspaceSetDeferLogin.java
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/** Tests for the `--defer-login` option to skip login when setting the current workspace. */
+/**
+ * Tests for the `--defer-login` option to skip the login prompt when setting the current workspace.
+ */
 @Tag("unit")
-public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
+public class WorkspaceSetDeferLogin extends SingleWorkspaceUnit {
   TestUsers workspaceSharee;
   UUID sharedWorkspaceId;
 

--- a/src/test/java/unit/WorkspaceSetSuppressLogin.java
+++ b/src/test/java/unit/WorkspaceSetSuppressLogin.java
@@ -4,17 +4,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.serialization.userfacing.UFAuthStatus;
 import bio.terra.cli.serialization.userfacing.UFStatus;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import harness.TestCommand;
 import harness.TestUsers;
 import harness.baseclasses.SingleWorkspaceUnit;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -22,6 +25,36 @@ import org.junit.jupiter.api.Test;
 /** Tests for the `--suppress-login` option to skip login when setting the current workspace. */
 @Tag("unit")
 public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
+  TestUsers workspaceSharee;
+  UUID sharedWorkspaceId;
+
+  @BeforeAll
+  protected void setupOnce() throws IOException {
+    super.setupOnce();
+
+    // `terra workspace create --format=json`
+    UFWorkspace createWorkspace =
+        TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
+    sharedWorkspaceId = createWorkspace.id;
+
+    workspaceSharee = TestUsers.chooseTestUserWhoIsNot(workspaceCreator);
+
+    // `terra workspace add-user --email=$sharee --role=READER`
+    TestCommand.runCommandExpectSuccess(
+        "workspace", "add-user", "--email=" + workspaceSharee.email, "--role=READER");
+  }
+
+  @AfterAll
+  protected void cleanupOnce() throws IOException {
+    super.cleanupOnce();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + sharedWorkspaceId);
+
+    // `terra workspace delete --quiet`
+    TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");
+  }
+
   @Test
   @DisplayName("workspace id can be set before logging in, and metadata loads after logging in")
   void workspaceLoadsOnlyAfterLogin() throws IOException {
@@ -67,7 +100,8 @@ public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
   }
 
   @Test
-  @DisplayName("workspace metadata fails to load after logging in as a user without read access")
+  @DisplayName(
+      "workspace metadata fails to load after logging in as a user without read access, then succeeds with a different workspace that they do have access to")
   void workspaceLoadFailsWithNoAccess() throws IOException {
     // `terra auth revoke`
     TestCommand.runCommandExpectSuccess("auth", "revoke");
@@ -80,23 +114,7 @@ public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
     // workspace, but it should also succeed in that the user is logged in afterwards (the pet SA
     // just could not be loaded). here we check an exception instead of a command exit code, because
     // test users bypass the login flow to avoid browser interaction.
-    TestUsers userWithNoAccess = TestUsers.chooseTestUserWhoIsNot(workspaceCreator);
-    SystemException loginException =
-        assertThrows(
-            SystemException.class,
-            () -> {
-              userWithNoAccess.login();
-            },
-            "login with a user that has no workspace access throws an exception");
-    assertThat(
-        "error message includes unauthorized to read workspace resource",
-        loginException.getMessage(),
-        CoreMatchers.containsStringIgnoringCase(
-            "User "
-                + userWithNoAccess.email
-                + " is not authorized to read resource "
-                + getWorkspaceId()
-                + " of type workspace"));
+    workspaceSharee.login();
 
     // `terra status`
     UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
@@ -128,6 +146,29 @@ public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
                 + " is not authorized to read resource "
                 + getWorkspaceId()
                 + " of type workspace"));
+
+    // `terra workspace set --id=$sharedId`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + sharedWorkspaceId);
+
+    // `terra status`
+    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(
+        sharedWorkspaceId,
+        status.workspace.id,
+        "status after login user with access includes shared workspace id");
+    assertNotNull(
+        status.workspace.googleProjectId,
+        "status after login user with access includes google project id");
+
+    // `terra auth status`
+    authStatus = TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    assertNotNull(
+        authStatus.userEmail, "auth status after login user with access includes user email");
+    assertNotNull(
+        authStatus.serviceAccountEmail,
+        "auth status after login user with access includes pet SA email");
+
+    TestCommand.runCommandExpectSuccess("resources", "list");
   }
 
   @Test
@@ -158,5 +199,26 @@ public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
 
     // `terra resources list`
     TestCommand.runCommandExpectSuccess("resources", "list");
+  }
+
+  @Test
+  @DisplayName("workspace set without flag still prompts for login")
+  void withoutFlagWorkspaceSetRequiresLogin() {
+    // `terra auth revoke`
+    TestCommand.runCommandExpectSuccess("auth", "revoke");
+
+    // `terra config set browser MANUAL`
+    TestCommand.runCommandExpectSuccess("config", "set", "browser", "MANUAL");
+
+    // `terra workspace set --id=$id`
+    ByteArrayInputStream stdIn =
+        new ByteArrayInputStream("invalid oauth code".getBytes(StandardCharsets.UTF_8));
+    TestCommand.Result cmd =
+        TestCommand.runCommand(stdIn, "workspace", "set", "--id=" + getWorkspaceId());
+    assertThat(
+        "stdout includes login prompt",
+        cmd.stdOut,
+        CoreMatchers.containsString(
+            "Please open the following address in a browser on any machine"));
   }
 }

--- a/src/test/java/unit/WorkspaceSetSuppressLogin.java
+++ b/src/test/java/unit/WorkspaceSetSuppressLogin.java
@@ -1,0 +1,162 @@
+package unit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import bio.terra.cli.exception.SystemException;
+import bio.terra.cli.serialization.userfacing.UFAuthStatus;
+import bio.terra.cli.serialization.userfacing.UFStatus;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import harness.TestCommand;
+import harness.TestUsers;
+import harness.baseclasses.SingleWorkspaceUnit;
+import java.io.IOException;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `--suppress-login` option to skip login when setting the current workspace. */
+@Tag("unit")
+public class WorkspaceSetSuppressLogin extends SingleWorkspaceUnit {
+  @Test
+  @DisplayName("workspace id can be set before logging in, and metadata loads after logging in")
+  void workspaceLoadsOnlyAfterLogin() throws IOException {
+    // `terra auth revoke`
+    TestCommand.runCommandExpectSuccess("auth", "revoke");
+
+    // `terra workspace set --id=$id --suppress-login`
+    UFWorkspace workspaceSet =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId(), "--suppress-login");
+    assertEquals(
+        getWorkspaceId(), workspaceSet.id, "workspace set before login includes workspace id");
+    assertNull(
+        workspaceSet.googleProjectId,
+        "workspace set before login does not include google project id");
+
+    // `terra status`
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(
+        getWorkspaceId(), status.workspace.id, "status before login includes workspace id");
+    assertNull(
+        status.workspace.googleProjectId, "status before login does not include google project id");
+
+    // `terra auth status`
+    UFAuthStatus authStatus =
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    assertNull(authStatus.userEmail, "auth status before login does not include user email");
+    assertNull(
+        authStatus.serviceAccountEmail, "auth status before login does not include pet SA email");
+
+    workspaceCreator.login();
+
+    // `terra status`
+    status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(getWorkspaceId(), status.workspace.id, "status after login includes workspace id");
+    assertNotNull(
+        status.workspace.googleProjectId, "status after login includes google project id");
+
+    // `terra auth status`
+    authStatus = TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    assertNotNull(authStatus.userEmail, "auth status after login includes user email");
+    assertNotNull(authStatus.serviceAccountEmail, "auth status after login includes pet SA email");
+  }
+
+  @Test
+  @DisplayName("workspace metadata fails to load after logging in as a user without read access")
+  void workspaceLoadFailsWithNoAccess() throws IOException {
+    // `terra auth revoke`
+    TestCommand.runCommandExpectSuccess("auth", "revoke");
+
+    // `terra workspace set --id=$id --suppress-login`
+    TestCommand.runCommandExpectSuccess(
+        "workspace", "set", "--id=" + getWorkspaceId(), "--suppress-login");
+
+    // the login command should throw an exception that the user doesn't have access to the
+    // workspace, but it should also succeed in that the user is logged in afterwards (the pet SA
+    // just could not be loaded). here we check an exception instead of a command exit code, because
+    // test users bypass the login flow to avoid browser interaction.
+    TestUsers userWithNoAccess = TestUsers.chooseTestUserWhoIsNot(workspaceCreator);
+    SystemException loginException =
+        assertThrows(
+            SystemException.class,
+            () -> {
+              userWithNoAccess.login();
+            },
+            "login with a user that has no workspace access throws an exception");
+    assertThat(
+        "error message includes unauthorized to read workspace resource",
+        loginException.getMessage(),
+        CoreMatchers.containsStringIgnoringCase(
+            "User "
+                + userWithNoAccess.email
+                + " is not authorized to read resource "
+                + getWorkspaceId()
+                + " of type workspace"));
+
+    // `terra status`
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(
+        getWorkspaceId(),
+        status.workspace.id,
+        "status after login user without access includes workspace id");
+    assertNull(
+        status.workspace.googleProjectId,
+        "status after login user without access does not include google project id");
+
+    // `terra auth status`
+    UFAuthStatus authStatus =
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    assertNotNull(
+        authStatus.userEmail, "auth status after login user without access includes user email");
+    assertNull(
+        authStatus.serviceAccountEmail,
+        "auth status after login user without access does not include pet SA email");
+
+    // `terra resources list`
+    String stdErr = TestCommand.runCommandExpectExitCode(2, "resources", "list");
+    assertThat(
+        "error message includes unauthorized to read workspace resource",
+        stdErr,
+        CoreMatchers.containsStringIgnoringCase(
+            "User "
+                + authStatus.userEmail
+                + " is not authorized to read resource "
+                + getWorkspaceId()
+                + " of type workspace"));
+  }
+
+  @Test
+  @DisplayName("suppress login flag does not have any effect if user is already logged in")
+  void workspaceLoadsImmediatelyWhenAlreadyLoggedIn() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id --suppress-login`
+    UFWorkspace workspaceSet =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId(), "--suppress-login");
+    assertEquals(
+        getWorkspaceId(), workspaceSet.id, "workspace set after login includes workspace id");
+    assertNotNull(
+        workspaceSet.googleProjectId, "workspace set after login includes google project id");
+
+    // `terra status`
+    UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
+    assertEquals(getWorkspaceId(), status.workspace.id, "status after login includes workspace id");
+    assertNotNull(
+        status.workspace.googleProjectId, "status after login includes google project id");
+
+    // `terra auth status`
+    UFAuthStatus authStatus =
+        TestCommand.runAndParseCommandExpectSuccess(UFAuthStatus.class, "auth", "status");
+    assertNotNull(authStatus.userEmail, "auth status after login includes user email");
+    assertNotNull(authStatus.serviceAccountEmail, "auth status after login includes pet SA email");
+
+    // `terra resources list`
+    TestCommand.runCommandExpectSuccess("resources", "list");
+  }
+}


### PR DESCRIPTION
- The motivation for this change is to set the workspace id on an AI notebook in the startup script.
  - We want to configure the CLI with the correct workspace for them ahead of time. We know the workspace id, but we don't have the user's credentials yet.
  - Previously, setting the workspace id required logging in first so we can fetch the workspace metadata from WSM using the user's credentials. This change removes that requirement, and allows us to defer fetching the workspace metadata to when the user does login.
- Added a `--defer-login` option to the `terra workspace set` command.
  - If the user is not already logged in, then the CLI will not prompt for login, but will save the workspace id and load the metadata the next time the user logs in.
  - If the user is already logged in, then this option has no effect.
  - The option is hidden because it's intended specifically for the notebook startup script, not for typical use.
- Refactored the authentication code a bit. Previously we only had two types of commands: those that required login and used credentials, and those that didn't. This new flag gives a third type of command: one that will use credentials if they're available, but not prompt for login if they're not. This is reason behind the refactoring.