### PR TITLE
PF-915: Include private user in resource list.

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/List.java
+++ b/src/main/java/bio/terra/cli/command/resource/List.java
@@ -6,6 +6,7 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
+import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.StewardshipType;
 import java.util.Comparator;
 import java.util.stream.Collectors;
@@ -55,8 +56,11 @@ public class List extends BaseCommand {
               + resource.resourceType
               + ", "
               + resource.stewardshipType
-              + "): "
-              + resource.description);
+              + (resource.accessScope.equals(AccessScope.PRIVATE_ACCESS)
+                  ? ", " + resource.accessScope + " " + resource.privateUserName
+                  : "")
+              + ")"
+              + (resource.description == null ? "" : ": " + resource.description));
     }
   }
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
@@ -64,8 +64,8 @@ public abstract class UFResource {
   /** Print out this object in text format. */
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    OUT.println("Name:         " + name);
-    OUT.println("Description:  " + description);
+    OUT.println("Name:         " + (name == null ? "" : name));
+    OUT.println("Description:  " + (description == null ? "" : description));
     OUT.println("Stewardship:  " + stewardshipType);
     OUT.println("Cloning:      " + cloningInstructions);
 

--- a/src/test/java/unit/AiNotebookControlled.java
+++ b/src/test/java/unit/AiNotebookControlled.java
@@ -52,7 +52,6 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         createdNotebook.privateUserName.toLowerCase(),
         "create output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     // check that the notebook is in the list
     UFAiNotebook matchedResource = listOneNotebookResourceWithName(name);
@@ -74,7 +73,6 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         describeResource.privateUserName.toLowerCase(),
         "describe output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra notebook delete --name=$name`
     TestCommand.Result cmd =
@@ -165,7 +163,6 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         createdNotebook.privateUserName.toLowerCase(),
         "create output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra resource describe --name=$name --format=json`
     UFAiNotebook describeResource =
@@ -187,7 +184,6 @@ public class AiNotebookControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         describeResource.privateUserName.toLowerCase(),
         "describe output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
   }
 
   @Test // NOTE: This test takes ~10 minutes to run.

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -232,7 +232,6 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         createdDataset.privateUserName.toLowerCase(),
         "create output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     Dataset createdDatasetOnCloud =
         ExternalBQDatasets.getBQClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
@@ -257,7 +256,6 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         describeResource.privateUserName.toLowerCase(),
         "describe output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -203,7 +203,6 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         createdBucket.privateUserName.toLowerCase(),
         "create output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     Bucket createdBucketOnCloud =
         ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
@@ -232,7 +231,6 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         workspaceCreator.email.toLowerCase(),
         describeResource.privateUserName.toLowerCase(),
         "describe output matches private user name");
-    // TODO (PF-616): check the private user roles once WSM returns them
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");


### PR DESCRIPTION
- Included the assigned user for private resources in the text output of `terra resource list`. It was already included in the JSON output.
- Added some null checks around the resource name and description, so we print out empty string instead of "null".
- Removed the TODOs for PF-616 to check the IAM roles for private resources. The team's decision was not to expose these in WSM's API, so there's nothing for the CLI tests to check.