### PR TITLE
PF-927: Allow deleting a workspace with no cloud context.

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -70,7 +70,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          name: logs-and-context-[${{ matrix.testOptions }}]
+          name: logs-and-context
           path: |
             build/test-context/.terra/logs/
             build/test-context/.terra/global-context.json

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -163,10 +163,19 @@ public class User {
    * global context directory.
    */
   public void fetchPetSaCredentials() {
+    // if the cloud context is undefined, then something went wrong during workspace creation
+    // just log an error here so that login will succeed, and the user can go back and delete the
+    // corrupted workspace
+    String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
+    if (googleProjectId == null) {
+      logger.error(
+          "No Google context for the current workspace. Skip fetching pet SA from SAM. MARIKO");
+      return;
+    }
+
     // ask SAM for the project-specific pet SA key
     HttpUtils.HttpResponse petSaKeySamResponse =
-        new SamService(this, Context.getServer())
-            .getPetSaKeyForProject(Context.requireWorkspace().getGoogleProjectId());
+        new SamService(this, Context.getServer()).getPetSaKeyForProject(googleProjectId);
     logger.debug("SAM response to pet SA key request: {})", petSaKeySamResponse);
     if (!HttpStatusCodes.isSuccess(petSaKeySamResponse.statusCode)) {
       throw new SystemException(

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -164,12 +164,11 @@ public class User {
    */
   public void fetchPetSaCredentials() {
     // if the cloud context is undefined, then something went wrong during workspace creation
-    // just log an error here so that login will succeed, and the user can go back and delete the
-    // corrupted workspace
+    // just log an error here instead of throwing an exception, so that the workspace load will
+    // will succeed and the user can delete the corrupted workspace
     String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
     if (googleProjectId == null) {
-      logger.error(
-          "No Google context for the current workspace. Skip fetching pet SA from SAM. MARIKO");
+      logger.error("No Google context for the current workspace. Skip fetching pet SA from SAM.");
       return;
     }
 

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -167,7 +167,7 @@ public class User {
     // just log an error here instead of throwing an exception, so that the workspace load will
     // will succeed and the user can delete the corrupted workspace
     String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
-    if (googleProjectId == null) {
+    if (googleProjectId == null || googleProjectId.isEmpty()) {
       logger.error("No Google context for the current workspace. Skip fetching pet SA from SAM.");
       return;
     }

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -35,7 +35,7 @@ public class CleanupTestUserWorkspaces {
 
   /**
    * List all workspaces the test user has access to and try to delete each one that the test user
-   * owns.
+   * owns. Deletes up to 100 workspaces at a time.
    */
   private static void deleteWorkspaces(TestUsers testUser, boolean isDryRun) throws IOException {
     System.out.println("Deleting workspaces for testuser " + testUser.email);
@@ -44,7 +44,8 @@ public class CleanupTestUserWorkspaces {
 
     // `terra workspace list`
     List<UFWorkspace> listWorkspaces =
-        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "workspace", "list");
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "workspace", "list", "--limit=100");
 
     List<UFWorkspaceUser> listWorkspaceUsers;
     for (UFWorkspace workspace : listWorkspaces) {

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -77,8 +77,8 @@ public class CleanupTestUserWorkspaces {
               "workspace", "delete", "--workspace=" + workspace.id, "--quiet");
           System.out.println(
               "Cleaned up workspace: id=" + workspace.id + ", testuser=" + testUser.email);
-          deletedWorkspaces.add(workspace.id);
         }
+        deletedWorkspaces.add(workspace.id);
       } catch (Throwable ex) {
         System.out.println(
             "Error deleting workspace: id=" + workspace.id + ", testuser=" + testUser.email);


### PR DESCRIPTION
If a workspace has no cloud context, then it means something went wrong during `workspace create`. In that case, the user should just delete the workspace and create a new one. Previously, this could be difficult to do because loading the workspace would fail when the pet SA fetch from SAM tried to use a null project id. This change is to skip the pet SA fetch if the workspace project id is undefined. This way, the workspace load will succeed and the user can successfully delete it, without errors.

This bug was causing leaked workspaces in tests. When a cloud context failed to be created, the test cleanup failed to delete the corrupted workspace.