### PR TITLE
PF-1006: Break-glass command.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@
     * [Alphabetize command lists](#alphabetize-command-lists)
     * [User readable exception messages](#user-readable-exception-messages)
     * [Singular command group names](#singular-command-group-names)
+7. [Break-glass access](#break-glass-access)
+    * [Grant break-glass](#grant-break-glass)
+    * [Requests catalog](#requests-catalog)
 
 -----
 
@@ -435,3 +438,53 @@ that should be reported, so there's no need to make these messages readable to t
 
 #### Singular command group names
 Use singular command group names instead of plural. e.g. `terra resource` instead of `terra resources`.
+
+
+### Break-glass access
+A break-glass implementation means that there is a way for users to request elevated permissions on a workspace.
+These elevated permissions invalidate the contract with WSM. Any guarantees about policy or access enforcement
+are off.
+
+The purpose of break-glass access is to grant select trusted users the ability to try out cloud features that
+are not yet available via WSM. The goal of this experimentation is to understand what use cases WSM could
+support in the future.
+
+Break-glass is intended for non-production environments only. This contributed to the decision to implement
+this on the client side, instead of e.g. as a new WSM endpoint.
+
+#### Grant break-glass
+To grant break-glass access to someone:
+1. Ask the requester to:
+    - Make your Terra user an owner of the workspace they want break-glass access to.
+      `terra workspace add-user --email=breakglassgranter@gmail.com --role=OWNER`
+    - Confirm that they are an owner of the workspace.
+      `terra workspace list-users`
+    - Relay any brief notes about the reason for the request.
+2. Download two SA key files:
+    - One that has permission to set IAM policy on all workspace projects. This will be specific 
+      to the server (i.e. WSM deployment) where the workspaces live.
+    - One that has permission to update a central BigQuery dataset that tracks break-glass requests.
+    - The `tools/render-config.sh` script downloads two SA key files that will work for workspaces 
+      on the `verily-cli` server and the central BigQuery dataset in the `terra-cli-dev` project.
+3. Run the `terra workspace break-glass` command.
+
+Example commands for granting break-glass access for a workspace in the `verily-cli` deployment:
+```
+./tools/render-config.sh
+terra auth login # login as yourself, the break-glass granter
+terra workspace break-glass --email=breakglassrequester@gmail.com --big-query-project=terra-cli-dev --big-query-sa=rendered/ci-account.json --user-project-admin-sa=rendered/verilycli-wsm-sa.json --notes="Testing break-glass command."
+```
+
+#### Requests catalog
+The `terra workspace break-glass` command updates a central BigQuery dataset to track break-glass requests.
+This dataset was setup by a script:
+```
+gcloud auth activate-service-account dev-ci-sa@broad-dsde-dev.iam.gserviceaccount.com --key-file=./rendered/ci-account.json
+./tools/create-break-glass-bq.sh terra-cli-dev
+```
+
+In the future, we can run the same script with different credentials and project id to setup another central
+BigQuery dataset somewhere else. (e.g. one for Verily deployments, one for Broad deployments). The SA activated
+in the first command needs to have BigQuery admin privileges in the target project.
+
+The current central BigQuery dataset exists in the `terra-cli-dev` project.

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -253,7 +253,7 @@ public class User {
     UserStatusInfo userInfo = samService.getUserInfoOrRegisterUser();
     id = userInfo.getUserSubjectId();
     email = userInfo.getUserEmail();
-    proxyGroupEmail = samService.getProxyGroupEmail();
+    proxyGroupEmail = samService.getProxyGroupEmail(email);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -289,8 +289,8 @@ public class Workspace {
    * Editor role is granted to the user's proxy group.
    *
    * @param granteeEmail email of the workspace user requesting break-glass access
-   * @param userProjectsAdminCredentials credentials for a SA that has admin access on user projects
-   *     in this WSM deployment (e.g. WSM application SA)
+   * @param userProjectsAdminCredentials credentials for a SA that has permission to set IAM policy
+   *     on workspace projects in this WSM deployment (e.g. WSM application SA)
    * @return the proxy group email of the workspace user that was granted break-glass access
    */
   public String grantBreakGlass(

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -1,13 +1,26 @@
 package bio.terra.cli.businessobject;
 
+import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.persisted.PDResource;
 import bio.terra.cli.serialization.persisted.PDWorkspace;
+import bio.terra.cli.service.GoogleOauth;
+import bio.terra.cli.service.SamService;
 import bio.terra.cli.service.WorkspaceManagerService;
+import bio.terra.cli.service.utils.CrlUtils;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.workspace.model.CloneWorkspaceResult;
 import bio.terra.workspace.model.ClonedWorkspace;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.WorkspaceDescription;
+import com.google.api.services.cloudresourcemanager.v3.model.Binding;
+import com.google.api.services.cloudresourcemanager.v3.model.GetIamPolicyRequest;
+import com.google.api.services.cloudresourcemanager.v3.model.Policy;
+import com.google.api.services.cloudresourcemanager.v3.model.SetIamPolicyRequest;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -271,6 +284,70 @@ public class Workspace {
         WorkspaceManagerService.fromContextForPetSa()
             .cloneWorkspace(id, name, description, location);
     return result.getWorkspace();
+  }
+
+  /**
+   * Grant break-glass access to a user of this workspace. The user must be a workspace owner. The
+   * Editor role is granted to the user's proxy group.
+   *
+   * @param granteeEmail email of the workspace user requesting break-glass access
+   * @param saKeyFile path to the key file for a SA that has admin access on user projects in this
+   *     WSM deployment (e.g. WSM application SA)
+   */
+  public void grantBreakGlass(String granteeEmail, String saKeyFile) {
+    // check that the SA key file exists and is valid
+    ServiceAccountCredentials userProjectsAdminSA;
+    try {
+      final List<String> USER_PROJECTS_ADMIN_SA_SCOPES =
+          ImmutableList.of(
+              "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform");
+      userProjectsAdminSA =
+          GoogleOauth.getServiceAccountCredential(
+              Path.of(saKeyFile).toFile(), USER_PROJECTS_ADMIN_SA_SCOPES);
+    } catch (IOException ioEx) {
+      throw new SystemException("Error reading SA key file.", ioEx);
+    }
+
+    // require that the requester is a workspace owner
+    Optional<WorkspaceUser> granteeWorkspaceUser =
+        WorkspaceUser.list().stream()
+            .filter(user -> user.getEmail().equalsIgnoreCase(granteeEmail))
+            .findAny();
+    if (granteeWorkspaceUser.isEmpty()
+        || !granteeWorkspaceUser.get().getRoles().contains(WorkspaceUser.Role.OWNER)) {
+      throw new UserActionableException(
+          "The break-glass requester must be an owner of the workspace.");
+    }
+
+    // fetch the user's proxy group email from SAM
+    String granteeProxyGroupEmail = SamService.fromContext().getProxyGroupEmail(granteeEmail);
+    logger.debug("granteeProxyGroupEmail: {}", granteeProxyGroupEmail);
+
+    // grant the Editor role to the user's proxy group email on the workspace project
+    CloudResourceManagerCow resourceManagerCow =
+        CrlUtils.createCloudResourceManagerCow(userProjectsAdminSA);
+    try {
+      Policy policy =
+          resourceManagerCow
+              .projects()
+              .getIamPolicy(googleProjectId, new GetIamPolicyRequest())
+              .execute();
+      List<Binding> updatedBindings =
+          Optional.ofNullable(policy.getBindings()).orElse(new ArrayList<>());
+      updatedBindings.add(
+          new Binding()
+              .setRole("roles/editor")
+              .setMembers(ImmutableList.of("group:" + granteeProxyGroupEmail)));
+      policy.setBindings(updatedBindings);
+      resourceManagerCow
+          .projects()
+          .setIamPolicy(googleProjectId, new SetIamPolicyRequest().setPolicy(policy))
+          .execute();
+    } catch (IOException ioEx) {
+      throw new SystemException("Error granting the Editor role to the user's proxy group.", ioEx);
+    }
+
+    // TODO: update the central BigQuery dataset with details of this request
   }
 
   // ====================================================

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -285,8 +285,8 @@ public class Workspace {
   }
 
   /**
-   * Grant break-glass access to a user of this workspace. The user must be a workspace owner. The
-   * Editor role is granted to the user's proxy group.
+   * Grant break-glass access to a user of this workspace. The Editor role is granted to the user's
+   * proxy group.
    *
    * @param granteeEmail email of the workspace user requesting break-glass access
    * @param userProjectsAdminCredentials credentials for a SA that has permission to set IAM policy
@@ -295,17 +295,6 @@ public class Workspace {
    */
   public String grantBreakGlass(
       String granteeEmail, ServiceAccountCredentials userProjectsAdminCredentials) {
-    // require that the requester is a workspace owner
-    Optional<WorkspaceUser> granteeWorkspaceUser =
-        WorkspaceUser.list().stream()
-            .filter(user -> user.getEmail().equalsIgnoreCase(granteeEmail))
-            .findAny();
-    if (granteeWorkspaceUser.isEmpty()
-        || !granteeWorkspaceUser.get().getRoles().contains(WorkspaceUser.Role.OWNER)) {
-      throw new UserActionableException(
-          "The break-glass requester must be an owner of the workspace.");
-    }
-
     // fetch the user's proxy group email from SAM
     String granteeProxyGroupEmail = SamService.fromContext().getProxyGroupEmail(granteeEmail);
     logger.debug("granteeProxyGroupEmail: {}", granteeProxyGroupEmail);

--- a/src/main/java/bio/terra/cli/command/Workspace.java
+++ b/src/main/java/bio/terra/cli/command/Workspace.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.command;
 
 import bio.terra.cli.command.workspace.AddUser;
+import bio.terra.cli.command.workspace.BreakGlass;
 import bio.terra.cli.command.workspace.Clone;
 import bio.terra.cli.command.workspace.Create;
 import bio.terra.cli.command.workspace.Delete;
@@ -30,5 +31,6 @@ import picocli.CommandLine.Command;
       RemoveUser.class,
       Set.class,
       Update.class,
+      BreakGlass.class,
     })
 public class Workspace {}

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -15,11 +15,6 @@ import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
 import com.google.common.collect.ImmutableList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
-import picocli.CommandLine.Command;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
@@ -27,6 +22,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
 
 /**
  * This class corresponds to the third-level "terra workspace break-glass" command. This command is

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -3,8 +3,30 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.exception.SystemException;
+import bio.terra.cli.exception.UserActionableException;
+import bio.terra.cli.service.GoogleOauth;
+import com.google.api.client.util.DateTime;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.TableId;
+import com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * This class corresponds to the third-level "terra workspace break-glass" command. This command is
@@ -15,6 +37,7 @@ import picocli.CommandLine.Command;
     description = "Grant break-glass access to a workspace user.",
     hidden = true)
 public class BreakGlass extends BaseCommand {
+  private static final Logger logger = LoggerFactory.getLogger(BreakGlass.class);
 
   @CommandLine.Option(
       names = "--email",
@@ -23,11 +46,29 @@ public class BreakGlass extends BaseCommand {
   private String granteeEmail;
 
   @CommandLine.Option(
-      names = "--sa-key-file",
+      names = "--user-project-admin-sa",
       required = true,
       description =
           "Path to the key file for a SA that has admin permissions on user projects for the current server.")
-  private String saKeyFile;
+  private String userProjectAdminSAKeyFile;
+
+  @CommandLine.Option(
+      names = "--big-query-sa",
+      required = true,
+      description =
+          "Path to the key file for a SA that has permissions to update the BigQuery dataset tracking break-glass requests.")
+  private String bigQuerySAKeyFile;
+
+  @CommandLine.Option(
+      names = "--big-query-project",
+      required = true,
+      description = "Project ID that contains the BigQuery dataset tracking break-glass requests.")
+  private String bigQueryProjectId;
+
+  @CommandLine.Option(
+      names = "--notes",
+      description = "Free text string about this request, to store in the BigQuery dataset.")
+  private String notes;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
@@ -36,7 +77,73 @@ public class BreakGlass extends BaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
 
-    Context.requireWorkspace().grantBreakGlass(granteeEmail, saKeyFile);
+    // check that the SA key files exist and are valid
+    ServiceAccountCredentials userProjectsAdminCredentials;
+    ServiceAccountCredentials bigQueryCredentials;
+    try {
+      final List<String> SA_SCOPES =
+          ImmutableList.of("https://www.googleapis.com/auth/cloud-platform");
+      userProjectsAdminCredentials =
+          GoogleOauth.getServiceAccountCredential(
+              Path.of(userProjectAdminSAKeyFile).toFile(), SA_SCOPES);
+      bigQueryCredentials =
+          GoogleOauth.getServiceAccountCredential(Path.of(bigQuerySAKeyFile).toFile(), SA_SCOPES);
+    } catch (IOException ioEx) {
+      throw new UserActionableException("Error reading break-glass SA key files.", ioEx);
+    }
+
+    // grant the user's proxy group the Editor role on the workspace project
+    String granteeProxyGroupEmail =
+        Context.requireWorkspace().grantBreakGlass(granteeEmail, userProjectsAdminCredentials);
+
+    // update the central BigQuery dataset with details of this request
+    BigQuery bigQueryClient =
+        BigQueryOptions.newBuilder()
+            .setProjectId(bigQueryProjectId)
+            .setCredentials(bigQueryCredentials)
+            .build()
+            .getService();
+    Map<String, Object> rowContent = new HashMap<>();
+    rowContent.put("id", UUID.randomUUID().toString());
+    rowContent.put("requestGrantedTimestamp", new DateTime(new Date()));
+    rowContent.put("granteeEmail", granteeEmail);
+    rowContent.put("granteeProxyGroupEmail", granteeProxyGroupEmail);
+    rowContent.put("serverName", Context.getServer().getName());
+    rowContent.put("serverWsmUri", Context.getServer().getWorkspaceManagerUri());
+    rowContent.put("workspaceId", Context.requireWorkspace().getId().toString());
+    rowContent.put("googleProjectId", Context.requireWorkspace().getGoogleProjectId());
+    rowContent.put("workspaceName", Context.requireWorkspace().getName());
+    rowContent.put("workspaceDescription", Context.requireWorkspace().getDescription());
+    rowContent.put("granterEmail", Context.requireUser().getEmail());
+    rowContent.put("notes", notes);
+
+    // keep the dataset/table names here consistent with those in tools/create-break-glass-bq.sh
+    TableId tableId = TableId.of("break_glass_requests", "requests");
+    InsertAllRequest insertRequest =
+        InsertAllRequest.newBuilder(tableId).addRow(rowContent).build();
+    InsertAllResponse insertResponse = bigQueryClient.insertAll(insertRequest);
+    if (insertResponse.hasErrors()) {
+      logger.error(
+          "hasErrors is true after inserting into the {}.{}.{} table",
+          bigQueryClient.getOptions().getProjectId(),
+          insertRequest.getTable().getDataset(),
+          insertRequest.getTable().getTable());
+      // log any insertion errors
+      for (Map.Entry<Long, List<BigQueryError>> entry :
+          insertResponse.getInsertErrors().entrySet()) {
+        entry
+            .getValue()
+            .forEach(
+                bqErr ->
+                    logger.error(
+                        "Error inserting row into break glass BigQuery table: {}",
+                        bqErr.toString()));
+      }
+      if (insertResponse.getInsertErrors().entrySet().size() > 0) {
+        throw new SystemException(
+            "Error updating BigQuery dataset that catalogs break-glass requests.");
+      }
+    }
 
     OUT.println("Break-glass access successfully granted to: " + granteeEmail);
   }

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -48,7 +48,7 @@ public class BreakGlass extends BaseCommand {
       names = "--user-project-admin-sa",
       required = true,
       description =
-          "Path to the key file for a SA that has admin permissions on user projects for the current server.")
+          "Path to the key file for a SA that has permission to set IAM policy on workspace projects for the current server.")
   private String userProjectAdminSAKeyFile;
 
   @CommandLine.Option(
@@ -96,6 +96,13 @@ public class BreakGlass extends BaseCommand {
         Context.requireWorkspace().grantBreakGlass(granteeEmail, userProjectsAdminCredentials);
 
     // update the central BigQuery dataset with details of this request
+    updateRequestsCatalog(bigQueryCredentials, granteeProxyGroupEmail);
+
+    OUT.println("Break-glass access successfully granted to: " + granteeEmail);
+  }
+
+  private void updateRequestsCatalog(
+      ServiceAccountCredentials bigQueryCredentials, String granteeProxyGroupEmail) {
     BigQuery bigQueryClient =
         BigQueryOptions.newBuilder()
             .setProjectId(bigQueryProjectId)
@@ -143,7 +150,5 @@ public class BreakGlass extends BaseCommand {
             "Error updating BigQuery dataset that catalogs break-glass requests.");
       }
     }
-
-    OUT.println("Break-glass access successfully granted to: " + granteeEmail);
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -1,0 +1,43 @@
+package bio.terra.cli.command.workspace;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/**
+ * This class corresponds to the third-level "terra workspace break-glass" command. This command is
+ * hidden in the usage help.
+ */
+@Command(
+    name = "break-glass",
+    description = "Grant break-glass access to a workspace user.",
+    hidden = true)
+public class BreakGlass extends BaseCommand {
+
+  @CommandLine.Option(
+      names = "--email",
+      required = true,
+      description = "Email of workspace user requesting break-glass access.")
+  private String granteeEmail;
+
+  @CommandLine.Option(
+      names = "--sa-key-file",
+      required = true,
+      description =
+          "Path to the key file for a SA that has admin permissions on user projects for the current server.")
+  private String saKeyFile;
+
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+
+  /** Grant break-glass access to the workspace. */
+  @Override
+  protected void execute() {
+    workspaceOption.overrideIfSpecified();
+
+    Context.requireWorkspace().grantBreakGlass(granteeEmail, saKeyFile);
+
+    OUT.println("Break-glass access successfully granted to: " + granteeEmail);
+  }
+}

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -155,11 +155,12 @@ public class SamService {
    * Call the SAM "/api/google/v1/user/proxyGroup/{email}" endpoint to get the email for the current
    * user's proxy group.
    *
+   * @param email address of the user
    * @return email address of the user's proxy group
    */
-  public String getProxyGroupEmail() {
+  public String getProxyGroupEmail(String email) {
     return callWithRetries(
-        () -> new GoogleApi(apiClient).getProxyGroup(user.getEmail()),
+        () -> new GoogleApi(apiClient).getProxyGroup(email),
         "Error getting proxy group email from SAM.");
   }
 

--- a/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
@@ -2,6 +2,7 @@ package bio.terra.cli.service.utils;
 
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.IOException;
@@ -21,6 +22,15 @@ public class CrlUtils {
       return AIPlatformNotebooksCow.create(clientConfig, googleCredentials);
     } catch (GeneralSecurityException | IOException e) {
       throw new SystemException("Error creating notebooks client.", e);
+    }
+  }
+
+  public static CloudResourceManagerCow createCloudResourceManagerCow(
+      GoogleCredentials googleCredentials) {
+    try {
+      return CloudResourceManagerCow.create(clientConfig, googleCredentials);
+    } catch (GeneralSecurityException | IOException ex) {
+      throw new SystemException("Error creating cloud resource manager client.", ex);
     }
   }
 }

--- a/tools/break-glass-bq/tableSchema_requests.json
+++ b/tools/break-glass-bq/tableSchema_requests.json
@@ -1,0 +1,62 @@
+[
+  {
+    "mode": "REQUIRED",
+    "name": "id",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "requestGrantedTimestamp",
+    "type": "TIMESTAMP"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "granteeEmail",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "granteeProxyGroupEmail",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "serverName",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "serverWsmUri",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "workspaceId",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "googleProjectId",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "workspaceName",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "workspaceDescription",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "granterEmail",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "notes",
+    "type": "STRING"
+  }
+]

--- a/tools/break-glass-bq/tableSchema_requests.json
+++ b/tools/break-glass-bq/tableSchema_requests.json
@@ -6,8 +6,18 @@
   },
   {
     "mode": "REQUIRED",
-    "name": "requestGrantedTimestamp",
+    "name": "requestTimestamp",
     "type": "TIMESTAMP"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "isFailure",
+    "type": "BOOLEAN"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "errorMsg",
+    "type": "STRING"
   },
   {
     "mode": "REQUIRED",
@@ -15,7 +25,7 @@
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "granteeProxyGroupEmail",
     "type": "STRING"
   },
@@ -56,7 +66,7 @@
   },
   {
     "mode": "NULLABLE",
-    "name": "notes",
+    "name": "requestNotes",
     "type": "STRING"
   }
 ]

--- a/tools/create-break-glass-bq.sh
+++ b/tools/create-break-glass-bq.sh
@@ -2,6 +2,12 @@
 
 ## This script creates a BigQuery dataset to catalog break-glass requests.
 ## Running this script more than once with the same project id has no effect (i.e. same as running it once).
+##
+## This script assumes that `bq` is authenticated with an account that has BigQuery admin permissions on
+## the specified project. e.g.
+##   gcloud auth activate-service-account dev-ci-sa@broad-dsde-dev.iam.gserviceaccount.com --key-file=./rendered/ci-account.json
+##   ./tools/create-break-glass-bq.sh terra-cli-dev
+##
 ## Dependencies: bq
 ## Inputs: projectId (arg, required)
 ## Usage: ./tools/create-break-glass-bq.sh [projectId]

--- a/tools/create-break-glass-bq.sh
+++ b/tools/create-break-glass-bq.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+## This script creates a BigQuery dataset to catalog break-glass requests.
+## Running this script more than once with the same project id has no effect (i.e. same as running it once).
+## Dependencies: bq
+## Inputs: projectId (arg, required)
+## Usage: ./tools/create-break-glass-bq.sh [projectId]
+
+## The script assumes that it is being run from the top-level directory "terra-cli/".
+if [ $(basename $PWD) != 'terra-cli' ]; then
+  echo "Script must be run from top-level directory 'terra-cli/'"
+  exit 1
+fi
+
+usage="Usage: ./tools/create-break-glass-bq.sh [projectId]"
+
+projectId=$1
+if [ -z "$projectId" ]; then
+    echo $usage
+    exit 1
+fi
+
+# keep the dataset/table names here consistent with those in command.workspace.BreakGlass class
+dataset=break_glass_requests
+table=requests
+
+# create the dataset if it does not exist
+bq show $projectId:$dataset || \
+    bq --location=US mk -d --description "Break-Glass Requests" $projectId:$dataset
+
+# create the tables if they do not exist
+bq show --schema $projectId:$dataset.$table || \
+    bq mk --table $projectId:$dataset.$table ./tools/break-glass-bq/tableSchema_requests.json
+
+# list tables in the BQ dataset
+bq ls $projectId:$dataset

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -17,6 +17,7 @@ CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
 TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
 EXT_PROJECT_SA_VAULT_PATH=secret/dsde/terra/cli-test/default/service-account-admin.json
 JANITOR_CLIENT_SA_VAULT_PATH=secret/dsde/terra/kernel/integration/tools/crl_janitor/client-sa
+VERILYCLI_WSM_SA_VAULT_PATH=secret/dsde/terra/kernel/integration/verilycli/workspace/app-sa
 
 # Helper function to read a secret from Vault and write it to a local file in the rendered/ directory.
 # Inputs: vault path, file name, [optional] decode from base 64
@@ -59,3 +60,7 @@ readFromVault "$EXT_PROJECT_SA_VAULT_PATH" "external-project-account.json"
 # used for cleaning up external (to WSM) test resources with Janitor
 echo "Reading the Janitor client service account key file from Vault"
 readFromVault "$JANITOR_CLIENT_SA_VAULT_PATH" "janitor-client.json" "base64"
+
+# used for granting break-glass access to a workspace in the verilycli deployment
+echo "Reading the WSM app service account key file for the verilycli deployment from Vault"
+readFromVault "$VERILYCLI_WSM_SA_VAULT_PATH" "verilycli-wsm-sa.json" "base64"

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -11,8 +11,15 @@ set -e
 ##
 ## Dependencies: jq
 ## Inputs: adminUsersGroupEmail (arg, required) email address of the SAM group for admin users
-## Usage: ./setup-test-users.sh  developer-admins@dev.test.firecloud.org
+## Usage: ./tools/setup-test-users.sh  developer-admins@dev.test.firecloud.org
 #     --> sets up the CLI test users and grants the developer-admins email ADMIN access to the cli-test-users SAM group
+
+## The script assumes that it is being run from the top-level directory "terra-cli/".
+if [ $(basename $PWD) != 'terra-cli' ]; then
+  echo "Script must be run from top-level directory 'terra-cli/'"
+  exit 1
+fi
+terra=$PWD/build/install/terra-cli/bin/terra
 
 usage="Usage: ./setup-test-users.sh [adminUsersGroupEmail]"
 
@@ -21,8 +28,6 @@ if [ -z "$adminUsersGroupEmail" ]; then
     echo $usage
     exit 1
 fi
-
-terra=/Users/marikomedlock/Workspaces/terra-cli/build/install/terra-cli/bin/terra
 
 # create the cli-test-users SAM group and add it as a user on the spend profile
 echo


### PR DESCRIPTION
- Add a hidden command `terra workspace break-glass` to grant Editor access to a workspace project.
- Included a script to create a central BQ dataset for cataloging break-glass requests. The command writes to this dataset.
- More details and example commands in `CONTRIBUTING.md`.