### PR TITLE
PF-1058: Add Project IAM Admin role to break-glass access.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -285,8 +285,8 @@ public class Workspace {
   }
 
   /**
-   * Grant break-glass access to a user of this workspace. The Editor role is granted to the user's
-   * proxy group.
+   * Grant break-glass access to a user of this workspace. The Editor and Project IAM Admin roles
+   * are granted to the user's proxy group.
    *
    * @param granteeEmail email of the workspace user requesting break-glass access
    * @param userProjectsAdminCredentials credentials for a SA that has permission to set IAM policy
@@ -314,13 +314,18 @@ public class Workspace {
           new Binding()
               .setRole("roles/editor")
               .setMembers(ImmutableList.of("group:" + granteeProxyGroupEmail)));
+      updatedBindings.add(
+          new Binding()
+              .setRole("roles/resourcemanager.projectIamAdmin")
+              .setMembers(ImmutableList.of("group:" + granteeProxyGroupEmail)));
       policy.setBindings(updatedBindings);
       resourceManagerCow
           .projects()
           .setIamPolicy(googleProjectId, new SetIamPolicyRequest().setPolicy(policy))
           .execute();
     } catch (IOException ioEx) {
-      throw new SystemException("Error granting the Editor role to the user's proxy group.", ioEx);
+      throw new SystemException(
+          "Error granting the Editor and Project IAM Admin roles to the user's proxy group.", ioEx);
     }
 
     return granteeProxyGroupEmail;


### PR DESCRIPTION
- Added the Project IAM Admin role to break-glass access. Previously, break-glass only granted the Editor role.
- This allows break-glass users to give themselves more permissions. Amy on the solutions team needed this to give herself and her pet SA the Vertex AI Admin role.

Not strictly part of this PR, but as part of this ticket, I removed the permissions I manually granted to Amy and using this updated code I re-granted Amy break-glass access on her workspace. This way, the request is logged and the permissions match what future requests will grant.