### PR TITLE
PF-920, PF-921: Fixes for nightly GH action.

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -107,7 +107,7 @@ jobs:
           echo ::set-output name=status-text::$text
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name != 'workflow_dispatch'
+        if: always() && github.event_name == 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -55,28 +55,22 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-unit
-          cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
-          cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-unit
       - name: Run integration tests against source code
         id: run_integration_tests_against_source_code
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-source
-          cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
-          cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-source
       - name: Run integration tests against release
         id: run_integration_tests_against_release
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-release
-          cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
-          cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-release
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -55,7 +55,7 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit ${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=unit ${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
           cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
@@ -64,7 +64,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration ${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=integration ${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
@@ -73,7 +73,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub ${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub ${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
@@ -96,6 +96,13 @@ jobs:
           L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
           text="Link to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
           bold="$L2 | $L3 | $L4"
+          titleText="CLI nightly test run: ${{ matrix.testServer }}"
+          if [ "${{ job.status }}" == "success" ]; then
+            title=":white_check_mark:$titleText"
+          else
+            title=":no_entry:$titleText"
+          fi
+          echo ::set-output name=status-title::$title
           echo ::set-output name=status-text::$text
           echo ::set-output name=status-bold::$bold
       - name: Notify PF alerts slack channel
@@ -109,7 +116,7 @@ jobs:
         with:
           status: ${{ job.status }}
           channel: "@mmedlock" #"#platform-foundation-alerts"
-          username: "CLI nightly test run"
+          username: ${{ steps.compose_status_message.outputs.status-title }}
           author_name: ${{ steps.compose_status_message.outputs.status-bold }}
           icon_emoji: ':cli:'
           text: ${{ steps.compose_status_message.outputs.status-text }}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -95,7 +95,7 @@ jobs:
           L2="Unit: ${{ steps.run_unit_tests.outcome }} "
           L3="Integ (Source): ${{ steps.run_integration_tests_against_source_code.outcome }} "
           L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
-          text="Server: ${{ matrix.testServer }}\nLink to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
+          text="Link to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
           if [ "${{ job.status }}" == "success" ]; then
             text=":white_check_mark: $text"
           else

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -55,7 +55,7 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
           cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
@@ -64,7 +64,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
@@ -73,7 +73,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -56,21 +56,21 @@ jobs:
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit --tests "unit.Workspace.createFailsWithoutSpendAccess"
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit
       - name: Run integration tests against source code
         id: run_integration_tests_against_source_code
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-source
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
       - name: Run integration tests against release
         id: run_integration_tests_against_release
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-release
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
       - name: Compile logs and context files for all test runs
         id: compile_logs_and_context_files
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,8 +8,7 @@ jobs:
   tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testOptions: [ "-PtestTag=unit", "-PtestTag=integration", "-PtestTag=integration -PtestInstallFromGitHub" ]
-        testServer: ["-Pserver=terra-dev", "-Pserver=terra-verily-autopush"]
+        testServer: [ "-Pserver=terra-dev", "-Pserver=terra-verily-autopush" ]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -51,23 +50,57 @@ jobs:
           TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
           DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
           EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
-      - name: Run tests
-        id: run_tests
+      - name: Run unit tests
+        id: run_unit_tests
+        if: always()
         run: |
-          echo "Running tests with options: ${{ matrix.testOptions }} ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag ${{ matrix.testOptions }} ${{ matrix.testServer }}
-      - name: Archive logs and context file
+          echo "Running unit tests for server: ${{ matrix.testServer }}"
+          ./gradlew runTestsWithTag -PtestTag=unit ${{ matrix.testServer }}
+          mkdir -p ~/logs-unit
+          cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
+          cp -R build/test-context/.terra/global-context.json ~/logs-unit/global-context.json
+      - name: Run integration tests against source code
+        id: run_integration_tests_against_source_code
+        if: always()
+        run: |
+          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
+          ./gradlew runTestsWithTag -PtestTag=integration ${{ matrix.testServer }}
+          mkdir -p ~/logs-integration-source
+          cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
+          cp -R build/test-context/.terra/global-context.json ~/logs-integration-source/global-context.json
+      - name: Run integration tests against release
+        id: run_integration_tests_against_release
+        if: always()
+        run: |
+          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub ${{ matrix.testServer }}
+          mkdir -p ~/logs-integration-release
+          cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
+          cp -R build/test-context/.terra/global-context.json ~/logs-integration-release/global-context.json
+      - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-and-context-[${{ matrix.testOptions }}]
+          name: logs-and-context-[${{ matrix.testServer }}]
           path: |
-            build/test-context/.terra/logs/
-            build/test-context/.terra/global-context.json
+            ~/logs-unit
+            ~/logs-integration-source
+            ~/logs-integration-release
+      - name: Compose status message
+        id: compose_status_message
+        if: always()
+        run: |
+          L2="Unit: ${{ steps.run_unit_tests.outcome }} "
+          L3="Integ (Source): ${{ steps.run_integration_tests_against_source_code.outcome }} "
+          L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
+          text="Link to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
+          bold="$L2 | $L3 | $L4"
+          echo ::set-output name=status-text::$text
+          echo ::set-output name=status-bold::$bold
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name != 'workflow_dispatch'
+        if: always() && github.event_name == 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,6 +108,6 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           status: ${{ job.status }}
-          channel: "#platform-foundation-alerts"
+          channel: "@mmedlock" #"#platform-foundation-alerts"
           username: "CLI nightly test run"
           fields: job,took

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -56,32 +56,33 @@ jobs:
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-unit --tests "unit.Workspace.createFailsWithoutSpendAccess"
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit --tests "unit.Workspace.createFailsWithoutSpendAccess"
       - name: Run integration tests against source code
         id: run_integration_tests_against_source_code
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-source
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-source --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source --tests "integration.Nextflow.helloWorld"
       - name: Run integration tests against release
         id: run_integration_tests_against_release
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-release
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-release --tests "integration.Nextflow.helloWorld"
-      - name: Compile all logs
-        id: compile_all_logs
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release --tests "integration.Nextflow.helloWorld"
+      - name: Compile logs and context files for all test runs
+        id: compile_logs_and_context_files
         if: always()
         run: |
-          echo "Compiling all logs"
-          echo "HOME"
-          ls -la $HOME
-          echo "~/logs-unit"
-          ls -la ~/logs-unit
-          echo "HOME/logs-unit"
-          ls -la $HOME/logs-unit
+          declare -a arr=("unit" "integration-source" "integration-release")
+          for i in "${arr[@]}"
+          do
+            echo "Compiling logs and context files for test run: $i"
+            mkdir -p ~/to-archive/$i
+            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
+            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
+          done
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()
@@ -89,12 +90,7 @@ jobs:
         with:
           name: logs-and-context-${{ matrix.testServer }}
           path: |
-            ~/logs-unit/logs/
-            ~/logs-unit/context.json
-            ~/logs-integration-source/logs/
-            ~/logs-integration-source/context.json
-            ~/logs-integration-release/logs/
-            ~/logs-integration-release/context.json
+            ~/to-archive/
       - name: Compose status message
         id: compose_status_message
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -58,7 +58,7 @@ jobs:
           ./gradlew runTestsWithTag -PtestTag=unit ${{ matrix.testServer }}
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
-          cp -R build/test-context/.terra/global-context.json ~/logs-unit/global-context.json
+          cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
       - name: Run integration tests against source code
         id: run_integration_tests_against_source_code
         if: always()
@@ -67,7 +67,7 @@ jobs:
           ./gradlew runTestsWithTag -PtestTag=integration ${{ matrix.testServer }}
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
-          cp -R build/test-context/.terra/global-context.json ~/logs-integration-source/global-context.json
+          cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
       - name: Run integration tests against release
         id: run_integration_tests_against_release
         if: always()
@@ -76,7 +76,7 @@ jobs:
           ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub ${{ matrix.testServer }}
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
-          cp -R build/test-context/.terra/global-context.json ~/logs-integration-release/global-context.json
+          cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -55,7 +55,7 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
           cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
@@ -64,7 +64,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
@@ -73,10 +73,10 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }}
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
-          cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
+          cp -R build/test-context/.terra/context-bad.json ~/logs-integration-release/context.json
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -110,4 +110,6 @@ jobs:
           status: ${{ job.status }}
           channel: "@mmedlock" #"#platform-foundation-alerts"
           username: "CLI nightly test run"
-          fields: job,took
+          author_name: ${{ steps.compose_status_message.outputs.status-bold }}
+          icon_emoji: ':cli:'
+          text: ${{ steps.compose_status_message.outputs.status-text }}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,7 +8,7 @@ jobs:
   tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testServer: [ "-Pserver=terra-dev", "-Pserver=terra-verily-autopush" ]
+        testServer: [ "terra-dev", "terra-verily-autopush" ]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +55,7 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit ${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
           cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
@@ -64,7 +64,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration ${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
@@ -73,7 +73,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub ${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
@@ -82,7 +82,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-and-context-[${{ matrix.testServer }}]
+          name: logs-and-context-${{ matrix.testServer }}
           path: |
             ~/logs-unit
             ~/logs-integration-source
@@ -94,9 +94,9 @@ jobs:
           L2="Unit: ${{ steps.run_unit_tests.outcome }} "
           L3="Integ (Source): ${{ steps.run_integration_tests_against_source_code.outcome }} "
           L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
-          text="Link to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
+          text="Server: ${{ matrix.testServer }}\nLink to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
           bold="$L2 | $L3 | $L4"
-          titleText="CLI nightly test run: ${{ matrix.testServer }}"
+          titleText="CLI nightly test run"
           if [ "${{ job.status }}" == "success" ]; then
             title=":white_check_mark: $titleText"
           else

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -107,7 +107,7 @@ jobs:
           echo ::set-output name=status-text::$text
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name == 'workflow_dispatch'
+        if: always() && github.event_name != 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -98,9 +98,9 @@ jobs:
           bold="$L2 | $L3 | $L4"
           titleText="CLI nightly test run: ${{ matrix.testServer }}"
           if [ "${{ job.status }}" == "success" ]; then
-            title=":white_check_mark:$titleText"
+            title=":white_check_mark: $titleText"
           else
-            title=":no_entry:$titleText"
+            title=":no_entry: $titleText"
           fi
           echo ::set-output name=status-title::$title
           echo ::set-output name=status-text::$text

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -91,17 +91,17 @@ jobs:
         id: compose_status_message
         if: always()
         run: |
+          title="CLI nightly test run: ${{ matrix.testServer }}"
           L2="Unit: ${{ steps.run_unit_tests.outcome }} "
           L3="Integ (Source): ${{ steps.run_integration_tests_against_source_code.outcome }} "
           L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
           text="Server: ${{ matrix.testServer }}\nLink to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
-          bold="$L2 | $L3 | $L4"
-          titleText="CLI nightly test run"
           if [ "${{ job.status }}" == "success" ]; then
-            title=":white_check_mark: $titleText"
+            text=":white_check_mark: $text"
           else
-            title=":no_entry: $titleText"
+            text=":no_entry: $text"
           fi
+          bold="$L2 | $L3 | $L4"
           echo ::set-output name=status-title::$title
           echo ::set-output name=status-text::$text
           echo ::set-output name=status-bold::$bold

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -55,7 +55,7 @@ jobs:
         if: always()
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} --tests "unit.Workspace.createFailsWithoutSpendAccess"
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-unit
           cp -R build/test-context/.terra/logs/ ~/logs-unit/logs/
           cp -R build/test-context/.terra/context.json ~/logs-unit/context.json
@@ -64,7 +64,7 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-source
           cp -R build/test-context/.terra/logs/ ~/logs-integration-source/logs/
           cp -R build/test-context/.terra/context.json ~/logs-integration-source/context.json
@@ -73,10 +73,10 @@ jobs:
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} --tests "integration.Nextflow.helloWorld"
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }}
           mkdir -p ~/logs-integration-release
           cp -R build/test-context/.terra/logs/ ~/logs-integration-release/logs/
-          cp -R build/test-context/.terra/context-bad.json ~/logs-integration-release/context.json
+          cp -R build/test-context/.terra/context.json ~/logs-integration-release/context.json
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()
@@ -95,19 +95,19 @@ jobs:
           L2="Unit: ${{ steps.run_unit_tests.outcome }} "
           L3="Integ (Source): ${{ steps.run_integration_tests_against_source_code.outcome }} "
           L4="Integ (Release): ${{ steps.run_integration_tests_against_release.outcome }}"
+          bold="$L2 | $L3 | $L4"
           text="Link to <https://github.com/DataBiosphere/terra-cli/actions/runs/$GITHUB_RUN_ID|test run>"
           if [ "${{ job.status }}" == "success" ]; then
             text=":white_check_mark: $text"
           else
             text=":no_entry: $text"
           fi
-          bold="$L2 | $L3 | $L4"
           echo ::set-output name=status-title::$title
-          echo ::set-output name=status-text::$text
           echo ::set-output name=status-bold::$bold
+          echo ::set-output name=status-text::$text
       - name: Notify PF alerts slack channel
         # don't notify manually triggered runs
-        if: always() && github.event_name == 'workflow_dispatch'
+        if: always() && github.event_name != 'workflow_dispatch'
         uses: broadinstitute/action-slack@v3.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}
         with:
           status: ${{ job.status }}
-          channel: "@mmedlock" #"#platform-foundation-alerts"
+          channel: "#platform-foundation-alerts"
           username: ${{ steps.compose_status_message.outputs.status-title }}
           author_name: ${{ steps.compose_status_message.outputs.status-bold }}
           icon_emoji: ':cli:'

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -56,21 +56,32 @@ jobs:
         run: |
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
-          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-unit
+          ./gradlew runTestsWithTag -PtestTag=unit -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-unit --tests "unit.Workspace.createFailsWithoutSpendAccess"
       - name: Run integration tests against source code
         id: run_integration_tests_against_source_code
         if: always()
         run: |
           echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-source
-          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-source
+          ./gradlew runTestsWithTag -PtestTag=integration -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-source --tests "integration.Nextflow.helloWorld"
       - name: Run integration tests against release
         id: run_integration_tests_against_release
         if: always()
         run: |
           echo "Running integration tests against release for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-integration-release
-          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-release
+          ./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=~/logs-integration-release --tests "integration.Nextflow.helloWorld"
+      - name: Compile all logs
+        id: compile_all_logs
+        if: always()
+        run: |
+          echo "Compiling all logs"
+          echo "HOME"
+          ls -la $HOME
+          echo "~/logs-unit"
+          ls -la ~/logs-unit
+          echo "HOME/logs-unit"
+          ls -la $HOME/logs-unit
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context
         if: always()
@@ -78,9 +89,12 @@ jobs:
         with:
           name: logs-and-context-${{ matrix.testServer }}
           path: |
-            ~/logs-unit
-            ~/logs-integration-source
-            ~/logs-integration-release
+            ~/logs-unit/logs/
+            ~/logs-unit/context.json
+            ~/logs-integration-source/logs/
+            ~/logs-integration-source/context.json
+            ~/logs-integration-release/logs/
+            ~/logs-integration-release/context.json
       - name: Compose status message
         id: compose_status_message
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,20 +173,24 @@ The on-PR-push GitHub action uses this flag to run against a locally built image
 
 #### Override context directory
 The `.terra` context directory is stored in the user's home directory (`$HOME`) by default.
-You can override this default by setting the `TERRA_CONTEXT_PARENT_DIR` environment variable to a valid directory.
-```
-export TERRA_CONTEXT_PARENT_DIR="/Desktop/cli-testing"
-terra config list
-```
-If the environment variable override does not point to a valid directory, then the CLI will throw a `SystemException`.
+You can override this default by setting the Gradle `contextDir` property to a valid directory. e.g.:
+`./gradlew runTestsWithTag -PtestTag=unit -PcontextDir=$HOME/context/for/tests`
+If the property does not point to a valid directory, then the CLI will throw a `SystemException`.
 
 This option is intended for tests, so that they don't overwrite the context for an installation on the same machine.
 
 Note that this override does not apply to installed JAR dependencies. So if you run integration tests against a CLI
 installation built from the latest GitHub release, the dependent libraries will overwrite an existing `$HOME/.terra/lib`
-directory, though logs, credentials, and context files will be preserved. (This doesn't apply to unit tests or
-integration tests run against a CLI installation built directly from source code, because their dependent libraries are
-all in the Gradle build directory.)
+directory, though logs, credentials, and context files will be written to the specified directory. (This doesn't apply 
+to unit tests or integration tests run against a CLI installation built directly from source code, because their 
+dependent libraries are all in the Gradle build directory.)
+
+You can also override the context directory in normal operation by specifying the `TERRA_CONTEXT_PARENT_DIR`
+environment variable. This can be helpful for debugging without clobbering an existing installation. e.g.:
+```
+export TERRA_CONTEXT_PARENT_DIR="/Desktop/cli-testing"
+terra config list
+```
 
 #### Setup test users
 Tests use domain-wide delegation (i.e. Harry Potter users). This avoids the Google OAuth flow, which requires

--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,7 @@ task runTestsWithTag(type: Test) {
         // gradle project properties define which tests to run and how to do the install before running them
         String testTag = project.findProperty("testTag");
         boolean testInstallFromGitHub = project.hasProperty("testInstallFromGitHub");
-        boolean writeContextToHomeDir = project.hasProperty("writeContextToHomeDir")
+        boolean contextDir = project.hasProperty("contextDir")
 
         // if the test tag is not defined, then throw an error. we don't know what tests to run
         if (testTag == null) {
@@ -159,9 +159,9 @@ task runTestsWithTag(type: Test) {
 
         // by default, tests override the global context directory with a sub-directory of the gradle build directory
         // this makes it easier to clean up after tests and makes sure the tests don't overwrite any context that
-        // exists on this same machine. you can override this default behavior by specifying -PwriteContextToHomeDir.
-        // this will cause context to be written to the user's $HOME directory, as it would during normal operation.
-        if (!writeContextToHomeDir) {
+        // exists on this same machine. you can override this default behavior by specifying -PcontextDir=/path/to/dir.
+        // this will cause context to be written to the specified directory.
+        if (!contextDir) {
             environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
             mkdir "${project.buildDir}/test-context/"
         }

--- a/build.gradle
+++ b/build.gradle
@@ -164,6 +164,8 @@ task runTestsWithTag(type: Test) {
         if (!contextDir) {
             environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
             mkdir "${project.buildDir}/test-context/"
+        } else {
+            environment "TERRA_CONTEXT_PARENT_DIR", project.findProperty("contextDir")
         }
 
         // specify the server to run tests against (e.g. -Pserver=verily-cli). defaults to "terra-dev"


### PR DESCRIPTION
Changed the nightly test GH action to run the three types of tests (unit, integration against source code, integration against GH release) serially instead of in parallel. This means the tests take longer to run (~1hr instead of ~35 min), but this is only for the nightly run, so it shouldn't matter. Tests run for PRs still run in parallel. Also compiled the result summary into a single Slack message per server.

- Fixed test run logs/context file getting overwritten by runs on a second server.
- Fixed link to test run not showing up in the Slack message.

Example Slack notification:
<img width="498" alt="Screen Shot 2021-07-27 at 1 51 25 PM" src="https://user-images.githubusercontent.com/12446128/127203775-6c09e983-79c7-4027-921e-6abc04f2d3a8.png">
The failure is artificial just to show what the message looks like. I expect all tests to pass against both environments.