### PR TITLE
PF-1017: Run nightly tests against devel instead of autopush.

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,7 +8,7 @@ jobs:
   tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testServer: [ "terra-dev", "terra-verily-autopush" ]
+        testServer: [ "terra-dev", "terra-verily-devel" ]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -43,8 +43,8 @@ group and grant that group OWNER access to the spend profile. e.g.:
 ```
 terra spend create-profile
 terra group create --name=developer-admins
-terra group add-user --email=admin1@gmail.com --policy=ADMIN
-terra group add-user --email=admin2@gmail.com --policy=ADMIN
+terra group add-user --name=developer-admins --email=admin1@gmail.com --policy=ADMIN
+terra group add-user --name=developer-admins --email=admin2@gmail.com --policy=ADMIN
 terra spend enable --email=developer-admins@gmail.com --policy=OWNER
 ```
 

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -1,0 +1,103 @@
+# terra-cli
+
+1. [Spend profile](#spend-profile)
+    * [Grant spend access](#grant-spend-access)
+    * [Setup spend profile](#setup-spend-profile)
+2. [Break-glass](#break-glass)
+    * [Grant break-glass](#grant-break-glass)
+    * [Requests catalog](#requests-catalog)
+
+-----
+
+### Spend profile
+In order to spend money (e.g. by creating a project and resources within it) in Terra, you need
+access to a billing account via a spend profile. In the future, there will be a dedicated Spend
+Profile Manager service that will allow users to setup different profiles that map to different
+billing accounts, and to grant access to users.
+
+Until that new service is build, Workspace Manager recognizes a single spend profile per deployment.
+This single spend profile corresponds to a SAM resource. The name of this resource is specified in
+the Workspace Manager deployment configuration (e.g. Helm charts) but needs to be setup and managed
+manually in SAM (i.e. there are no WSM endpoints for managing spend profiles, you have to talk to SAM
+directly). The CLI provides convenience commands for this setup and management.
+
+#### Grant spend access
+- [Preferred] Add a user to a Terra group that is a user of the spend profile. To also grant permission
+  to add new members to the group, use `policy=ADMIN` instead.
+  `terra group add-user --name=enterprise-pilot-testers --policy=MEMBER --email=testuser@gmail.com`
+
+- Add a user directly to the spend profile. To also grant permission to add new users to the spend profile,
+  user `policy=OWNER` instead.
+  `terra spend enable --policy=USER --email=testuser@gmail.com`
+
+#### Setup spend profile
+To create the spend profile:
+  `terra spend create-profile`
+This command uses the spend profile name specified in the `src/main/resources/servers` file for the current
+server. For most servers, the name is `wm-default-spend-profile`.
+
+The user who runs the create command will automatically be added as an OWNER of the spend profile, with
+permissions to add new users. You should also make sure that other people have access to the profile,
+so that changes can be made when you're unavailable. The recommended way to do this is to create an admins
+group and grant that group OWNER access to the spend profile. e.g.:
+```
+terra spend create-profile
+terra group create --name=developer-admins
+terra group add-user --email=admin1@gmail.com --policy=ADMIN
+terra group add-user --email=admin2@gmail.com --policy=ADMIN
+terra spend enable --email=developer-admins@gmail.com --policy=OWNER
+```
+
+To delete the spend profile:
+  `terra spend delete-profile`
+This is helpful if you accidentally create the spend profile with the wrong name and need to start over.
+
+### Break-glass
+A break-glass implementation means that there is a way for users to request elevated permissions on a workspace.
+These elevated permissions invalidate the contract with WSM. Any guarantees about policy or access enforcement
+are off.
+
+The purpose of break-glass access is to grant select trusted users the ability to try out cloud features that
+are not yet available via WSM. The goal of this experimentation is to understand what use cases WSM could
+support in the future.
+
+Break-glass is intended for non-production environments only. This contributed to the decision to implement
+this on the client side, instead of e.g. as a new WSM endpoint.
+
+#### Grant break-glass
+To grant break-glass access to someone:
+1. Ask the requester to:
+    - Make your Terra user an owner of the workspace they want break-glass access to.
+      `terra workspace add-user --email=breakglassgranter@gmail.com --role=OWNER`
+    - Confirm that they are an owner of the workspace.
+      `terra workspace list-users`
+    - Relay any brief notes about the reason for the request.
+2. Download two SA key files:
+    - One that has permission to set IAM policy on all workspace projects. This will be specific
+      to the server (i.e. WSM deployment) where the workspaces live.
+    - One that has permission to update a central BigQuery dataset that tracks break-glass requests.
+    - The `tools/render-config.sh` script downloads two SA key files that will work for workspaces
+      on the `verily-cli` server and the central BigQuery dataset in the `terra-cli-dev` project.
+3. Run the `terra workspace break-glass` command.
+
+Example commands for granting break-glass access for a workspace in the `verily-cli` deployment:
+```
+./tools/render-config.sh
+terra auth login # login as yourself, the break-glass granter
+terra workspace break-glass --email=breakglassrequester@gmail.com --big-query-project=terra-cli-dev --big-query-sa=rendered/ci-account.json --user-project-admin-sa=rendered/verilycli-wsm-sa.json --notes="Testing break-glass command."
+```
+
+#### Requests catalog
+The `terra workspace break-glass` command updates a central BigQuery dataset to track break-glass requests.
+This dataset was setup by a script:
+```
+gcloud auth activate-service-account dev-ci-sa@broad-dsde-dev.iam.gserviceaccount.com --key-file=./rendered/ci-account.json
+./tools/create-break-glass-bq.sh terra-cli-dev
+```
+
+In the future, we can run the same script with different credentials and project id to setup another central
+BigQuery dataset somewhere else. (e.g. one for Verily deployments, one for Broad deployments). The SA activated
+in the first command needs to have BigQuery admin privileges in the target project.
+
+The current central BigQuery dataset exists in the `terra-cli-dev` project.
+

--- a/README.md
+++ b/README.md
@@ -72,16 +72,7 @@ In order to spend money (e.g. by creating a project and resources within it) in 
 access to a billing account via a spend profile. Currently, there is a single spend profile used
 by Workspace Manager. Your email needs to either be added as a user of that spend profile or added
 to a Terra group that is a user of that spend profile. This needs to be done by someone else with
-owner access to that spend profile.
-
-- [Preferred] Add a user to a Terra group that is a user of the spend profile. To also grant permission
-to add new members to the group, use `policy=admin` instead.
-
-`terra group add-user --name=enterprise-pilot-testers --policy=MEMBER --email=testuser@gmail.com`
-
-- Add a user directly to the spend profile. To also grant permission to add new users to the spend profile,
-user `policy=owner` instead.
-`terra spend enable --policy=USER --email=testuser@gmail.com`
+owner access to that spend profile. Instructions on granting spend profile access are in ADMIN.md.
 
 #### External data 
 To allow supported applications (i.e. the ones shown by `terra app list`) to read or write data

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
         // terra libraries
         crlPlatform = "0.2.0"
-        samClient = "0.1-9435410-SNAP"
+        samClient = "0.1-ffb0a89-SNAP" // "0.1-9435410-SNAP"
         workspaceManagerClient = "0.254.80-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
@@ -106,7 +106,7 @@ dependencies {
     implementation "bio.terra.cloud-resource-lib:google-notebooks"
     implementation "bio.terra.cloud-resource-lib:google-storage"
 
-    implementation "org.broadinstitute.dsde.workbench:sam-client_2.12:${samClient}"
+    implementation "org.broadinstitute.dsde.workbench:sam-client_2.13:${samClient}"
     implementation "bio.terra:datarepo-client:${dataRepoClient}"
     implementation "bio.terra:workspace-manager-client:${workspaceManagerClient}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
         // terra libraries
         crlPlatform = "0.2.0"
-        samClient = "0.1-ffb0a89-SNAP" // "0.1-9435410-SNAP"
+        samClient = "0.1-ffb0a89-SNAP"
         workspaceManagerClient = "0.254.80-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 

--- a/src/main/java/bio/terra/cli/command/Spend.java
+++ b/src/main/java/bio/terra/cli/command/Spend.java
@@ -1,5 +1,7 @@
 package bio.terra.cli.command;
 
+import bio.terra.cli.command.spend.CreateProfile;
+import bio.terra.cli.command.spend.DeleteProfile;
 import bio.terra.cli.command.spend.Disable;
 import bio.terra.cli.command.spend.Enable;
 import bio.terra.cli.command.spend.ListUsers;
@@ -12,5 +14,11 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "spend",
     description = "Manage spend profiles.",
-    subcommands = {Enable.class, Disable.class, ListUsers.class})
+    subcommands = {
+      CreateProfile.class,
+      Enable.class,
+      DeleteProfile.class,
+      Disable.class,
+      ListUsers.class
+    })
 public class Spend {}

--- a/src/main/java/bio/terra/cli/command/spend/CreateProfile.java
+++ b/src/main/java/bio/terra/cli/command/spend/CreateProfile.java
@@ -7,7 +7,8 @@ import picocli.CommandLine.Command;
 /** This class corresponds to the third-level "terra spend create-profile" command. */
 @Command(
     name = "create-profile",
-    description = "Create the Workspace Manager default spend profile.")
+    description = "Create the Workspace Manager default spend profile.",
+    hidden = true)
 public class CreateProfile extends BaseCommand {
   /** Create the WSM default spend profile. */
   @Override

--- a/src/main/java/bio/terra/cli/command/spend/CreateProfile.java
+++ b/src/main/java/bio/terra/cli/command/spend/CreateProfile.java
@@ -1,0 +1,18 @@
+package bio.terra.cli.command.spend;
+
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.service.SpendProfileManagerService;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra spend create-profile" command. */
+@Command(
+    name = "create-profile",
+    description = "Create the Workspace Manager default spend profile.")
+public class CreateProfile extends BaseCommand {
+  /** Create the WSM default spend profile. */
+  @Override
+  protected void execute() {
+    SpendProfileManagerService.fromContext().createDefaultSpendProfile();
+    OUT.println("Default WSM spend profile created successfully.");
+  }
+}

--- a/src/main/java/bio/terra/cli/command/spend/DeleteProfile.java
+++ b/src/main/java/bio/terra/cli/command/spend/DeleteProfile.java
@@ -1,0 +1,23 @@
+package bio.terra.cli.command.spend;
+
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.DeletePrompt;
+import bio.terra.cli.service.SpendProfileManagerService;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra spend delete-profile" command. */
+@Command(
+    name = "delete-profile",
+    description = "Delete the Workspace Manager default spend profile.")
+public class DeleteProfile extends BaseCommand {
+  @CommandLine.Mixin DeletePrompt deletePromptOption;
+
+  /** Delete the WSM default spend profile. */
+  @Override
+  protected void execute() {
+    deletePromptOption.confirmOrThrow();
+    SpendProfileManagerService.fromContext().deleteDefaultSpendProfile();
+    OUT.println("Default WSM spend profile deleted successfully.");
+  }
+}

--- a/src/main/java/bio/terra/cli/command/spend/DeleteProfile.java
+++ b/src/main/java/bio/terra/cli/command/spend/DeleteProfile.java
@@ -9,7 +9,8 @@ import picocli.CommandLine.Command;
 /** This class corresponds to the third-level "terra spend delete-profile" command. */
 @Command(
     name = "delete-profile",
-    description = "Delete the Workspace Manager default spend profile.")
+    description = "Delete the Workspace Manager default spend profile.",
+    hidden = true)
 public class DeleteProfile extends BaseCommand {
   @CommandLine.Mixin DeletePrompt deletePromptOption;
 

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -28,7 +28,7 @@ terra=/Users/marikomedlock/Workspaces/terra-cli/build/install/terra-cli/bin/terr
 echo
 echo "Creating the SAM group for CLI test users."
 groupName="cli-test-users"
-$terra group create --name=$groupName
+$terra group describe --name=$groupName || $terra group create --name=$groupName
 groupEmail=$($terra group describe --name=$groupName --format=json | jq -r .email)
 
 echo


### PR DESCRIPTION
- Added two new admin commands for setting up/deleting the default spend profile: `terra spend create-profile`, `terra spend delete-profile`
- Changed the nightly tests GH action to run against the `terra-verily-devel` server instead of `terra-verily-autopush`. I've got a successful run [here](https://github.com/DataBiosphere/terra-cli/actions/runs/1304423547).
- Also some smaller changes:
  - Improved exception logging when using retries. Previously, we were only logging the last exception message, now all are logged.
  - Separated out documentation for the spend profile and break-glass commands into a new ADMIN.md.
  - Changed the script for setting up CLI test users to not quit if the SAM group already exists.

Not part of this PR, but as part of this ticket, I've setup the spend profile and CLI test users on all three Verily deployments: `terra-verily-devel`, `terra-verily-autopush`, `terra-verily-staging`. This means that:
  - the default WSM spend profile exists and has both owner and user policies
  - the `developer-admins` SAM group is defined and populated with PF team members
  - `developer-admins` is an owner of the default WSM spend profile SAM resource
  - SAM group and spend permissions are setup for the CLI test users
  - `developer-admins` is an admin of the `cli-test-users` SAM group

The first three items above are manual setup steps, and the last two are done by running the `tools/setup-test-users.sh` script.