### PR TITLE
PF-994: Define CLI enum for workspace user roles.

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/List.java
+++ b/src/main/java/bio/terra/cli/command/resource/List.java
@@ -56,7 +56,8 @@ public class List extends BaseCommand {
               + resource.resourceType
               + ", "
               + resource.stewardshipType
-              + (resource.accessScope.equals(AccessScope.PRIVATE_ACCESS)
+              + (resource.stewardshipType.equals(StewardshipType.CONTROLLED)
+                      && resource.accessScope.equals(AccessScope.PRIVATE_ACCESS)
                   ? ", " + resource.accessScope + " " + resource.privateUserName
                   : "")
               + ")"

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -5,7 +5,6 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
-import bio.terra.workspace.model.IamRole;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -20,7 +19,7 @@ public class AddUser extends BaseCommand {
       names = "--role",
       required = true,
       description = "Role to grant: ${COMPLETION-CANDIDATES}.")
-  private IamRole role;
+  private WorkspaceUser.Role role;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -3,7 +3,6 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
-import bio.terra.workspace.model.IamRole;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -18,7 +17,7 @@ public class RemoveUser extends BaseCommand {
       names = "--role",
       required = true,
       description = "Role to grant: ${COMPLETION-CANDIDATES}.")
-  private IamRole role;
+  private WorkspaceUser.Role role;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
@@ -1,8 +1,8 @@
 package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.WorkspaceUser;
+import bio.terra.cli.businessobject.WorkspaceUser.Role;
 import bio.terra.cli.utils.UserIO;
-import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 @JsonDeserialize(builder = UFWorkspaceUser.Builder.class)
 public class UFWorkspaceUser {
   public final String email;
-  public final List<IamRole> roles;
+  public final List<Role> roles;
 
   public UFWorkspaceUser(WorkspaceUser internalObj) {
     this.email = internalObj.getEmail();
@@ -36,21 +36,21 @@ public class UFWorkspaceUser {
   /** Print out this object in text format. */
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    List<String> rolesStr = roles.stream().map(IamRole::toString).collect(Collectors.toList());
+    List<String> rolesStr = roles.stream().map(Role::toString).collect(Collectors.toList());
     OUT.println(email + ": " + String.join(",", rolesStr));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
     private String email;
-    private List<IamRole> roles;
+    private List<Role> roles;
 
     public Builder email(String email) {
       this.email = email;
       return this;
     }
 
-    public Builder roles(List<IamRole> roles) {
+    public Builder roles(List<Role> roles) {
       this.roles = roles;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceUser.java
@@ -36,8 +36,8 @@ public class UFWorkspaceUser {
   /** Print out this object in text format. */
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    List<String> rolesStr = roles.stream().map(Role::toString).collect(Collectors.toList());
-    OUT.println(email + ": " + String.join(",", rolesStr));
+    String rolesStr = roles.stream().map(Role::toString).collect(Collectors.joining(","));
+    OUT.println(email + ": " + rolesStr);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -1,9 +1,9 @@
 package harness.utils;
 
+import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
-import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.type.TypeReference;
 import harness.TestCommand;
 import harness.TestContext;
@@ -61,7 +61,8 @@ public class CleanupTestUserWorkspaces {
                 .filter(user -> user.email.equalsIgnoreCase(testUser.email))
                 .findAny();
         // skip deleting if the test user is not an owner
-        if (workspaceUser.isEmpty() || !workspaceUser.get().roles.contains(IamRole.OWNER)) {
+        if (workspaceUser.isEmpty()
+            || !workspaceUser.get().roles.contains(WorkspaceUser.Role.OWNER)) {
           System.out.println(
               "Skip deleting workspace because test user is not an owner: id="
                   + workspace.id

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -5,11 +5,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.bigquery.Dataset;
@@ -203,7 +203,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     AccessScope access = AccessScope.PRIVATE_ACCESS;
     CloningInstructionsEnum cloning = CloningInstructionsEnum.DEFINITION;
     String description = "\"create with all options\"";
-    IamRole iamRole = IamRole.READER;
+    WorkspaceUser.Role role = WorkspaceUser.Role.READER;
     String location = "us-east1";
     UFBqDataset createdDataset =
         TestCommand.runAndParseCommandExpectSuccess(
@@ -217,7 +217,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
             "--cloning=" + cloning,
             "--description=" + description,
             "--email=" + workspaceCreator.email,
-            "--iam-roles=" + iamRole,
+            "--iam-roles=" + role,
             "--location=" + location);
 
     // check that the properties match

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -4,11 +4,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.serialization.userfacing.input.GcsStorageClass;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.cloud.storage.Bucket;
@@ -174,7 +174,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     AccessScope access = AccessScope.PRIVATE_ACCESS;
     CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
     String description = "\"create with all options except lifecycle\"";
-    IamRole iamRole = IamRole.WRITER;
+    WorkspaceUser.Role role = WorkspaceUser.Role.WRITER;
     String location = "US";
     GcsStorageClass storage = GcsStorageClass.NEARLINE;
     UFGcsBucket createdBucket =
@@ -189,7 +189,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
             "--cloning=" + cloning,
             "--description=" + description,
             "--email=" + workspaceCreator.email,
-            "--iam-roles=" + iamRole,
+            "--iam-roles=" + role,
             "--location=" + location,
             "--storage=" + storage);
 

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -16,12 +16,12 @@ import static unit.Workspace.listWorkspacesWithId;
 import static unit.WorkspaceUser.expectListedUserWithRoles;
 import static unit.WorkspaceUser.workspaceListUsersWithEmail;
 
+import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
 import bio.terra.cli.serialization.userfacing.resource.UFAiNotebook;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
-import bio.terra.workspace.model.IamRole;
 import com.google.api.services.bigquery.model.DatasetReference;
 import com.google.cloud.Identity;
 import com.google.cloud.storage.BucketInfo;
@@ -347,7 +347,7 @@ public class WorkspaceOverride extends ClearContextUnit {
     // check that the user exists in the list output for workspace 2, but not workspace 1
 
     // `terra workspace list-users --email=$email --role=READER --workspace=$id2`
-    expectListedUserWithRoles(testUser.email, workspace2.id, IamRole.READER);
+    expectListedUserWithRoles(testUser.email, workspace2.id, WorkspaceUser.Role.READER);
 
     // `terra workspace list-users --email=$email --role=READER`
     Optional<UFWorkspaceUser> workspaceUser = workspaceListUsersWithEmail(testUser.email);

--- a/src/test/java/unit/WorkspaceUser.java
+++ b/src/test/java/unit/WorkspaceUser.java
@@ -1,10 +1,12 @@
 package unit;
 
+import static bio.terra.cli.businessobject.WorkspaceUser.Role.OWNER;
+import static bio.terra.cli.businessobject.WorkspaceUser.Role.READER;
+import static bio.terra.cli.businessobject.WorkspaceUser.Role.WRITER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
-import bio.terra.workspace.model.IamRole;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import harness.TestCommand;
@@ -40,7 +42,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
       if (user.email.equalsIgnoreCase(workspaceCreator.email)) {
         continue;
       }
-      for (IamRole role : user.roles) {
+      for (bio.terra.cli.businessobject.WorkspaceUser.Role role : user.roles) {
         // `terra workspace remove-user --email=$email --role=$role
         TestCommand.runCommandExpectSuccess(
             "workspace", "remove-user", "--email=" + user.email, "--role=" + role);
@@ -59,7 +61,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
     // check that the workspace creator is in the list as an owner
-    expectListedUserWithRoles(workspaceCreator.email, IamRole.OWNER);
+    expectListedUserWithRoles(workspaceCreator.email, OWNER);
   }
 
   @Test
@@ -82,10 +84,10 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
             "--role=READER");
 
     // check that the user has the READER role
-    assertTrue(addUserReader.roles.contains(IamRole.READER), "reader role returned by add-user");
+    assertTrue(addUserReader.roles.contains(READER), "reader role returned by add-user");
 
     // check that the user is in the list as a reader
-    expectListedUserWithRoles(testUser.email, IamRole.READER);
+    expectListedUserWithRoles(testUser.email, READER);
 
     // `terra workspace add-user --email=$email --role=WRITER --format=json
     UFWorkspaceUser addUserWriter =
@@ -98,11 +100,11 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
 
     // check that the user has both the READER and WRITER roles
     assertTrue(
-        addUserWriter.roles.containsAll(Arrays.asList(IamRole.READER, IamRole.WRITER)),
+        addUserWriter.roles.containsAll(Arrays.asList(READER, WRITER)),
         "reader and writer roles returned by add-user");
 
     // check that the user is in the list as a reader + writer
-    expectListedUserWithRoles(testUser.email, IamRole.READER, IamRole.WRITER);
+    expectListedUserWithRoles(testUser.email, READER, WRITER);
   }
 
   @Test
@@ -128,7 +130,7 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
         "workspace", "remove-user", "--email=" + testUser.email, "--role=READER");
 
     // check that the user is in the list as an OWNER only
-    expectListedUserWithRoles(testUser.email, IamRole.OWNER);
+    expectListedUserWithRoles(testUser.email, OWNER);
 
     // `terra workspace remove-user --email=$email --role=READER`
     TestCommand.runCommandExpectSuccess(
@@ -143,7 +145,8 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
    * Helper method to check that a workspace user is included in the list with the specified roles.
    * Uses the current workspace.
    */
-  private static void expectListedUserWithRoles(String userEmail, IamRole... roles)
+  private static void expectListedUserWithRoles(
+      String userEmail, bio.terra.cli.businessobject.WorkspaceUser.Role... roles)
       throws JsonProcessingException {
     expectListedUserWithRoles(userEmail, null, roles);
   }
@@ -152,7 +155,8 @@ public class WorkspaceUser extends SingleWorkspaceUnit {
    * Helper method to check that a workspace user is included in the list with the specified roles.
    * Filters on the specified workspace id; Uses the current workspace if null.
    */
-  static void expectListedUserWithRoles(String userEmail, UUID workspaceId, IamRole... roles)
+  static void expectListedUserWithRoles(
+      String userEmail, UUID workspaceId, bio.terra.cli.businessobject.WorkspaceUser.Role... roles)
       throws JsonProcessingException {
     Optional<UFWorkspaceUser> workspaceUser = workspaceListUsersWithEmail(userEmail, workspaceId);
     assertTrue(workspaceUser.isPresent(), "test user is in users list");


### PR DESCRIPTION
Defined a CLI enum for workspace user roles: READER, WRITER, OWNER. It is different from the WSM enum for workspace user roles, which also includes the APPLICATION role.

We don't want to expose the APPLICATION role to CLI users at this time. There are no immediate use cases for it, and possible future use cases (e.g. Leo) may not use the CLI to setup the application user anyway. So for now, I've hidden this role from CLI users to avoid confusion. Previously trying to define an application user resulted in an error.

Also fixed an NPE when listing referenced resources in text format.