### PR TITLE
PF-899: Set workspace id in notebook startup script.

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -3,5 +3,5 @@
 Directory for AI Notebook scripts.
 
 For now, we're experimenting with post startup scripts for customizing Terra AI Notebook instances.
-While these scripts may eventually migrate to a notebook specific repository, for now its convenient
+While these scripts may eventually migrate to a notebook specific repository, for now it's convenient
 to have them here.

--- a/notebooks/post-startup.sh
+++ b/notebooks/post-startup.sh
@@ -52,3 +52,8 @@ readonly TERRA_SERVER=$(get_metadata_value "instance/attributes/terra-cli-server
 if [[ -n "${TERRA_SERVER}" ]]; then
   sudo -u "${JUPYTER_USER}" sh -c "terra server set --name=${TERRA_SERVER}"
 fi
+# Set the CLI terra workspace id using the VM metadata, if set.
+readonly TERRA_WORKSPACE=$(get_metadata_value "instance/attributes/terra-workspace-id")
+if [[ -n "${TERRA_WORKSPACE}" ]]; then
+  sudo -u "${JUPYTER_USER}" sh -c "terra workspace set --id=${TERRA_WORKSPACE} --defer-login"
+fi

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
@@ -58,8 +58,8 @@ public class UFConfig {
   /** Print out this object in text format. */
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    OUT.println("[app-launch] app launch mode = " + browserLaunchOption);
-    OUT.println("[browser] browser launch for login = " + commandRunnerOption);
+    OUT.println("[app-launch] app launch mode = " + commandRunnerOption);
+    OUT.println("[browser] browser launch for login = " + browserLaunchOption);
     OUT.println("[image] docker image id = " + dockerImageId);
     OUT.println(
         "[resource-limit] max number of resources to allow per workspace = " + resourcesCacheSize);


### PR DESCRIPTION
- Updated the notebook startup script to set the workspace id from the VM metadata, similar to how the server is set.
- Fixed a bug in the text output of the `terra config list` command, where the `app-launch` and `browser` property values were swapped.