### PR TITLE
PF-574: Write up command style guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@
     * [Always specify a description](#always-specify-a-description)
     * [Alphabetize command lists](#alphabetize-command-lists)
     * [User readable exception messages](#user-readable-exception-messages)
+    * [Singular command group  names](#singular-command-group-names)
 
 -----
 
@@ -393,10 +394,10 @@ instead of `terra workspace add-user user@gmail.com READER`.
 This makes it easier to maintain backwards compatibility when adding new arguments. It also makes it easier to read
 commands with multiple arguments, without having to remember the order.
 
-All option names should start with two dashes. e.g. `--email`
-
 The exception to this rule are the `config get-value` and `config set` commands. These will only ever take one argument
 and use a parameter instead of an option.
+
+All option names should start with two dashes. e.g. `--email`
 
 #### Always specify a description
 Specify a description for all commands and options. Write it like a sentence: end with a period and capitalize the first

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,11 @@
     * [Serialization](#serialization)
     * [Terra and cloud services](#terra-and-cloud-services)
     * [Servers](#servers)
+6. [Command style guide](#command-style-guide)
+    * [Options instead of parameters](#options-instead-of-parameters)
+    * [Always specify a description](#always-specify-a-description)
+    * [Alphabetize command lists](#alphabetize-command-lists)
+    * [User readable exception messages](#user-readable-exception-messages)
 
 -----
 
@@ -374,3 +379,42 @@ class here.
 
 To add a new server specification, create a new file in this directory and add the file name to the `all-servers.json` 
 file.
+
+
+### Command style guide
+Below are guidelines for adding or modifying commands. The goal is to have a consistent presentation across commands.
+These are not hard rules, but should apply to most commands. Always choose better usability over following a rule here.
+
+#### Options instead of parameters
+Use options instead of parameters, wherever possible. 
+e.g. `terra workspace add-user --email=user@gmail.com --role=READER`
+instead of `terra workspace add-user user@gmail.com READER`.
+
+This makes it easier to maintain backwards compatibility when adding new arguments. It also makes it easier to read
+commands with multiple arguments, without having to remember the order.
+
+All option names should start with two dashes. e.g. `--email`
+
+The exception to this rule are the `config get-value` and `config set` commands. These will only ever take one argument
+and use a parameter instead of an option.
+
+#### Always specify a description
+Specify a description for all commands and options. Write it like a sentence: end with a period and capitalize the first
+letter of the first word. e.g. `Add a user or group to the workspace.`, `Group name.`
+
+Use a verb for the first word of a command or command group description. e.g. `Manage spend profiles.`
+
+#### Alphabetize command lists
+Alphabetize commands by their name (not their Java class name, though that is usually identical) when specifying
+a list of sub-commands. picocli does not do this automatically.
+
+#### User readable exception messages
+`UserActionableException`s are expected in the course of normal use. Their messages should be readable to the user.
+`SystemException`s and any other exceptions are not expected in the course of normal use. They indicate a bug or error 
+that should be reported, so there's no need to make these messages readable to the user.
+
+#### Singular command group names
+Use singular command group names instead of plural. e.g. `terra resource` instead of `terra resources`.
+
+TODO (PF-802): fix this for existing commands
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@
     * [Always specify a description](#always-specify-a-description)
     * [Alphabetize command lists](#alphabetize-command-lists)
     * [User readable exception messages](#user-readable-exception-messages)
-    * [Singular command group  names](#singular-command-group-names)
+    * [Singular command group names](#singular-command-group-names)
 
 -----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,8 +394,7 @@ instead of `terra workspace add-user user@gmail.com READER`.
 This makes it easier to maintain backwards compatibility when adding new arguments. It also makes it easier to read
 commands with multiple arguments, without having to remember the order.
 
-The exception to this rule are the `config get-value` and `config set` commands. These will only ever take one argument
-and use a parameter instead of an option.
+The exception to this rule is the `config set` command, which takes one parameter instead of an option.
 
 All option names should start with two dashes. e.g. `--email`
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ A controlled resource is a cloud resource that is managed by Terra. It exists wi
 For example, a bucket within the workspace Google project.
 
 A referenced resource is a cloud resource that is NOT managed by Terra. It exists outside the current workspace
-context. For example, a Big Query dataset hosted outside of Terra or in another workspace.
+context. For example, a BigQuery dataset hosted outside of Terra or in another workspace.
 
 The `check-access` command lets you see whether you have access to a particular resource. This is useful when a
 different user created or added the resource and subsequently shared the workspace with you.

--- a/src/main/java/bio/terra/cli/businessobject/resources/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resources/BqDataset.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Internal representation of a Big Query dataset workspace resource. Instances of this class are
+ * Internal representation of a BigQuery dataset workspace resource. Instances of this class are
  * part of the current context or state.
  */
 public class BqDataset extends Resource {
@@ -23,10 +23,10 @@ public class BqDataset extends Resource {
   private String datasetId;
 
   /**
-   * Delimiter between the project id and dataset id for a Big Query dataset.
+   * Delimiter between the project id and dataset id for a BigQuery dataset.
    *
    * <p>The choice is somewhat arbitrary. BigQuery Datatsets do not have true URIs. The '.'
-   * delimiter allows the path to be used directly in SQL calls with a Big Query extension.
+   * delimiter allows the path to be used directly in SQL calls with a BigQuery extension.
    */
   private static final char BQ_PROJECT_DATASET_DELIMITER = '.';
 
@@ -66,7 +66,7 @@ public class BqDataset extends Resource {
   }
 
   /**
-   * Add a Big Query dataset as a referenced resource in the workspace.
+   * Add a BigQuery dataset as a referenced resource in the workspace.
    *
    * @return the resource that was added
    */
@@ -88,7 +88,7 @@ public class BqDataset extends Resource {
   }
 
   /**
-   * Create a Big Query dataset as a controlled resource in the workspace.
+   * Create a BigQuery dataset as a controlled resource in the workspace.
    *
    * @return the resource that was created
    */
@@ -106,7 +106,7 @@ public class BqDataset extends Resource {
     return new BqDataset(createdResource);
   }
 
-  /** Update a Big Query dataset resource in the workspace. */
+  /** Update a BigQuery dataset resource in the workspace. */
   public void update(UpdateResourceParams updateParams) {
     if (updateParams.name != null) {
       validateEnvironmentVariableName(updateParams.name);
@@ -126,21 +126,21 @@ public class BqDataset extends Resource {
     super.updatePropertiesAndSync(updateParams);
   }
 
-  /** Delete a Big Query dataset referenced resource in the workspace. */
+  /** Delete a BigQuery dataset referenced resource in the workspace. */
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
         .deleteReferencedBigQueryDataset(Context.requireWorkspace().getId(), id);
   }
 
-  /** Delete a Big Query dataset controlled resource in the workspace. */
+  /** Delete a BigQuery dataset controlled resource in the workspace. */
   protected void deleteControlled() {
     // call WSM to delete the resource
     WorkspaceManagerService.fromContext()
         .deleteControlledBigQueryDataset(Context.requireWorkspace().getId(), id);
   }
 
-  /** This enum specifies the possible ways to resolve a Big Query dataset resource. */
+  /** This enum specifies the possible ways to resolve a BigQuery dataset resource. */
   public enum ResolveOptions {
     FULL_PATH, // [project id].[dataset id]
     DATASET_ID_ONLY, // [dataset id]
@@ -148,7 +148,7 @@ public class BqDataset extends Resource {
   }
 
   /**
-   * Resolve a Big Query dataset resource to its cloud identifier. Returns the SQL path to the
+   * Resolve a BigQuery dataset resource to its cloud identifier. Returns the SQL path to the
    * dataset: [GCP project id].[BQ dataset id]
    */
   public String resolve() {
@@ -156,7 +156,7 @@ public class BqDataset extends Resource {
   }
 
   /**
-   * Resolve a Big Query dataset resource to its cloud identifier. Returns the SQL path to the
+   * Resolve a BigQuery dataset resource to its cloud identifier. Returns the SQL path to the
    * dataset: [GCP project id].[BQ dataset id]
    */
   public String resolve(ResolveOptions resolveOption) {
@@ -168,7 +168,7 @@ public class BqDataset extends Resource {
       case PROJECT_ID_ONLY:
         return projectId;
       default:
-        throw new IllegalArgumentException("Unknown Big Query dataset resolve option.");
+        throw new IllegalArgumentException("Unknown BigQuery dataset resolve option.");
     }
   }
 

--- a/src/main/java/bio/terra/cli/command/App.java
+++ b/src/main/java/bio/terra/cli/command/App.java
@@ -11,5 +11,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "app",
     description = "Run applications in the workspace.",
-    subcommands = {List.class, Execute.class})
+    subcommands = {Execute.class, List.class})
 public class App {}

--- a/src/main/java/bio/terra/cli/command/Auth.java
+++ b/src/main/java/bio/terra/cli/command/Auth.java
@@ -12,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "auth",
     description = "Retrieve and manage user credentials.",
-    subcommands = {Status.class, Login.class, Revoke.class})
+    subcommands = {Login.class, Revoke.class, Status.class})
 public class Auth {}

--- a/src/main/java/bio/terra/cli/command/Config.java
+++ b/src/main/java/bio/terra/cli/command/Config.java
@@ -12,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "config",
     description = "Configure the CLI.",
-    subcommands = {List.class, GetValue.class, Set.class})
+    subcommands = {GetValue.class, List.class, Set.class})
 public class Config {}

--- a/src/main/java/bio/terra/cli/command/Groups.java
+++ b/src/main/java/bio/terra/cli/command/Groups.java
@@ -17,12 +17,12 @@ import picocli.CommandLine;
     name = "groups",
     description = "Manage groups of users.",
     subcommands = {
-      List.class,
+      AddUser.class,
       Create.class,
       Delete.class,
       Describe.class,
+      List.class,
       ListUsers.class,
-      AddUser.class,
       RemoveUser.class
     })
 public class Groups {}

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -24,22 +24,22 @@ import picocli.CommandLine.ParseResult;
 @Command(
     name = "terra",
     subcommands = {
+      App.class,
+      Auth.class,
+      Bq.class,
+      Config.class,
+      Gcloud.class,
+      Groups.class,
+      Gsutil.class,
+      Nextflow.class,
+      Notebooks.class,
+      Resolve.class,
+      Resources.class,
+      Server.class,
+      Spend.class,
       Status.class,
       Version.class,
-      Auth.class,
-      Server.class,
-      Workspace.class,
-      Resources.class,
-      App.class,
-      Notebooks.class,
-      Groups.class,
-      Spend.class,
-      Config.class,
-      Resolve.class,
-      Gcloud.class,
-      Gsutil.class,
-      Bq.class,
-      Nextflow.class
+      Workspace.class
     },
     description = "Terra CLI")
 public class Main implements Runnable {

--- a/src/main/java/bio/terra/cli/command/Server.java
+++ b/src/main/java/bio/terra/cli/command/Server.java
@@ -12,5 +12,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "server",
     description = "Connect to a Terra server.",
-    subcommands = {Status.class, List.class, Set.class})
+    subcommands = {List.class, Set.class, Status.class})
 public class Server {}

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -19,14 +19,14 @@ import picocli.CommandLine.Command;
     name = "workspace",
     description = "Setup a Terra workspace.",
     subcommands = {
-      List.class,
+      AddUser.class,
       Create.class,
-      Set.class,
       Delete.class,
       Describe.class,
-      Update.class,
+      List.class,
       ListUsers.class,
-      AddUser.class,
-      RemoveUser.class
+      RemoveUser.class,
+      Set.class,
+      Update.class,
     })
 public class Workspace {}

--- a/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
+++ b/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
@@ -10,7 +10,7 @@ import picocli.CommandLine.Command;
 @Command(name = "app-launch", description = "Configure the ways apps are launched.")
 public class AppLaunch extends BaseCommand {
 
-  @CommandLine.Parameters(index = "0", description = "App launch mode: ${COMPLETION-CANDIDATES}")
+  @CommandLine.Parameters(index = "0", description = "App launch mode: ${COMPLETION-CANDIDATES}.")
   private Config.CommandRunnerOption mode;
 
   /** Updates the command runner option property of the global context. */

--- a/src/main/java/bio/terra/cli/command/config/set/Browser.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Browser.java
@@ -14,7 +14,7 @@ public class Browser extends BaseCommand {
 
   @CommandLine.Parameters(
       index = "0",
-      description = "Browser launch mode: ${COMPLETION-CANDIDATES}")
+      description = "Browser launch mode: ${COMPLETION-CANDIDATES}.")
   private Config.BrowserLaunchOption mode;
 
   /** Updates the browser launch option property of the global context. */

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -14,10 +14,10 @@ public class Image extends BaseCommand {
   ImageIdArgGroup argGroup;
 
   static class ImageIdArgGroup {
-    @CommandLine.Option(names = "--image", description = "image id or tag")
+    @CommandLine.Option(names = "--image", description = "Docker image id or tag.")
     private String imageId;
 
-    @CommandLine.Option(names = "--default", description = "use the default image id or tag")
+    @CommandLine.Option(names = "--default", description = "Use the default image id or tag.")
     private boolean useDefault;
   }
 

--- a/src/main/java/bio/terra/cli/command/config/set/Logging.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Logging.java
@@ -13,10 +13,10 @@ public class Logging extends BaseCommand {
   Logging.LogLevelArgGroup argGroup;
 
   static class LogLevelArgGroup {
-    @CommandLine.Option(names = "--console", description = "console logging level")
+    @CommandLine.Option(names = "--console", description = "Console logging level.")
     private boolean console;
 
-    @CommandLine.Option(names = "--file", description = "file logging level")
+    @CommandLine.Option(names = "--file", description = "File logging level.")
     private boolean file;
   }
 

--- a/src/main/java/bio/terra/cli/command/config/set/ResourceLimit.java
+++ b/src/main/java/bio/terra/cli/command/config/set/ResourceLimit.java
@@ -19,12 +19,13 @@ public class ResourceLimit extends BaseCommand {
   static class ResourceLimitArgGroup {
     @CommandLine.Option(
         names = "--max",
-        description = "maximum number to allow before throwing an error")
+        description = "Maximum number to allow before throwing an error.")
     private int max;
 
     @CommandLine.Option(
         names = "--default",
-        description = "use the default number of resources: " + Config.DEFAULT_RESOURCES_CACHE_SIZE)
+        description =
+            "Use the default number of resources: " + Config.DEFAULT_RESOURCES_CACHE_SIZE + ".")
     private boolean useDefault;
   }
 

--- a/src/main/java/bio/terra/cli/command/resources/List.java
+++ b/src/main/java/bio/terra/cli/command/resources/List.java
@@ -16,12 +16,12 @@ import picocli.CommandLine;
 public class List extends BaseCommand {
   @CommandLine.Option(
       names = "--stewardship",
-      description = "Filter on a particular stewardship type: ${COMPLETION-CANDIDATES}")
+      description = "Filter on a particular stewardship type: ${COMPLETION-CANDIDATES}.")
   private StewardshipType stewardship;
 
   @CommandLine.Option(
       names = "--type",
-      description = "Filter on a particular resource type: ${COMPLETION-CANDIDATES}")
+      description = "Filter on a particular resource type: ${COMPLETION-CANDIDATES}.")
   private Resource.Type type;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resources/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resources/Resolve.java
@@ -25,7 +25,7 @@ public class Resolve extends BaseCommand {
       names = "--bq-path",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
       description =
-          "[For BIG_QUERY_DATASET] Cloud id format: FULL_PATH=[project id].[dataset id], DATASET_ID_ONLY=[dataset id], PROJECT_ID_ONLY=[project id]")
+          "[For BIG_QUERY_DATASET] Cloud id format: FULL_PATH=[project id].[dataset id], DATASET_ID_ONLY=[dataset id], PROJECT_ID_ONLY=[project id].")
   private BqDataset.ResolveOptions bqPathFormat = BqDataset.ResolveOptions.FULL_PATH;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
@@ -13,24 +13,24 @@ import picocli.CommandLine;
 /** This class corresponds to the fourth-level "terra resources add-ref bq-dataset" command. */
 @CommandLine.Command(
     name = "bq-dataset",
-    description = "Add a referenced Big Query dataset.",
+    description = "Add a referenced BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
   @CommandLine.Mixin ResourceCreation resourceCreationOptions;
 
-  @CommandLine.Option(names = "--project-id", required = true, description = "GCP project id.")
+  @CommandLine.Option(
+      names = "--project-id",
+      required = true,
+      description = "GCP project id of the dataset.")
   private String gcpProjectId;
 
-  @CommandLine.Option(
-      names = "--dataset-id",
-      required = true,
-      description = "Big Query dataset id.")
+  @CommandLine.Option(names = "--dataset-id", required = true, description = "BigQuery dataset id.")
   private String bigQueryDatasetId;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
-  /** Add a referenced Big Query dataset to the workspace. */
+  /** Add a referenced BigQuery dataset to the workspace. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
@@ -52,7 +52,7 @@ public class BqDataset extends BaseCommand {
 
   /** Print this command's output in text format. */
   private static void printText(UFBqDataset returnValue) {
-    OUT.println("Successfully added referenced Big Query dataset.");
+    OUT.println("Successfully added referenced BigQuery dataset.");
     returnValue.print();
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/addref/BqDataset.java
@@ -18,10 +18,13 @@ import picocli.CommandLine;
 public class BqDataset extends BaseCommand {
   @CommandLine.Mixin ResourceCreation resourceCreationOptions;
 
-  @CommandLine.Option(names = "--project-id", required = true, description = "GCP project id")
+  @CommandLine.Option(names = "--project-id", required = true, description = "GCP project id.")
   private String gcpProjectId;
 
-  @CommandLine.Option(names = "--dataset-id", required = true, description = "Big Query dataset id")
+  @CommandLine.Option(
+      names = "--dataset-id",
+      required = true,
+      description = "Big Query dataset id.")
   private String bigQueryDatasetId;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resources/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/addref/GcsBucket.java
@@ -22,7 +22,7 @@ public class GcsBucket extends BaseCommand {
       names = "--bucket-name",
       required = true,
       description =
-          "Name of the GCS bucket, without the prefix. (e.g. 'my-bucket', not 'gs://my-bucket')")
+          "Name of the GCS bucket, without the prefix. (e.g. 'my-bucket', not 'gs://my-bucket').")
   private String bucketName;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/AiNotebook.java
@@ -26,7 +26,7 @@ import picocli.CommandLine;
     name = "ai-notebook",
     description =
         "Add a controlled AI Platform Notebook instance resource.\n"
-            + "For a detailed explanation of some parameters, see https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1/projects.locations.instances#Instance",
+            + "For a detailed explanation of some parameters, see https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1/projects.locations.instances#Instance.",
     showDefaultValues = true,
     sortOptions = false)
 public class AiNotebook extends BaseCommand {
@@ -71,7 +71,7 @@ public class AiNotebook extends BaseCommand {
           "https://raw.githubusercontent.com/DataBiosphere/terra-cli/main/notebooks/post-startup.sh",
       description =
           "Path to a Bash script that automatically runs after a notebook instance fully boots up. "
-              + "The path must be a URL or Cloud Storage path, e.g. 'gs://path-to-file/file-name'")
+              + "The path must be a URL or Cloud Storage path, e.g. 'gs://path-to-file/file-name'.")
   private String postStartupScript;
 
   @CommandLine.Option(
@@ -97,7 +97,7 @@ public class AiNotebook extends BaseCommand {
                 + DEFAULT_VM_IMAGE_PROJECT
                 + " --vm-image-family="
                 + DEFAULT_VM_IMAGE_FAMILY
-                + "' %n")
+                + "'.%n")
     VmImage vm;
 
     @CommandLine.ArgGroup(
@@ -140,7 +140,7 @@ public class AiNotebook extends BaseCommand {
         required = true,
         description =
             "The path to the container image repository. For example: "
-                + "'gcr.io/{project_id}/{imageName}'")
+                + "'gcr.io/{project_id}/{imageName}'.")
     private String repository;
 
     @CommandLine.Option(
@@ -158,12 +158,12 @@ public class AiNotebook extends BaseCommand {
   AiNotebook.AcceleratorConfig acceleratorConfig;
 
   static class AcceleratorConfig {
-    @CommandLine.Option(names = "--accelerator-type", description = "type of this accelerator")
+    @CommandLine.Option(names = "--accelerator-type", description = "Type of this accelerator.")
     private String type;
 
     @CommandLine.Option(
         names = "--accelerator-core-count",
-        description = "Count of cores of this accelerator")
+        description = "Count of cores of this accelerator.")
     private Long coreCount;
   }
 
@@ -177,7 +177,7 @@ public class AiNotebook extends BaseCommand {
     @CommandLine.Option(
         names = "--install-gpu-driver",
         description =
-            "If true, the end user authorizes Google Cloud to install a GPU driver on this instance")
+            "If true, the end user authorizes Google Cloud to install a GPU driver on this instance.")
     private Boolean installGpuDriver;
 
     @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
@@ -13,15 +13,12 @@ import picocli.CommandLine;
 /** This class corresponds to the fourth-level "terra resources create bq-dataset" command. */
 @CommandLine.Command(
     name = "bq-dataset",
-    description = "Add a controlled Big Query dataset.",
+    description = "Add a controlled BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
   @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
 
-  @CommandLine.Option(
-      names = "--dataset-id",
-      required = true,
-      description = "Big Query dataset id.")
+  @CommandLine.Option(names = "--dataset-id", required = true, description = "BigQuery dataset id.")
   private String bigQueryDatasetId;
 
   @CommandLine.Option(
@@ -32,7 +29,7 @@ public class BqDataset extends BaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
-  /** Add a controlled Big Query dataset to the workspace. */
+  /** Add a controlled BigQuery dataset to the workspace. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
@@ -56,7 +53,7 @@ public class BqDataset extends BaseCommand {
 
   /** Print this command's output in text format. */
   private static void printText(UFBqDataset returnValue) {
-    OUT.println("Successfully added controlled Big Query dataset.");
+    OUT.println("Successfully added controlled BigQuery dataset.");
     returnValue.print();
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/BqDataset.java
@@ -18,12 +18,15 @@ import picocli.CommandLine;
 public class BqDataset extends BaseCommand {
   @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
 
-  @CommandLine.Option(names = "--dataset-id", required = true, description = "Big Query dataset id")
+  @CommandLine.Option(
+      names = "--dataset-id",
+      required = true,
+      description = "Big Query dataset id.")
   private String bigQueryDatasetId;
 
   @CommandLine.Option(
       names = "--location",
-      description = "Dataset location (https://cloud.google.com/bigquery/docs/locations)")
+      description = "Dataset location (https://cloud.google.com/bigquery/docs/locations).")
   private String location;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/create/GcsBucket.java
@@ -23,14 +23,14 @@ public class GcsBucket extends BaseCommand {
       names = "--bucket-name",
       required = true,
       description =
-          "Name of the GCS bucket, without the prefix. (e.g. 'my-bucket', not 'gs://my-bucket')")
+          "Name of the GCS bucket, without the prefix. (e.g. 'my-bucket', not 'gs://my-bucket').")
   private String bucketName;
 
   @CommandLine.Mixin GcsBucketStorageClass storageClassOption;
 
   @CommandLine.Option(
       names = "--location",
-      description = "Bucket location (https://cloud.google.com/storage/docs/locations)")
+      description = "Bucket location (https://cloud.google.com/storage/docs/locations).")
   private String location;
 
   @CommandLine.Mixin bio.terra.cli.command.shared.options.GcsBucketLifecycle lifecycleOptions;

--- a/src/main/java/bio/terra/cli/command/resources/update/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resources/update/BqDataset.java
@@ -13,7 +13,7 @@ import picocli.CommandLine;
 /** This class corresponds to the fourth-level "terra resources update bq-dataset" command. */
 @CommandLine.Command(
     name = "bq-dataset",
-    description = "Update a Big Query dataset.",
+    description = "Update a BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
@@ -21,7 +21,7 @@ public class BqDataset extends BaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
-  /** Update a Big Query dataset in the workspace. */
+  /** Update a BigQuery dataset in the workspace. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
@@ -44,7 +44,7 @@ public class BqDataset extends BaseCommand {
 
   /** Print this command's output in text format. */
   private static void printText(UFBqDataset returnValue) {
-    OUT.println("Successfully updated Big Query dataset.");
+    OUT.println("Successfully updated BigQuery dataset.");
     returnValue.print();
   }
 }

--- a/src/main/java/bio/terra/cli/command/resources/update/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resources/update/GcsBucket.java
@@ -26,7 +26,7 @@ public class GcsBucket extends BaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
-  /** Update a Big Query dataset in the workspace. */
+  /** Update a BigQuery dataset in the workspace. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();

--- a/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
@@ -18,19 +18,19 @@ public class ControlledResourceCreation {
 
   @CommandLine.Option(
       names = "--access",
-      description = "Access scope for the resource: ${COMPLETION-CANDIDATES}")
+      description = "Access scope for the resource: ${COMPLETION-CANDIDATES}.")
   public AccessScope access = AccessScope.SHARED_ACCESS;
 
   @CommandLine.Option(
       names = "--email",
-      description = "[PRIVATE ACCESS ONLY] Email address for user of private resource")
+      description = "[PRIVATE ACCESS ONLY] Email address for user of private resource.")
   public String privateUserEmail;
 
   @CommandLine.Option(
       names = "--iam-roles",
       split = ",",
       description =
-          "[PRIVATE ACCESS ONLY] IAM roles to grant user of private resource: ${COMPLETION-CANDIDATES}")
+          "[PRIVATE ACCESS ONLY] IAM roles to grant user of private resource: ${COMPLETION-CANDIDATES}.")
   public List<ControlledResourceIamRole> privateIamRoles;
 
   /** Helper method to validate conditional required options. */

--- a/src/main/java/bio/terra/cli/command/shared/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/Format.java
@@ -20,7 +20,7 @@ public class Format {
       names = "--format",
       defaultValue = "text",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS,
-      description = "Set the format for printing command output: ${COMPLETION-CANDIDATES}")
+      description = "Set the format for printing command output: ${COMPLETION-CANDIDATES}.")
   private FormatOptions format;
 
   /** This enum specifies the format options for printing the command output. */

--- a/src/main/java/bio/terra/cli/command/shared/options/GcsBucketStorageClass.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/GcsBucketStorageClass.java
@@ -13,7 +13,7 @@ public class GcsBucketStorageClass {
   @CommandLine.Option(
       names = "--storage",
       description =
-          "Storage class (https://cloud.google.com/storage/docs/storage-classes): ${COMPLETION-CANDIDATES}")
+          "Storage class (https://cloud.google.com/storage/docs/storage-classes): ${COMPLETION-CANDIDATES}.")
   public GcpGcsBucketDefaultStorageClass storageClass;
 
   public boolean isDefined() {

--- a/src/main/java/bio/terra/cli/command/shared/options/GroupMember.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/GroupMember.java
@@ -21,6 +21,6 @@ public class GroupMember {
   @CommandLine.Option(
       names = "--policy",
       required = true,
-      description = "Policy: ${COMPLETION-CANDIDATES}")
+      description = "Group policy: ${COMPLETION-CANDIDATES}.")
   public SamService.GroupPolicy policy;
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
@@ -18,7 +18,7 @@ public class ResourceCreation {
   @CommandLine.Option(
       names = "--cloning",
       description =
-          "Instructions for handling when cloning the workspace: ${COMPLETION-CANDIDATES}.")
+          "Instructions for handling when cloning the workspace or resource: ${COMPLETION-CANDIDATES}.")
   public CloningInstructionsEnum cloning = CloningInstructionsEnum.NOTHING;
 
   /**

--- a/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
@@ -18,7 +18,7 @@ public class ResourceCreation {
   @CommandLine.Option(
       names = "--cloning",
       description =
-          "Instructions for handling when cloning the workspace: ${COMPLETION-CANDIDATES}")
+          "Instructions for handling when cloning the workspace: ${COMPLETION-CANDIDATES}.")
   public CloningInstructionsEnum cloning = CloningInstructionsEnum.NOTHING;
 
   /**

--- a/src/main/java/bio/terra/cli/command/shared/options/ResourceDescription.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ResourceDescription.java
@@ -8,6 +8,6 @@ import picocli.CommandLine;
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
 public class ResourceDescription {
-  @CommandLine.Option(names = "--description", description = "Description of the resource")
+  @CommandLine.Option(names = "--description", description = "Description of the resource.")
   public String description;
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/SpendProfileUser.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/SpendProfileUser.java
@@ -18,6 +18,6 @@ public class SpendProfileUser {
   @CommandLine.Option(
       names = "--policy",
       required = true,
-      description = "Policy: ${COMPLETION-CANDIDATES}")
+      description = "Spend policy: ${COMPLETION-CANDIDATES}.")
   public SpendProfileManagerService.SpendProfilePolicy policy;
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
@@ -17,7 +17,7 @@ public class WorkspaceOverride {
 
   @CommandLine.Option(
       names = "--workspace",
-      description = "Workspace id to use for this command only")
+      description = "Workspace id to use for this command only.")
   private UUID id;
 
   /** Helper method to override the current workspace if the `--workspace` flag specifies an id. */

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -19,7 +19,7 @@ public class AddUser extends BaseCommand {
   @CommandLine.Option(
       names = "--role",
       required = true,
-      description = "Role to grant: ${COMPLETION-CANDIDATES}")
+      description = "Role to grant: ${COMPLETION-CANDIDATES}.")
   private IamRole role;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -11,13 +11,16 @@ import picocli.CommandLine.Command;
 @Command(name = "create", description = "Create a new workspace.")
 public class Create extends BaseCommand {
 
-  @CommandLine.Option(names = "--name", required = false, description = "workspace display name")
+  @CommandLine.Option(
+      names = "--name",
+      required = false,
+      description = "Workspace display name (not unique).")
   private String displayName;
 
   @CommandLine.Option(
       names = "--description",
       required = false,
-      description = "workspace description")
+      description = "Workspace description.")
   private String description;
 
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -17,7 +17,7 @@ public class RemoveUser extends BaseCommand {
   @CommandLine.Option(
       names = "--role",
       required = true,
-      description = "Role to grant: ${COMPLETION-CANDIDATES}")
+      description = "Role to grant: ${COMPLETION-CANDIDATES}.")
   private IamRole role;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.Command;
 @Command(name = "set", description = "Set the workspace to an existing one.")
 public class Set extends BaseCommand {
 
-  @CommandLine.Option(names = "--id", required = true, description = "workspace id")
+  @CommandLine.Option(names = "--id", required = true, description = "Workspace id.")
   private UUID id;
 
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -20,7 +20,10 @@ public class Update extends BaseCommand {
   Update.UpdateArgGroup argGroup;
 
   static class UpdateArgGroup {
-    @CommandLine.Option(names = "--name", required = false, description = "Workspace display name.")
+    @CommandLine.Option(
+        names = "--name",
+        required = false,
+        description = "Workspace display name (not unique).")
     private String displayName;
 
     @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -20,13 +20,13 @@ public class Update extends BaseCommand {
   Update.UpdateArgGroup argGroup;
 
   static class UpdateArgGroup {
-    @CommandLine.Option(names = "--name", required = false, description = "workspace display name")
+    @CommandLine.Option(names = "--name", required = false, description = "Workspace display name.")
     private String displayName;
 
     @CommandLine.Option(
         names = "--description",
         required = false,
-        description = "workspace description")
+        description = "Workspace description.")
     private String description;
   }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resources/UFBqDataset.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
 
 /**
- * External representation of a workspace Big Query dataset resource for command input/output.
+ * External representation of a workspace BigQuery dataset resource for command input/output.
  *
  * <p>This is a POJO class intended for serialization. This JSON format is user-facing.
  *
@@ -38,7 +38,7 @@ public class UFBqDataset extends UFResource {
     super.print();
     PrintStream OUT = UserIO.getOut();
     OUT.println("GCP project id: " + projectId);
-    OUT.println("Big Query dataset id: " + datasetId);
+    OUT.println("BigQuery dataset id: " + datasetId);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -438,11 +438,11 @@ public class WorkspaceManagerService {
   /**
    * Call the Workspace Manager POST
    * "/api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets" endpoint to add a
-   * Big Query dataset as a referenced resource in the workspace.
+   * BigQuery dataset as a referenced resource in the workspace.
    *
    * @param workspaceId the workspace to add the resource to
    * @param createParams resource definition to add
-   * @return the Big Query dataset resource object
+   * @return the BigQuery dataset resource object
    */
   public GcpBigQueryDatasetResource createReferencedBigQueryDataset(
       UUID workspaceId, CreateBqDatasetParams createParams) {
@@ -462,7 +462,7 @@ public class WorkspaceManagerService {
         () ->
             new ReferencedGcpResourceApi(apiClient)
                 .createBigQueryDatasetReference(createRequest, workspaceId),
-        "Error creating referenced Big Query dataset in the workspace.");
+        "Error creating referenced BigQuery dataset in the workspace.");
   }
 
   /**
@@ -645,7 +645,7 @@ public class WorkspaceManagerService {
    *
    * @param workspaceId the workspace to add the resource to
    * @param createParams resource definition to create
-   * @return the Big Query dataset resource object
+   * @return the BigQuery dataset resource object
    */
   public GcpBigQueryDatasetResource createControlledBigQueryDataset(
       UUID workspaceId, CreateBqDatasetParams createParams) {
@@ -662,7 +662,7 @@ public class WorkspaceManagerService {
             new ControlledGcpResourceApi(apiClient)
                 .createBigQueryDataset(createRequest, workspaceId)
                 .getBigQueryDataset(),
-        "Error creating controlled Big Query dataset in the workspace.");
+        "Error creating controlled BigQuery dataset in the workspace.");
   }
 
   /**
@@ -743,7 +743,7 @@ public class WorkspaceManagerService {
   /**
    * Call the Workspace Manager POST
    * "/api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/{resourceId}"
-   * endpoint to update a Big Query dataset referenced resource in the workspace.
+   * endpoint to update a BigQuery dataset referenced resource in the workspace.
    *
    * @param workspaceId the workspace where the resource exists
    * @param resourceId the resource id
@@ -760,13 +760,13 @@ public class WorkspaceManagerService {
         () ->
             new ReferencedGcpResourceApi(apiClient)
                 .updateBigQueryDatasetReference(updateRequest, workspaceId, resourceId),
-        "Error updating referenced Big Query dataset in the workspace.");
+        "Error updating referenced BigQuery dataset in the workspace.");
   }
 
   /**
    * Call the Workspace Manager POST
    * "/api/workspaces/v1/{workspaceId}/resources/controlled/gcp/bqdatasets/{resourceId}" endpoint to
-   * update a Big Query dataset controlled resource in the workspace.
+   * update a BigQuery dataset controlled resource in the workspace.
    *
    * @param workspaceId the workspace where the resource exists
    * @param resourceId the resource id
@@ -783,7 +783,7 @@ public class WorkspaceManagerService {
         () ->
             new ControlledGcpResourceApi(apiClient)
                 .updateBigQueryDataset(updateRequest, workspaceId, resourceId),
-        "Error updating controlled Big Query dataset in the workspace.");
+        "Error updating controlled BigQuery dataset in the workspace.");
   }
 
   /**
@@ -804,7 +804,7 @@ public class WorkspaceManagerService {
   /**
    * Call the Workspace Manager DELETE
    * "/api/workspaces/v1/{workspaceId}/resources/referenced/gcp/bigquerydatasets/{resourceId}"
-   * endpoint to delete a Big Query dataset as a referenced resource in the workspace.
+   * endpoint to delete a BigQuery dataset as a referenced resource in the workspace.
    *
    * @param workspaceId the workspace to remove the resource from
    * @param resourceId the resource id
@@ -814,7 +814,7 @@ public class WorkspaceManagerService {
         () ->
             new ReferencedGcpResourceApi(apiClient)
                 .deleteBigQueryDatasetReference(workspaceId, resourceId),
-        "Error deleting referenced Big Query dataset in the workspace.");
+        "Error deleting referenced BigQuery dataset in the workspace.");
   }
 
   /**
@@ -895,7 +895,7 @@ public class WorkspaceManagerService {
   /**
    * Call the Workspace Manager POST
    * "/api/workspaces/v1/{workspaceId}/resources/controlled/gcp/bqdatasets/{resourceId}" endpoint to
-   * delete a Big Query dataset as a controlled resource in the workspace.
+   * delete a BigQuery dataset as a controlled resource in the workspace.
    *
    * @param workspaceId the workspace to remove the resource from
    * @param resourceId the resource id
@@ -904,7 +904,7 @@ public class WorkspaceManagerService {
     callWithRetries(
         () ->
             new ControlledGcpResourceApi(apiClient).deleteBigQueryDataset(workspaceId, resourceId),
-        "Error deleting controlled Big Query dataset in the workspace.");
+        "Error deleting controlled BigQuery dataset in the workspace.");
   }
 
   /** Helper method that checks a JobReport's status and returns false if it's still RUNNING. */

--- a/src/test/java/unit/ClientExceptionHandling.java
+++ b/src/test/java/unit/ClientExceptionHandling.java
@@ -76,8 +76,7 @@ public class ClientExceptionHandling extends SingleWorkspaceUnit {
     assertThat(
         "stderr includes the CLI error message",
         stdErr,
-        CoreMatchers.containsString(
-            "Error creating controlled Big Query dataset in the workspace"));
+        CoreMatchers.containsString("Error creating controlled BigQuery dataset in the workspace"));
     assertThat(
         "stderr includes the WSM error message",
         stdErr,


### PR DESCRIPTION
Wrote up brief notes on command style guidelines. Goal is to make the usage help and commands look consistent.

Most commands already follow these guidelines. I made some trivial (non-functional) changes to commands (e.g. added periods, fixed capitalization) to make the rest consistent.

As part of this style update, I'm also planning to make the command group names consistently singular
`groups` -> `group`
`notebooks` -> `notebook`
`resources` -> `resource`
to match the existing `app`, `server`, `spend`, `workspace`. But I'm going to do this in a follow-on PR.

Reviewers, feel free to include any other suggestions/comments about general style/consistency while I'm doing this once-over.