### PR TITLE
PF-1087: Include location in bucket and dataset output.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
@@ -8,8 +8,12 @@ import bio.terra.cli.serialization.userfacing.input.UpdateBqDatasetParams;
 import bio.terra.cli.serialization.userfacing.input.UpdateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.cli.service.WorkspaceManagerService;
+import bio.terra.cli.service.utils.CrlUtils;
+import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.workspace.model.GcpBigQueryDatasetResource;
 import bio.terra.workspace.model.ResourceDescription;
+import com.google.api.services.bigquery.model.Dataset;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -170,6 +174,18 @@ public class BqDataset extends Resource {
         return projectId;
       default:
         throw new IllegalArgumentException("Unknown BigQuery dataset resolve option.");
+    }
+  }
+
+  /** Query the cloud for information about the dataset. */
+  public Optional<Dataset> getDataset() {
+    try {
+      BigQueryCow bigQueryCow =
+          CrlUtils.createBigQueryCow(Context.requireUser().getPetSACredentials());
+      return Optional.of(bigQueryCow.datasets().get(projectId, datasetId).execute());
+    } catch (Exception ex) {
+      logger.error("Caught exception looking up dataset", ex);
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
@@ -8,8 +8,12 @@ import bio.terra.cli.serialization.userfacing.input.UpdateGcsBucketParams;
 import bio.terra.cli.serialization.userfacing.input.UpdateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.cli.service.WorkspaceManagerService;
+import bio.terra.cli.service.utils.CrlUtils;
+import bio.terra.cloudres.google.storage.BucketCow;
+import bio.terra.cloudres.google.storage.StorageCow;
 import bio.terra.workspace.model.GcpGcsBucketResource;
 import bio.terra.workspace.model.ResourceDescription;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,6 +146,18 @@ public class GcsBucket extends Resource {
    */
   public String resolve(boolean includePrefix) {
     return includePrefix ? GCS_BUCKET_URL_PREFIX + bucketName : bucketName;
+  }
+
+  /** Query the cloud for information about the bucket. */
+  public Optional<BucketCow> getBucket() {
+    try {
+      StorageCow storageCow =
+          CrlUtils.createStorageCow(Context.requireUser().getPetSACredentials());
+      return Optional.of(storageCow.get(bucketName));
+    } catch (Exception ex) {
+      logger.error("Caught exception looking up bucket", ex);
+      return Optional.empty();
+    }
   }
 
   // ====================================================

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFBqDataset.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFBqDataset.java
@@ -47,7 +47,7 @@ public class UFBqDataset extends UFResource {
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCP project id: " + projectId);
     OUT.println(prefix + "BigQuery dataset id: " + datasetId);
-    OUT.println(prefix + "Location: " + location);
+    OUT.println(prefix + "Location: " + (location == null ? "(undefined)" : location));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFBqDataset.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFBqDataset.java
@@ -5,7 +5,9 @@ import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.api.services.bigquery.model.Dataset;
 import java.io.PrintStream;
+import java.util.Optional;
 
 /**
  * External representation of a workspace BigQuery dataset resource for command input/output.
@@ -18,12 +20,16 @@ import java.io.PrintStream;
 public class UFBqDataset extends UFResource {
   public final String projectId;
   public final String datasetId;
+  public final String location;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFBqDataset(BqDataset internalObj) {
     super(internalObj);
     this.projectId = internalObj.getProjectId();
     this.datasetId = internalObj.getDatasetId();
+
+    Optional<Dataset> dataset = internalObj.getDataset();
+    this.location = dataset.isPresent() ? dataset.get().getLocation() : null;
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -31,6 +37,7 @@ public class UFBqDataset extends UFResource {
     super(builder);
     this.projectId = builder.projectId;
     this.datasetId = builder.datasetId;
+    this.location = builder.location;
   }
 
   /** Print out this object in text format. */
@@ -40,12 +47,14 @@ public class UFBqDataset extends UFResource {
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCP project id: " + projectId);
     OUT.println(prefix + "BigQuery dataset id: " + datasetId);
+    OUT.println(prefix + "Location: " + location);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder extends UFResource.Builder {
     private String projectId;
     private String datasetId;
+    private String location;
 
     public Builder projectId(String projectId) {
       this.projectId = projectId;
@@ -54,6 +63,11 @@ public class UFBqDataset extends UFResource {
 
     public Builder datasetId(String datasetId) {
       this.datasetId = datasetId;
+      return this;
+    }
+
+    public Builder location(String location) {
+      this.location = location;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
@@ -58,7 +58,7 @@ public class UFGcpNotebook extends UFResource {
     super.print(prefix);
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCP project id:                " + projectId);
-    OUT.println(prefix + "Location: " + location);
+    OUT.println(prefix + "Location: " + (location == null ? "(undefined)" : location));
     OUT.println(prefix + "Instance id:       " + instanceId);
     OUT.println(prefix + "Instance name: " + (instanceName == null ? "(undefined)" : instanceName));
     OUT.println(prefix + "State:         " + (state == null ? "(undefined)" : state));

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
@@ -58,8 +58,8 @@ public class UFGcpNotebook extends UFResource {
     super.print(prefix);
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCP project id:                " + projectId);
-    OUT.println(prefix + "GCP Notebook instance location: " + location);
-    OUT.println(prefix + "GCP Notebook instance id:       " + instanceId);
+    OUT.println(prefix + "Location: " + location);
+    OUT.println(prefix + "Instance id:       " + instanceId);
     OUT.println(prefix + "Instance name: " + (instanceName == null ? "(undefined)" : instanceName));
     OUT.println(prefix + "State:         " + (state == null ? "(undefined)" : state));
     OUT.println(prefix + "Proxy URL:     " + (proxyUri == null ? "(undefined)" : proxyUri));

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcsBucket.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcsBucket.java
@@ -43,7 +43,7 @@ public class UFGcsBucket extends UFResource {
     super.print(prefix);
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCS bucket name: " + bucketName);
-    OUT.println(prefix + "Location: " + location);
+    OUT.println(prefix + "Location: " + (location == null ? "(undefined)" : location));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcsBucket.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcsBucket.java
@@ -3,9 +3,11 @@ package bio.terra.cli.serialization.userfacing.resource;
 import bio.terra.cli.businessobject.resource.GcsBucket;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.cli.utils.UserIO;
+import bio.terra.cloudres.google.storage.BucketCow;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
+import java.util.Optional;
 
 /**
  * External representation of a workspace GCS bucket resource for command input/output.
@@ -17,17 +19,22 @@ import java.io.PrintStream;
 @JsonDeserialize(builder = UFGcsBucket.Builder.class)
 public class UFGcsBucket extends UFResource {
   public final String bucketName;
+  public final String location;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFGcsBucket(GcsBucket internalObj) {
     super(internalObj);
     this.bucketName = internalObj.getBucketName();
+
+    Optional<BucketCow> bucket = internalObj.getBucket();
+    this.location = bucket.isPresent() ? bucket.get().getBucketInfo().getLocation() : null;
   }
 
   /** Constructor for Jackson deserialization during testing. */
   private UFGcsBucket(Builder builder) {
     super(builder);
     this.bucketName = builder.bucketName;
+    this.location = builder.location;
   }
 
   /** Print out this object in text format. */
@@ -36,14 +43,21 @@ public class UFGcsBucket extends UFResource {
     super.print(prefix);
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCS bucket name: " + bucketName);
+    OUT.println(prefix + "Location: " + location);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder extends UFResource.Builder {
     private String bucketName;
+    private String location;
 
     public Builder bucketName(String bucketName) {
       this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder location(String location) {
+      this.location = location;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
@@ -2,9 +2,12 @@ package bio.terra.cli.service.utils;
 
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cloudres.common.ClientConfig;
+import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
+import bio.terra.cloudres.google.storage.StorageCow;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -31,6 +34,19 @@ public class CrlUtils {
       return CloudResourceManagerCow.create(clientConfig, googleCredentials);
     } catch (GeneralSecurityException | IOException ex) {
       throw new SystemException("Error creating cloud resource manager client.", ex);
+    }
+  }
+
+  public static StorageCow createStorageCow(GoogleCredentials googleCredentials) {
+    return new StorageCow(
+        clientConfig, StorageOptions.newBuilder().setCredentials(googleCredentials).build());
+  }
+
+  public static BigQueryCow createBigQueryCow(GoogleCredentials googleCredentials) {
+    try {
+      return BigQueryCow.create(clientConfig, googleCredentials);
+    } catch (GeneralSecurityException | IOException ex) {
+      throw new SystemException("Error creating Big Query client.", ex);
     }
   }
 }


### PR DESCRIPTION
Included the location in the user-facing output (text and JSON) for both bucket and dataset resources. This applies to both controlled and referenced resources. Location is already included for notebooks, so this brings the other resource types in line with that.