### PR TITLE
PF-922: Re-enable notebook tests.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -426,6 +426,3 @@ that should be reported, so there's no need to make these messages readable to t
 
 #### Singular command group names
 Use singular command group names instead of plural. e.g. `terra resource` instead of `terra resources`.
-
-TODO (PF-802): fix this for existing commands
-

--- a/src/test/java/unit/AiNotebookControlled.java
+++ b/src/test/java/unit/AiNotebookControlled.java
@@ -203,13 +203,11 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
     pollDescribeForNotebookState(name, "PROVISIONING");
 
     // `terra notebook start --name=$name`
-    // TODO (PF-869): change this to expect success once polling notebook operations is fixed
-    TestCommand.runCommand("notebook", "start", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("notebook", "start", "--name=" + name);
     pollDescribeForNotebookState(name, "ACTIVE");
 
     // `terra notebook stop --name=$name`
-    // TODO (PF-869): change this to expect success once polling notebook operations is fixed
-    TestCommand.runCommand("notebook", "stop", "--name=" + name);
+    TestCommand.runCommandExpectSuccess("notebook", "stop", "--name=" + name);
     pollDescribeForNotebookState(name, "STOPPED");
   }
 

--- a/src/test/java/unit/AiNotebookControlled.java
+++ b/src/test/java/unit/AiNotebookControlled.java
@@ -210,6 +210,10 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
     // `terra notebook stop --name=$name`
     TestCommand.runCommandExpectSuccess("notebook", "stop", "--name=" + name);
     assertNotebookState(name, "STOPPED");
+
+    // `terra notebook start --name=$name`
+    TestCommand.runCommandExpectSuccess("notebook", "start", "--name=" + name);
+    assertNotebookState(name, "ACTIVE");
   }
 
   /**

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -39,7 +39,6 @@ import java.util.UUID;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -421,7 +420,7 @@ public class WorkspaceOverride extends ClearContextUnit {
     assertEquals(1, matchingWorkspaces.size(), "workspace 1 is still included in list");
   }
 
-  @Disabled // TODO (PF-869): enable this test once polling notebook operations is fixed
+  @Test
   @DisplayName("notebook commands respect workspace override")
   void notebooks() throws IOException, InterruptedException {
     workspaceCreator.login();
@@ -444,15 +443,11 @@ public class WorkspaceOverride extends ClearContextUnit {
     assertEquals(0, matchedNotebooks.size(), "list output for notebooks in workspace 1 is empty");
 
     // `terra notebook start --name=$name`
-    // TODO (PF-869): change this to expect success and remove polling (state change is covered by
-    // ctrl notebooks tests)
-    TestCommand.runCommand("notebook", "start", "--name=" + name, "--workspace=" + workspace2.id);
-    pollDescribeForNotebookState(name, "ACTIVE", workspace2.id);
+    TestCommand.runCommandExpectSuccess(
+        "notebook", "start", "--name=" + name, "--workspace=" + workspace2.id);
 
     // `terra notebook stop --name=$name`
-    // TODO (PF-869): change this to expect success and remove polling (state change is covered by
-    // ctrl notebooks tests)
-    TestCommand.runCommand("notebook", "stop", "--name=" + name, "--workspace=" + workspace2.id);
-    pollDescribeForNotebookState(name, "STOPPED", workspace2.id);
+    TestCommand.runCommandExpectSuccess(
+        "notebook", "stop", "--name=" + name, "--workspace=" + workspace2.id);
   }
 }

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -4,6 +4,7 @@ import static harness.utils.ExternalBQDatasets.randomDatasetId;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static unit.AiNotebookControlled.assertNotebookState;
 import static unit.AiNotebookControlled.listNotebookResourcesWithName;
 import static unit.AiNotebookControlled.listOneNotebookResourceWithName;
 import static unit.AiNotebookControlled.pollDescribeForNotebookState;
@@ -432,7 +433,8 @@ public class WorkspaceOverride extends ClearContextUnit {
     String name = "notebooks";
     TestCommand.runCommandExpectSuccess(
         "resource", "create", "ai-notebook", "--name=" + name, "--workspace=" + workspace2.id);
-    pollDescribeForNotebookState(name, "PROVISIONING", workspace2.id);
+    assertNotebookState(name, "PROVISIONING", workspace2.id);
+    pollDescribeForNotebookState(name, "ACTIVE", workspace2.id);
 
     // `terra resources list --type=AI_NOTEBOOK --workspace=$id2`
     UFAiNotebook matchedNotebook = listOneNotebookResourceWithName(name, workspace2.id);


### PR DESCRIPTION
Now that permissions for `notebook start/stop` commands are fixed, re-enabled the tests and assertions for these commands.