### PR TITLE
PF-1010: Get pet SA token directly from SAM.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -165,13 +165,15 @@ public class User {
 
   /**
    * Fetch the pet SA credentials and email for this user + current workspace from SAM and persist
-   * it in the global context directory.
+   * it in the global context directory. This method assumes that this user is the current user, and
+   * that there is a current workspace specified.
    */
   public void fetchPetSaCredentials() {
     // if the cloud context is undefined, then something went wrong during workspace creation
     // just log an error here instead of throwing an exception, so that the workspace load will
     // will succeed and the user can delete the corrupted workspace
-    String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
+    Workspace currentWorkspace = Context.requireWorkspace();
+    String googleProjectId = currentWorkspace.getGoogleProjectId();
     if (googleProjectId == null || googleProjectId.isEmpty()) {
       logger.error("No Google context for the current workspace. Skip fetching pet SA from SAM.");
       return;
@@ -206,7 +208,7 @@ public class User {
     // other app calls can run.
     // TODO(PF-991): This behavior will change in the future when WSM disallows SA
     //  self-impersonation
-    Workspace.enablePet();
+    currentWorkspace.enablePet();
     logger.debug("Enabled pet SA impersonation");
 
     petSACredentials = createSaCredentials(jsonKeyPath);

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -9,6 +9,7 @@ import bio.terra.cli.utils.FileUtils;
 import bio.terra.cli.utils.UserIO;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
 import com.google.common.annotations.VisibleForTesting;
@@ -50,6 +51,9 @@ public class User {
   // this field.
   private String proxyGroupEmail;
 
+  // pet SA email that Terra associates with this user. the CLI queries SAM to populate this field.
+  private String petSAEmail;
+
   // Google credentials for the user and their pet SA
   private UserCredentials userCredentials;
   private ServiceAccountCredentials petSACredentials;
@@ -74,6 +78,7 @@ public class User {
     this.id = configFromDisk.id;
     this.email = configFromDisk.email;
     this.proxyGroupEmail = configFromDisk.proxyGroupEmail;
+    this.petSAEmail = configFromDisk.petSAEmail;
   }
 
   /** Build an empty instance of this class. */
@@ -159,8 +164,8 @@ public class User {
   }
 
   /**
-   * Fetch the pet SA credentials for this user + current workspace from SAM and persist it in the
-   * global context directory.
+   * Fetch the pet SA credentials and email for this user + current workspace from SAM and persist
+   * it in the global context directory.
    */
   public void fetchPetSaCredentials() {
     // if the cloud context is undefined, then something went wrong during workspace creation
@@ -172,9 +177,13 @@ public class User {
       return;
     }
 
+    // ask SAM for the project-specific pet SA email and persist it on disk
+    SamService samService = new SamService(this, Context.getServer());
+    petSAEmail = samService.getPetSaEmailForProject(googleProjectId);
+    Context.setUser(this);
+
     // ask SAM for the project-specific pet SA key
-    HttpUtils.HttpResponse petSaKeySamResponse =
-        new SamService(this, Context.getServer()).getPetSaKeyForProject(googleProjectId);
+    HttpUtils.HttpResponse petSaKeySamResponse = samService.getPetSaKeyForProject(googleProjectId);
     logger.debug("SAM response to pet SA key request: {})", petSaKeySamResponse);
     if (!HttpStatusCodes.isSuccess(petSaKeySamResponse.statusCode)) {
       throw new SystemException(
@@ -296,15 +305,15 @@ public class User {
   }
 
   public String getPetSaEmail() {
-    return petSACredentials == null ? null : petSACredentials.getClientEmail();
+    return petSAEmail;
   }
 
   public UserCredentials getUserCredentials() {
     return userCredentials;
   }
 
-  public ServiceAccountCredentials getPetSACredentials() {
-    return petSACredentials;
+  public GoogleCredentials getPetSACredentials() {
+    return GoogleCredentials.create(getPetSaAccessToken());
   }
 
   /** Return true if the user credentials are expired or do not exist on disk. */
@@ -328,6 +337,10 @@ public class User {
 
   /** Get the access token for the pet SA credentials. */
   public AccessToken getPetSaAccessToken() {
-    return GoogleOauth.getAccessToken(petSACredentials);
+    String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
+    String accessTokenStr =
+        new SamService(this, Context.getServer())
+            .getPetSaAccessTokenForProject(googleProjectId, PET_SA_SCOPES);
+    return new AccessToken(accessTokenStr, null);
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -178,12 +178,12 @@ public class Workspace {
   }
 
   /**
-   * Enable the current user and their pet to impersonate their pet SA in the current workspace.
+   * Enable the current user and their pet to impersonate their pet SA in this workspace.
    *
    * @return Email identifier of the pet SA the current user can now actAs.
    */
-  public static String enablePet() {
-    return WorkspaceManagerService.fromContext().enablePet(Context.requireWorkspace().getId());
+  public String enablePet() {
+    return WorkspaceManagerService.fromContext().enablePet(id);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
@@ -16,18 +16,21 @@ public class PDUser {
   public final String id;
   public final String email;
   public final String proxyGroupEmail;
+  public final String petSAEmail;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDUser(User internalObj) {
     this.id = internalObj.getId();
     this.email = internalObj.getEmail();
     this.proxyGroupEmail = internalObj.getProxyGroupEmail();
+    this.petSAEmail = internalObj.getPetSaEmail();
   }
 
   private PDUser(PDUser.Builder builder) {
     this.id = builder.id;
     this.email = builder.email;
     this.proxyGroupEmail = builder.proxyGroupEmail;
+    this.petSAEmail = builder.petSAEmail;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -35,6 +38,7 @@ public class PDUser {
     private String id;
     private String email;
     private String proxyGroupEmail;
+    private String petSAEmail;
 
     public Builder id(String id) {
       this.id = id;
@@ -48,6 +52,11 @@ public class PDUser {
 
     public Builder proxyGroupEmail(String proxyGroupEmail) {
       this.proxyGroupEmail = proxyGroupEmail;
+      return this;
+    }
+
+    public Builder petSAEmail(String petSAEmail) {
+      this.petSAEmail = petSAEmail;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -328,6 +328,35 @@ public class SamService {
   }
 
   /**
+   * Call the SAM "POST /api/google/v1/user/petServiceAccount/{project}" GET endpoint to get a
+   * project-specific pet SA email for the current user (i.e. the one whose credentials were
+   * supplied to the apiClient object).
+   *
+   * @param googleProjectId
+   * @return the pet SA email
+   */
+  public String getPetSaEmailForProject(String googleProjectId) {
+    return callWithRetries(
+        () -> new GoogleApi(apiClient).getPetServiceAccount(googleProjectId),
+        "Error getting pet SA email for project from SAM.");
+  }
+
+  /**
+   * Call the SAM "POST /api/google/v1/user/petServiceAccount/{project}/token" GET endpoint to get a
+   * project-specific pet SA access token for the current user (i.e. the one whose credentials were
+   * supplied to the apiClient object).
+   *
+   * @param googleProjectId
+   * @param scopes
+   * @return the access token string
+   */
+  public String getPetSaAccessTokenForProject(String googleProjectId, List<String> scopes) {
+    return callWithRetries(
+        () -> new GoogleApi(apiClient).getPetServiceAccountToken(googleProjectId, scopes),
+        "Error getting pet SA access token for project from SAM.");
+  }
+
+  /**
    * Call the SAM "/api/google/v1/user/petServiceAccount/{project}/key" endpoint to get a
    * project-specific pet SA key for the current user (i.e. the one whose credentials were supplied
    * to the apiClient object).

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -121,7 +121,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     assertThat(
         "gcloud account = pet SA email",
         cmd.stdOut,
-        CoreMatchers.containsString(Context.requireUser().getPetSACredentials().getClientEmail()));
+        CoreMatchers.containsString(Context.requireUser().getPetSaEmail()));
   }
 
   @Test


### PR DESCRIPTION
- Fetch a pet SA access token directly from SAM instead of creating one from the cached pet SA key file.
- Fetch the pet SA email directly from SAM instead of reading the client email from the pet SA key.
- With this change, the CLI still fetches the pet SA key file from SAM and caches it locally. Instead of using this key file every time pet SA credentials are needed, now the CLI only uses this file for setting application default credentials on the Docker container for running third-party tools.

This is a first step towards removing use of the pet SA key file from the CLI. Remaining work is to figure out how to not require this for running apps on the Docker container. Once we have a solution for that, then we can remove this pet SA key file fetch and caching from the CLI entirely.