### PR TITLE
PF-1102: Better error message when spend profile access denied.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.businessobject;
 
 import bio.terra.cli.exception.SystemException;
-import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.persisted.PDUser;
 import bio.terra.cli.service.GoogleOauth;
 import bio.terra.cli.service.SamService;
@@ -135,13 +134,7 @@ public class User {
         user.fetchUserInfo();
       } catch (SystemException sysEx) {
         user.deleteOauthCredentials();
-        if (sysEx.getMessage().contains("Please request an invite from an admin")) {
-          throw new UserActionableException(
-              "Fetching the user's registration information failed. If you are not already a registered user, ask an administrator to invite you.",
-              sysEx);
-        } else {
-          throw sysEx;
-        }
+        throw sysEx;
       }
 
       // update the global context on disk

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -137,7 +137,8 @@ public class User {
         user.deleteOauthCredentials();
         if (sysEx.getMessage().contains("Please request an invite from an admin")) {
           throw new UserActionableException(
-              "Fetching the user's registration information failed. If you are not already a registered user, ask an administrator to invite you.");
+              "Fetching the user's registration information failed. If you are not already a registered user, ask an administrator to invite you.",
+              sysEx);
         } else {
           throw sysEx;
         }

--- a/src/main/java/bio/terra/cli/service/GoogleNotebooks.java
+++ b/src/main/java/bio/terra/cli/service/GoogleNotebooks.java
@@ -8,6 +8,7 @@ import bio.terra.cloudres.google.api.services.common.OperationUtils;
 import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.services.notebooks.v1.model.Instance;
 import com.google.api.services.notebooks.v1.model.Operation;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -71,7 +72,8 @@ public class GoogleNotebooks {
       GoogleJsonResponseException googleJsonEx = (GoogleJsonResponseException) ex;
       int httpCode = googleJsonEx.getStatusCode();
       String message = googleJsonEx.getDetails().getMessage();
-      if (httpCode == 409 && message.contains("unable to queue the operation")) {
+      if (httpCode == HttpStatusCodes.STATUS_CODE_CONFLICT
+          && message.contains("unable to queue the operation")) {
         throw new UserActionableException(
             "Error changing notebook state: The notebook is not in the right state to start/stop. Wait a few minutes and try again. (409: unable to queue the operation)",
             googleJsonEx);

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -1149,6 +1149,9 @@ public class WorkspaceManagerService {
       // if this is a WSM client exception, check for a message in the response body
       if (ex instanceof ApiException) {
         String exceptionErrorMessage = logErrorMessage((ApiException) ex);
+
+        // if this is a spend profile access denied error, then throw a more user-friendly error
+        // message
         if (exceptionErrorMessage.contains("spend profile")
             && ((ApiException) ex).getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
           throw new UserActionableException(

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -1148,7 +1148,13 @@ public class WorkspaceManagerService {
     } catch (ApiException | InterruptedException ex) {
       // if this is a WSM client exception, check for a message in the response body
       if (ex instanceof ApiException) {
-        errorMsg += ": " + logErrorMessage((ApiException) ex);
+        String exceptionErrorMessage = logErrorMessage((ApiException) ex);
+        if (exceptionErrorMessage.contains("User is unauthorized to link spend profile")) {
+          throw new UserActionableException(
+              "Accessing the spend profile failed. Ask an administrator to grant you access.", ex);
+        }
+
+        errorMsg += ": " + exceptionErrorMessage;
       }
 
       // wrap the WSM exception and re-throw it

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -1149,7 +1149,8 @@ public class WorkspaceManagerService {
       // if this is a WSM client exception, check for a message in the response body
       if (ex instanceof ApiException) {
         String exceptionErrorMessage = logErrorMessage((ApiException) ex);
-        if (exceptionErrorMessage.contains("User is unauthorized to link spend profile")) {
+        if (exceptionErrorMessage.contains("spend profile")
+            && ((ApiException) ex).getCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
           throw new UserActionableException(
               "Accessing the spend profile failed. Ask an administrator to grant you access.", ex);
         }

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -261,11 +261,12 @@ public class Workspace extends ClearContextUnit {
     testUser.login();
 
     // `terra workspace create`
-    String stdErr = TestCommand.runCommandExpectExitCode(2, "workspace", "create");
+    String stdErr = TestCommand.runCommandExpectExitCode(1, "workspace", "create");
     assertThat(
         "error message includes spend profile unauthorized",
         stdErr,
-        CoreMatchers.containsString("User is unauthorized to link spend profile"));
+        CoreMatchers.containsString(
+            "Accessing the spend profile failed. Ask an administrator to grant you access."));
   }
 
   /**


### PR DESCRIPTION
Added a better error message when a command fails because a user does not have access to the spend profile. This is now a `UserActionableException` because there is a way for the user to address it: ask an admin to grant them access. This better message should apply regardless of what command the user runs to hit this error (e.g. `workspace create`, `resource create`, etc.).

Previous:
![Screen Shot 2021-11-01 at 11 26 59 AM](https://user-images.githubusercontent.com/12446128/139697020-73a98046-1074-42ef-844a-cde25f20e209.png)

New:
![now](https://user-images.githubusercontent.com/12446128/139696965-bd785bfc-b408-4a06-b1b2-d3f4cce32ba0.png)

