### PR TITLE
[no ticket] Update spend profile name in Verily environments.

### DIFF
--- a/src/main/resources/servers/terra-verily-preprod.json
+++ b/src/main/resources/servers/terra-verily-preprod.json
@@ -6,5 +6,5 @@
   "samUri": "https://terra-preprod-sam.api.verily.com",
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-preprod-wsm.api.verily.com",
-  "wsmDefaultSpendProfile": "wm-default-spend-profile"
+  "wsmDefaultSpendProfile": "wm-temp-spend-profile"
 }

--- a/src/main/resources/servers/terra-verily.json
+++ b/src/main/resources/servers/terra-verily.json
@@ -6,5 +6,5 @@
   "samUri": "https://terra-sam.api.verily.com",
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-wsm.api.verily.com",
-  "wsmDefaultSpendProfile": "wm-default-spend-profile"
+  "wsmDefaultSpendProfile": "wm-temp-spend-profile"
 }


### PR DESCRIPTION
Changed `default` > `temp` in WSM default spend profile name for prod and pre-prod environments.