### PR TITLE
PF-829: Use Terraformed project + SA for creating test resources.

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -47,9 +47,11 @@ jobs:
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
           echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+          echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
+          EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
       - name: Run cleanup script
         id: run_cleanup_script
         run: |

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -42,7 +42,7 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect these
+          # regardless of how it was fetched, tests and scripts expect these
           # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -37,7 +37,7 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect these
+          # regardless of how it was fetched, scripts expect these
           # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -37,7 +37,7 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, scripts expect these
+          # regardless of how it was fetched, tests and scripts expect these
           # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -37,12 +37,16 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, the publish-release script expects this
-          # key to be stored in rendered/ci-account.json
+          # regardless of how it was fetched, tests expect these
+          # keys to be stored in rendered/
           mkdir -p rendered
+          echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
           echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+          echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
         env:
+          TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
+          EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
       - name: Publish a release
         id: publish_release
         run: |

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -40,7 +40,7 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect these
+          # regardless of how it was fetched, tests and scripts expect these
           # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -45,9 +45,11 @@ jobs:
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
           echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+          echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
+          EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
       - name: Run tests
         id: run_tests
         run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -67,9 +67,11 @@ jobs:
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
           echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+          echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
         env:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
+          EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
       - name: Run tests
         id: run_tests
         run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -62,7 +62,7 @@ jobs:
           # this step does the equivalent of the tools/render-config.sh script.
           # on local machines, the script fetches a SA from Vault.
           # in GH actions, the SA key is stored in a GH repo secret.
-          # regardless of how it was fetched, tests expect these
+          # regardless of how it was fetched, tests and scripts expect these
           # keys to be stored in rendered/
           mkdir -p rendered
           echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json

--- a/src/test/java/harness/TestExternalResources.java
+++ b/src/test/java/harness/TestExternalResources.java
@@ -13,14 +13,11 @@ import java.util.List;
  * external resources.
  */
 public class TestExternalResources {
-  // TODO (PF-829): change this project id and SA key file to point to ones Terraformed specifically
-  // for testing
-
   // Google project to create resources in
-  private static final String gcpProjectId = "terra-cli-dev";
+  private static final String gcpProjectId = "terra-cli-test";
 
   // SA with permission to create/delete/query resources in the project
-  private static final String saKeyFile = "./rendered/ci-account.json";
+  private static final String saKeyFile = "./rendered/external-project-account.json";
 
   // default scope to request for the SA
   private static final List<String> cloudPlatformScope =

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -17,22 +17,32 @@ CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
 TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
 EXT_PROJECT_SA_VAULT_PATH=secret/dsde/terra/cli-test/default/service-account-admin.json
 
+# Helper function to read a secret from Vault and write it to a local file in the rendered/ directory.
+# Inputs: vault path, file name
+# Usage: readFromVault $CI_SA_VAULT_PATH ci-account.json
+readFromVault () {
+  vaultPath=$1
+  fileName=$2
+  if [ -z "$vaultPath" ] || [ -z "$fileName" ]; then
+    echo "Two arguments required for readFromVault function"
+    exit 1
+  fi
+  docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json $vaultPath \
+            | jq -r .data > "rendered/$fileName"
+  return 0
+}
+
 mkdir -p rendered
 
 # used for publishing Docker images to GCR in the terra-cli-dev project
 echo "Reading the CI service account key file from Vault"
-docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json ${CI_SA_VAULT_PATH} \
-            | jq -r .data > rendered/ci-account.json
+readFromVault "$CI_SA_VAULT_PATH" "ci-account.json"
 
 # used for generating domain-wide delegated credentials for test users
 echo "Reading the domain-wide delegated test users service account key file from Vault"
-docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json ${TEST_USER_SA_VAULT_PATH} \
-            | jq -r .data > rendered/test-user-account.json
+readFromVault "$TEST_USER_SA_VAULT_PATH" "test-user-account.json"
 
 # used for creating external cloud resources in the terra-cli-test project for tests
 echo "Reading the external project service account key file from Vault"
-docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json ${EXT_PROJECT_SA_VAULT_PATH} \
-            | jq -r .data > rendered/external-project-account.json
+readFromVault "$EXT_PROJECT_SA_VAULT_PATH" "external-project-account.json"

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -31,7 +31,7 @@ docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${TEST_USER_SA_VAULT_PATH} \
             | jq -r .data > rendered/test-user-account.json
 
-# used for creating external cloud resources for tests (i.e. external to a workspace)
+# used for creating external cloud resources in the terra-cli-test project for tests
 echo "Reading the external project service account key file from Vault"
 docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${EXT_PROJECT_SA_VAULT_PATH} \

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -15,15 +15,24 @@ VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
 CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
 TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
+EXT_PROJECT_SA_VAULT_PATH=secret/dsde/terra/cli-test/default/service-account-admin.json
 
 mkdir -p rendered
 
+# used for publishing Docker images to GCR in the terra-cli-dev project
 echo "Reading the CI service account key file from Vault"
 docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${CI_SA_VAULT_PATH} \
             | jq -r .data > rendered/ci-account.json
 
+# used for generating domain-wide delegated credentials for test users
 echo "Reading the domain-wide delegated test users service account key file from Vault"
 docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
             vault read -format json ${TEST_USER_SA_VAULT_PATH} \
             | jq -r .data > rendered/test-user-account.json
+
+# used for creating external cloud resources for tests (i.e. external to a workspace)
+echo "Reading the external project service account key file from Vault"
+docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json ${EXT_PROJECT_SA_VAULT_PATH} \
+            | jq -r .data > rendered/external-project-account.json


### PR DESCRIPTION
The CLI tests for referenced workspace resources create buckets and BQ datasets in an external (to WSM) project. Previously, the tests were using the `terra-cli-dev` project, which was manually created and is intended for holding the client id and GCR repository only. This PR changes the tests to use the `terra-cli-test` project, which was Terraformed specifically for CLI tests (see related terraform-ap-modules [PR](https://github.com/broadinstitute/terraform-ap-modules/pull/189) and terraform-ap-deployments [PR](https://github.com/broadinstitute/terraform-ap-deployments/pull/353)).

I also added a new GH secret to this repo for the key file of the new SA.