### PR TITLE
Update docs with known-good Nextflow config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,13 @@ in the workspace's backing Google project). This is the same example workflow us
           process.executor = 'google-lifesciences'
           process.container = 'nextflow/rnaseq-nf:latest'
           workDir = "$TERRA_mybucket/scratch"
-          google.location = 'europe-west2'
-          google.region  = 'europe-west1'
+
+          google.region  = 'us-east1'
           google.project = "$GOOGLE_CLOUD_PROJECT"
+          
+          google.lifeSciences.serviceAccountEmail = "$GOOGLE_SERVICE_ACCOUNT_EMAIL"
+          google.lifeSciences.network = 'network'
+          google.lifeSciences.subnetwork = 'subnetwork'
       }
     ```
 - Do a dry-run to confirm the config is set correctly.


### PR DESCRIPTION
I was tinkering a bit with the CLI today and ran into some errors using the example provided here in the README.

This PR updates the example 'gls' Nextflow profile to work correctly with a recent Terra-configured workspace.