### PR TITLE
PF-928: Make notebook tests more tolerant of timeouts and 409s.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ owner access to that spend profile.
 - [Preferred] Add a user to a Terra group that is a user of the spend profile. To also grant permission
 to add new members to the group, use `policy=admin` instead.
 
-`terra group add-user --group=enterprise-pilot-testers --policy=member testuser@gmail.com`
+`terra group add-user --name=enterprise-pilot-testers --policy=MEMBER --email=testuser@gmail.com`
 
 - Add a user directly to the spend profile. To also grant permission to add new users to the spend profile,
 user `policy=owner` instead.
-`terra spend enable --policy=user testuser@gmail.com`
+`terra spend enable --policy=USER --email=testuser@gmail.com`
 
 #### External data 
 To allow supported applications (i.e. the ones shown by `terra app list`) to read or write data

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
         googleOauth2 = '0.22.0'
         googleClient = '1.31.1'
         bigQuery = '1.116.6'
-        cloudStorage = '1.113.2'
+        cloudStorage = '1.117.0'
 
         // Docker
         docker = '3.2.7'

--- a/src/main/java/bio/terra/cli/service/GoogleAiNotebooks.java
+++ b/src/main/java/bio/terra/cli/service/GoogleAiNotebooks.java
@@ -1,11 +1,13 @@
 package bio.terra.cli.service;
 
 import bio.terra.cli.exception.SystemException;
+import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.cloudres.google.api.services.common.OperationCow;
 import bio.terra.cloudres.google.api.services.common.OperationUtils;
 import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
 import bio.terra.cloudres.google.notebooks.InstanceName;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.notebooks.v1.model.Instance;
 import com.google.api.services.notebooks.v1.model.Operation;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -32,6 +34,7 @@ public class GoogleAiNotebooks {
       Operation startOperation = notebooks.instances().start(instanceName).execute();
       pollForSuccess(startOperation, "Error starting notebook instance: ");
     } catch (InterruptedException | IOException e) {
+      checkFor409BadState(e);
       throw new SystemException("Error starting notebook instance", e);
     }
   }
@@ -41,6 +44,7 @@ public class GoogleAiNotebooks {
       Operation stopOperation = notebooks.instances().stop(instanceName).execute();
       pollForSuccess(stopOperation, "Error stopping notebook instance: ");
     } catch (InterruptedException | IOException e) {
+      checkFor409BadState(e);
       throw new SystemException("Error stopping notebook instance", e);
     }
   }
@@ -53,6 +57,25 @@ public class GoogleAiNotebooks {
             operationCow, Duration.ofSeconds(5), Duration.ofMinutes(3));
     if (operationCow.getOperation().getError() != null) {
       throw new SystemException(errorMessage + operationCow.getOperation().getError().getMessage());
+    }
+  }
+
+  /**
+   * If the exception is a 409 from GCP with "unable to queue the operation" message, then wrap in a
+   * UserActionableException and tell the user to try waiting a few minutes before trying again.
+   * There is an open issue against the java-notebooks library on GitHub for this:
+   * https://github.com/googleapis/java-notebooks/issues/201.
+   */
+  private void checkFor409BadState(Exception ex) {
+    if (ex instanceof GoogleJsonResponseException) {
+      GoogleJsonResponseException googleJsonEx = (GoogleJsonResponseException) ex;
+      int httpCode = googleJsonEx.getStatusCode();
+      String message = googleJsonEx.getDetails().getMessage();
+      if (httpCode == 409 && message.contains("unable to queue the operation")) {
+        throw new UserActionableException(
+            "Error starting notebook instance: The notebook is not in the right state to start/stop. Wait a few minutes and try again. (409: unable to queue the operation)",
+            googleJsonEx);
+      }
     }
   }
 }

--- a/src/main/java/bio/terra/cli/service/GoogleAiNotebooks.java
+++ b/src/main/java/bio/terra/cli/service/GoogleAiNotebooks.java
@@ -73,7 +73,7 @@ public class GoogleAiNotebooks {
       String message = googleJsonEx.getDetails().getMessage();
       if (httpCode == 409 && message.contains("unable to queue the operation")) {
         throw new UserActionableException(
-            "Error starting notebook instance: The notebook is not in the right state to start/stop. Wait a few minutes and try again. (409: unable to queue the operation)",
+            "Error changing notebook state: The notebook is not in the right state to start/stop. Wait a few minutes and try again. (409: unable to queue the operation)",
             googleJsonEx);
       }
     }

--- a/src/test/java/unit/GcsBucketLifecycle.java
+++ b/src/test/java/unit/GcsBucketLifecycle.java
@@ -238,7 +238,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
         lifecycleRuleFromGCS.getCondition().getMatchesStorageClass();
     assertEquals(1, matchesStorageClass.size(), "condition matches storage class has correct size");
     assertTrue(
-        matchesStorageClass.containsAll(Arrays.asList(StorageClass.NEARLINE)),
+        matchesStorageClass.contains(StorageClass.NEARLINE),
         "condition matches storage class has correct elements");
     assertEquals(
         70,
@@ -297,17 +297,13 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
         "gcs-bucket",
         "--name=" + resourceName,
         "--bucket-name=" + bucketName,
-        "--lifecycle=" + lifecycle1.toString());
+        "--lifecycle=" + lifecycle1);
 
     // `terra resource update gcs-bucket --name=$resourceName --lifecycle=$lifecycle2"
     String lifecycleFilename2 = "setStorageClass_age.json";
     Path lifecycle2 = TestCommand.getPathForTestInput("gcslifecycle/" + lifecycleFilename2);
     TestCommand.runCommandExpectSuccess(
-        "resource",
-        "update",
-        "gcs-bucket",
-        "--name=" + resourceName,
-        "--lifecycle=" + lifecycle2.toString());
+        "resource", "update", "gcs-bucket", "--name=" + resourceName, "--lifecycle=" + lifecycle2);
 
     List<? extends BucketInfo.LifecycleRule> lifecycleRulesFromGCS =
         getLifecycleRulesFromCloud(bucketName);
@@ -332,17 +328,13 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
         "gcs-bucket",
         "--name=" + resourceName,
         "--bucket-name=" + bucketName,
-        "--lifecycle=" + lifecycle1.toString());
+        "--lifecycle=" + lifecycle1);
 
     // `terra resource update gcs-bucket --name=$resourceName --lifecycle=$lifecycle2"
     String lifecycleFilename2 = "empty.json";
     Path lifecycle2 = TestCommand.getPathForTestInput("gcslifecycle/" + lifecycleFilename2);
     TestCommand.runCommandExpectSuccess(
-        "resource",
-        "update",
-        "gcs-bucket",
-        "--name=" + resourceName,
-        "--lifecycle=" + lifecycle2.toString());
+        "resource", "update", "gcs-bucket", "--name=" + resourceName, "--lifecycle=" + lifecycle2);
 
     List<? extends BucketInfo.LifecycleRule> lifecycleRulesFromGCS =
         getLifecycleRulesFromCloud(bucketName);
@@ -437,7 +429,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
         "gcs-bucket",
         "--name=" + resourceName,
         "--bucket-name=" + bucketName,
-        "--lifecycle=" + lifecycle.toString());
+        "--lifecycle=" + lifecycle);
 
     return getLifecycleRulesFromCloud(bucketName);
   }
@@ -453,7 +445,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
     List<? extends BucketInfo.LifecycleRule> lifecycleRules =
         createdBucketOnCloud.getLifecycleRules();
     assertNotNull(lifecycleRules, "looking up lifecycle rules via GCS API succeeded");
-    lifecycleRules.stream().forEach(System.out::println); // log to console
+    lifecycleRules.forEach(System.out::println); // log to console
 
     return lifecycleRules;
   }


### PR DESCRIPTION
- Notebook start/stop sometimes fails with a 409: unable to queue operation error. Polling the notebook state to make sure that it is ACTIVE/STOPPED before calling stop/start does not prevent this. There is an [open bug](https://github.com/googleapis/java-notebooks/issues/201) against the GCP notebooks Java client for this. In the meantime, I've added a "wait a few minutes and try again" note to the exception message when this error occurs.
- Updated the README with correct commands for giving a user spend profile access.

Test fixes:
- Changed the delete test for a notebook resource to tolerate timeouts in the CLI waiting for the delete job in WSM to complete. In the future this should use long-running job commands, once they are implemented. Reenabled this test.
- Changed the start/stop test for a notebook to tolerate 409s from GCP if the notebook is not in the right state to issue a change of state command.
- Bumped the GCS library version to get a fix for some GCS lifecycle rule properties that were causing tests to fail.

With the above changes, I have gotten many clean runs locally and one clean nightly test run against the `terra-dev` server. The notebook failures are flakey, so further changes may be needed if they recur. The lifecycle tests were failing reliably, so those should be completely fixed.