### PR TITLE
PF-1086: Add default locations for controlled GCS buckets and BQ datasets.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         // terra libraries
         crlPlatform = "0.2.0"
         samClient = "0.1-ffb0a89-SNAP"
-        workspaceManagerClient = "0.254.80-SNAPSHOT"
+        workspaceManagerClient = "0.254.114-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
@@ -25,6 +25,7 @@ public class BqDataset extends BaseCommand {
 
   @CommandLine.Option(
       names = "--location",
+      defaultValue = "us-central1",
       description = "Dataset location (https://cloud.google.com/bigquery/docs/locations).")
   private String location;
 

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -56,7 +56,8 @@ public class GcpNotebook extends BaseCommand {
   @CommandLine.Option(
       names = "--location",
       defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance.")
+      description =
+          "The Google Cloud location of the instance (https://cloud.google.com/vertex-ai/docs/general/locations#user-managed-notebooks-locations).")
   private String location;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
@@ -30,6 +30,7 @@ public class GcsBucket extends BaseCommand {
 
   @CommandLine.Option(
       names = "--location",
+      defaultValue = "US-CENTRAL1",
       description = "Bucket location (https://cloud.google.com/storage/docs/locations).")
   private String location;
 


### PR DESCRIPTION
WSM now requires the location parameter when creating controlled GCS buckets and BQ datasets. This broke existing CLI usage where this optional parameter is not specified. Added a default location for both resource types. This is consistent with what we already did for GCP notebooks.

Also bumped the WSM client library version.