### PR TITLE
PF-926: Install Nextflow in the notebook startup script.

### DIFF
--- a/notebooks/post-startup.sh
+++ b/notebooks/post-startup.sh
@@ -41,6 +41,12 @@ function get_metadata_value() {
 # Install nbstripout for the jupyter user in all git repositories.
 sudo -u "${JUPYTER_USER}" sh -c "/opt/conda/bin/nbstripout --install --global"
 
+# Install Nextflow. Use an edge release that allows overriding the default compute engine SA and VPC network
+export NXF_VER=21.05.0-edge
+export NXF_MODE=google
+curl -s https://get.nextflow.io | bash
+sudo mv nextflow /usr/bin/nextflow
+
 # Install & configure the Terra CLI
 sudo -u "${JUPYTER_USER}" sh -c "curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash"
 sudo cp terra /usr/bin/terra

--- a/notebooks/post-startup.sh
+++ b/notebooks/post-startup.sh
@@ -46,7 +46,6 @@ export NXF_VER=21.05.0-edge
 export NXF_MODE=google
 sudo -u "${JUPYTER_USER}" sh -c "curl -s https://get.nextflow.io | bash"
 sudo mv nextflow /usr/bin/nextflow
-sudo chmod a+x /usr/bin/nextflow
 
 # Install & configure the Terra CLI
 sudo -u "${JUPYTER_USER}" sh -c "curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash"

--- a/notebooks/post-startup.sh
+++ b/notebooks/post-startup.sh
@@ -45,6 +45,7 @@ sudo -u "${JUPYTER_USER}" sh -c "/opt/conda/bin/nbstripout --install --global"
 export NXF_VER=21.05.0-edge
 export NXF_MODE=google
 curl -s https://get.nextflow.io | bash
+sudo chmod a+x nextflow
 sudo mv nextflow /usr/bin/nextflow
 
 # Install & configure the Terra CLI

--- a/notebooks/post-startup.sh
+++ b/notebooks/post-startup.sh
@@ -44,9 +44,9 @@ sudo -u "${JUPYTER_USER}" sh -c "/opt/conda/bin/nbstripout --install --global"
 # Install Nextflow. Use an edge release that allows overriding the default compute engine SA and VPC network
 export NXF_VER=21.05.0-edge
 export NXF_MODE=google
-curl -s https://get.nextflow.io | bash
-sudo chmod a+x nextflow
+sudo -u "${JUPYTER_USER}" sh -c "curl -s https://get.nextflow.io | bash"
 sudo mv nextflow /usr/bin/nextflow
+sudo chmod a+x /usr/bin/nextflow
 
 # Install & configure the Terra CLI
 sudo -u "${JUPYTER_USER}" sh -c "curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash"


### PR DESCRIPTION
This is a request from the solutions team, so that they can run Nextflow locally on the notebook VM instead of being forced to use the CLI's Docker container via `terra nextflow ...`. When using the CLI's Docker container, you can't use Nextflow's container mode, because that would mean running Docker in Docker, which doesn't work.

The CLI has a config property `app-launch` that controls whether apps, such as Nextflow, are launched in the Docker container or in a local process. One reason this config property was added was to workaround this Docker in Docker problem with Nextflow. The solutions team is going to experiment with using this config property to call the local installation of Nextflow via `terra nextflow ...`, but have asked me to not set it in the startup script just yet.

I've installed the same edge version of Nextflow on the notebook VM that is installed in the CLI's Docker image.

<img width="539" alt="Screen Shot 2021-08-06 at 5 55 59 PM" src="https://user-images.githubusercontent.com/12446128/128574827-20cdb3c2-b2ff-45ff-a957-1c53545bebbd.png">

