### PR TITLE
PF-1129: Update server names with broad/verily prefix.

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -7,7 +7,7 @@ on:
         required: false
         default: 'true'
       terra_server:
-        description: 'the server to cleanup (e.g. terra-dev)'
+        description: 'the server to cleanup (e.g. broad-dev)'
         required: true
 
 jobs:

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,7 +8,7 @@ jobs:
   tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testServer: [ "terra-dev", "terra-verily-devel" ]
+        testServer: [ "broad-dev", "verily-devel" ]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Run tests
         id: run_tests
         run: |
-          # runs against the default server: terra-dev
+          # runs against the default server: broad-dev
           echo "Running tests with tag: ${{ matrix.testTag }}"
           echo "Using docker image (uses default if blank): $TEST_DOCKER_IMAGE"
           ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} $TEST_DOCKER_IMAGE

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -99,10 +99,10 @@ To grant break-glass access to someone:
       to the server (i.e. WSM deployment) where the workspaces live.
     - One that has permission to update a central BigQuery dataset that tracks break-glass requests.
     - The `tools/render-config.sh` script downloads two SA key files that will work for workspaces
-      on the `verily-cli` server and the central BigQuery dataset in the `terra-cli-dev` project.
+      on the `broad-dev-*` servers and the central BigQuery dataset in the `terra-cli-dev` project.
 3. Run the `terra workspace break-glass` command.
 
-Example commands for granting break-glass access for a workspace in the `verily-cli` deployment:
+Example commands for granting break-glass access for a workspace in the `broad-dev-cli-testing` deployment:
 ```
 ./tools/render-config.sh
 terra auth login # login as yourself, the break-glass granter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,9 +158,9 @@ CLI installation on the same machine.
 `./gradlew runTestsWithTag -PtestTag=unit --tests "unit.Workspace.createFailsWithoutSpendAccess" --info`
 
 #### Override default server
-The tests run against the `terra-dev` server by default. You can run them against a different server
+The tests run against the `broad-dev` server by default. You can run them against a different server
 by specifying the Gradle `server` property. e.g.:
-`./gradlew runTestsWithTag -PtestTag=unit -Pserver=verily-cli`
+`./gradlew runTestsWithTag -PtestTag=unit -Pserver=verily-devel`
 
 #### Override default Docker image
 The tests use the default Docker image by default. This is the image in GCR that corresponds the current version in

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ configuration properties are:
 [logging, console] logging level for printing directly to the terminal = OFF
 [logging, file] logging level for writing to files in /Users/marikomedlock/.terra/logs = INFO
 
-[server] server = terra-verily-devel
+[server] server = verily-devel
 [workspace] workspace = ef8cf0a4-ec70-41be-9fae-9ab6f98cd7e7
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -173,8 +173,8 @@ task runTestsWithTag(type: Test) {
             environment "TERRA_CONTEXT_PARENT_DIR", project.findProperty("contextDir")
         }
 
-        // specify the server to run tests against (e.g. -Pserver=verily-cli). defaults to "terra-dev"
-        String terraServer = project.hasProperty("server") ? project.findProperty("server") : "terra-dev"
+        // specify the server to run tests against (e.g. -Pserver=verily-devel). defaults to "broad-dev"
+        String terraServer = project.hasProperty("server") ? project.findProperty("server") : "broad-dev"
         environment "TERRA_SERVER", terraServer
 
         // specify the Docker image to run tests with (e.g. -PdockerImage=terra-cli/local:b5fdce0). if unspecified, tests use the default Docker image
@@ -211,9 +211,9 @@ task runTestsWithTag(type: Test) {
 
 // cleanup workspaces owned by test users.
 // 1) do a dry run (i.e. don't actually try to delete anything)
-//    ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev -PdryRun
+//    ./gradlew cleanupTestUserWorkspaces -Pserver=broad-dev -PdryRun
 // 2) try to delete each workspace owned by a test user
-//    ./gradlew cleanupTestUserWorkspaces -Pserver=terra-dev
+//    ./gradlew cleanupTestUserWorkspaces -Pserver=broad-dev
 task cleanupTestUserWorkspaces(type: JavaExec) {
     classpath sourceSets.test.runtimeClasspath
     main = "harness.utils.CleanupTestUserWorkspaces"
@@ -223,7 +223,7 @@ task cleanupTestUserWorkspaces(type: JavaExec) {
     environment "TERRA_CONTEXT_PARENT_DIR", "${buildDir}/test-context/"
     mkdir "${project.buildDir}/test-context/"
 
-    // [required] specify the server to cleanup (e.g. -Pserver=terra-dev). no default value, force caller to specify this
+    // [required] specify the server to cleanup (e.g. -Pserver=broad-dev). no default value, force caller to specify this
     systemProperty "TERRA_SERVER", project.findProperty("server")
 
     // [optional] specify that this is a dry run (e.g. -PdryRun)

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -8,6 +8,7 @@ import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.cli.utils.FileUtils;
 import bio.terra.cli.utils.JacksonMapper;
 import bio.terra.datarepo.model.RepositoryStatusModel;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -26,7 +27,7 @@ public class Server {
   private static final Logger logger = LoggerFactory.getLogger(Server.class);
 
   // unique identifier that matches the JSON file name under resources/servers.
-  // (e.g. terra-dev)
+  // (e.g. broad-dev)
   private String name;
 
   // free-form text field that indicates what the server is used for
@@ -41,9 +42,9 @@ public class Server {
   private String wsmDefaultSpendProfile;
   private String dataRepoUri;
 
-  private static final String DEFAULT_SERVER_FILENAME = "verily-cli.json";
-  private static final String RESOURCE_DIRECTORY = "servers";
-  private static final String ALL_SERVERS_FILENAME = "all-servers.json";
+  private static final String DEFAULT_SERVER_FILENAME = "broad-dev-cli-testing.json";
+  @VisibleForTesting public static final String RESOURCE_DIRECTORY = "servers";
+  @VisibleForTesting public static final String ALL_SERVERS_FILENAME = "all-servers.json";
 
   /** Build an instance of this class from the serialized format on disk. */
   public Server(PDServer configFromDisk) {
@@ -141,7 +142,8 @@ public class Server {
    * @param fileName file name
    * @return an instance of this class
    */
-  private static PDServer fromJsonFile(String fileName) {
+  @VisibleForTesting
+  public static PDServer fromJsonFile(String fileName) {
     PDServer server;
     try {
       try {

--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,14 +1,15 @@
 [
-  "jcarlton-dev.json",
-  "localhost.json",
-  "mm-dev.json",
-  "terra-dev.json",
-  "terra-verily.json",
-  "terra-verily-autopush.json",
-  "terra-verily-devel.json",
-  "terra-verily-preprod.json",
-  "terra-verily-staging.json",
-  "verily-cli.json",
-  "wchamber-dev.json",
-  "zloery-dev.json"
+  "broad-dev.json",
+  "broad-dev-cli-testing.json",
+  "broad-dev-jcarlton.json",
+  "broad-dev-local-wsm.json",
+  "broad-dev-local-sam.json",
+  "broad-dev-mmedlock.json",
+  "broad-dev-wchamber.json",
+  "broad-dev-zloery.json",
+  "verily.json",
+  "verily-autopush.json",
+  "verily-devel.json",
+  "verily-preprod.json",
+  "verily-staging.json"
 ]

--- a/src/main/resources/servers/broad-dev-cli-testing.json
+++ b/src/main/resources/servers/broad-dev-cli-testing.json
@@ -1,6 +1,6 @@
 {
-  "name": "verily-cli",
-  "description": "A more stable dev-like environment for development with the CLI.",
+  "name": "broad-dev-cli-testing",
+  "description": "Broad development environment for CLI testing. More stable and updated less frequently than the main development environment.",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev-jcarlton.json
+++ b/src/main/resources/servers/broad-dev-jcarlton.json
@@ -1,9 +1,9 @@
 {
-  "name": "zloery-dev",
-  "description": "(zloery) Personal development environment",
+  "name": "broad-dev-jcarlton",
+  "description": "Broad developer environment (jcarlton)",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.zloery.integ.envs.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.jcarlton.integ.envs.broadinstitute.org",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/broad-dev-local-sam.json
+++ b/src/main/resources/servers/broad-dev-local-sam.json
@@ -1,10 +1,9 @@
 {
-  "name": "localhost",
-  "description": "Local builds of WSM and SAM",
+  "name": "broad-dev-local-sam",
+  "description": "Local SAM and Broad development environment for other services.",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://local.broadinstitute.org:50443",
-  "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://workspace.dsde-dev.broadinstitute.org",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/broad-dev-local-wsm.json
+++ b/src/main/resources/servers/broad-dev-local-wsm.json
@@ -1,9 +1,9 @@
 {
-  "name": "wchamber-dev",
-  "description": "(wchamber) Personal development environment",
+  "name": "broad-dev-local-wsm",
+  "description": "Local WSM and Broad development environment for other services.",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.wchamber.integ.envs.broadinstitute.org",
+  "workspaceManagerUri": "http://localhost:8080",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/broad-dev-mmedlock.json
+++ b/src/main/resources/servers/broad-dev-mmedlock.json
@@ -1,9 +1,9 @@
 {
-  "name": "terra-dev",
-  "description": "Broad dev environment",
+  "name": "broad-dev-mmedlock",
+  "description": "Broad developer environment (mmedlock)",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.dsde-dev.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.mmedlock.integ.envs.broadinstitute.org",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/broad-dev-wchamber.json
+++ b/src/main/resources/servers/broad-dev-wchamber.json
@@ -1,0 +1,9 @@
+{
+  "name": "broad-dev-wchamber",
+  "description": "Broad developer environment (wchamber)",
+
+  "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.wchamber.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
+}

--- a/src/main/resources/servers/broad-dev-zloery.json
+++ b/src/main/resources/servers/broad-dev-zloery.json
@@ -1,9 +1,9 @@
 {
-  "name": "mm-dev",
-  "description": "(mmedlock) Personal development environment",
+  "name": "broad-dev-zloery",
+  "description": "Broad developer environment (zloery)",
 
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.mmedlock.integ.envs.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.zloery.integ.envs.broadinstitute.org",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/broad-dev.json
+++ b/src/main/resources/servers/broad-dev.json
@@ -1,8 +1,9 @@
 {
-  "name": "jcarlton-dev",
-  "description": "(jcarlton) Personal development environment",
+  "name": "broad-dev",
+  "description": "Broad main development environment",
+
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
   "samUri": "https://sam.dsde-dev.broadinstitute.org",
-  "workspaceManagerUri": "https://workspace.jcarlton.integ.envs.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.dsde-dev.broadinstitute.org",
   "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/verily-autopush.json
+++ b/src/main/resources/servers/verily-autopush.json
@@ -1,6 +1,6 @@
 {
-  "name": "terra-verily-autopush",
-  "description": "Verily autopush environment",
+  "name": "verily-autopush",
+  "description": "Verily auto-push environment",
 
   "samUri": "https://terra-autopush-sam.api.verily.com",
   "samInviteRequiresAdmin": true,

--- a/src/main/resources/servers/verily-devel.json
+++ b/src/main/resources/servers/verily-devel.json
@@ -1,5 +1,5 @@
 {
-  "name": "terra-verily-devel",
+  "name": "verily-devel",
   "description": "Verily devel environment",
 
   "samUri": "https://terra-devel-sam.api.verily.com",

--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -1,6 +1,6 @@
 {
-  "name": "terra-verily-preprod",
-  "description": "Verily preprod environment",
+  "name": "verily-preprod",
+  "description": "Verily pre-prod environment",
 
   "samUri": "https://terra-preprod-sam.api.verily.com",
   "samInviteRequiresAdmin": true,

--- a/src/main/resources/servers/verily-staging.json
+++ b/src/main/resources/servers/verily-staging.json
@@ -1,5 +1,5 @@
 {
-  "name": "terra-verily-staging",
+  "name": "verily-staging",
   "description": "Verily staging environment",
 
   "samUri": "https://terra-staging-sam.api.verily.com",

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -1,5 +1,5 @@
 {
-  "name": "terra-verily",
+  "name": "verily",
   "description": "Verily production environment",
 
   "samUri": "https://terra-sam.api.verily.com",

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -94,29 +94,29 @@ public class Config extends SingleWorkspaceUnit {
   @Test
   @DisplayName("config server set and server set are equivalent")
   void server() throws IOException {
-    // `terra server set --name=terra-verily-devel`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=terra-verily-devel", "--quiet");
+    // `terra server set --name=verily-devel`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=verily-devel", "--quiet");
 
     // `terra config get server`
     UFServer getValue =
         TestCommand.runAndParseCommandExpectSuccess(UFServer.class, "config", "get", "server");
-    assertEquals("terra-verily-devel", getValue.name, "server set affects config get");
+    assertEquals("verily-devel", getValue.name, "server set affects config get");
 
     // `terra config list`
     UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals("terra-verily-devel", config.serverName, "server set affects config list");
+    assertEquals("verily-devel", config.serverName, "server set affects config list");
 
-    // `terra config set server --name=terra-dev`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=terra-dev", "--quiet");
+    // `terra config set server --name=broad-dev`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev", "--quiet");
 
     // `terra config get server`
     getValue =
         TestCommand.runAndParseCommandExpectSuccess(UFServer.class, "config", "get", "server");
-    assertEquals("terra-dev", getValue.name, "config set server affects config get");
+    assertEquals("broad-dev", getValue.name, "config set server affects config get");
 
     // `terra config list`
     config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals("terra-dev", config.serverName, "config set server affects config list");
+    assertEquals("broad-dev", config.serverName, "config set server affects config list");
   }
 
   @Test

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -1,20 +1,27 @@
 package unit;
 
+import static bio.terra.cli.businessobject.Server.ALL_SERVERS_FILENAME;
+import static bio.terra.cli.businessobject.Server.RESOURCE_DIRECTORY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.cli.serialization.persisted.PDServer;
 import bio.terra.cli.serialization.userfacing.UFAuthStatus;
 import bio.terra.cli.serialization.userfacing.UFStatus;
+import bio.terra.cli.utils.FileUtils;
+import bio.terra.cli.utils.JacksonMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnit;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -36,7 +43,7 @@ public class Server extends SingleWorkspaceUnit {
   @DisplayName("status, server list reflect server set")
   void statusListReflectSet() throws JsonProcessingException {
     // `terra server set --name=$serverName1`
-    String serverName1 = "terra-verily-devel";
+    String serverName1 = "verily-devel";
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName1, "--quiet");
 
     // `terra status`
@@ -50,14 +57,14 @@ public class Server extends SingleWorkspaceUnit {
     TestCommand.Result cmd = TestCommand.runCommand("server", "list");
     assertEquals(0, cmd.exitCode, "server list returned successfully");
     // the regex below matches the starred server, which indicates it's the current one (e.g. " *
-    // terra-dev")
+    // broad-dev")
     String asteriskAtStartOfLine = "(?s).*\\*\\s+";
     assertTrue(
         cmd.stdOut.matches(asteriskAtStartOfLine + serverName1 + ".*"),
         "server list flags correct current server (1)");
 
     // `terra server set --name=$serverName2`
-    String serverName2 = "terra-dev";
+    String serverName2 = "broad-dev";
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName2, "--quiet");
 
     // `terra status`
@@ -90,8 +97,8 @@ public class Server extends SingleWorkspaceUnit {
         TestCommand.runAndParseCommandExpectSuccess(String.class, "server", "status");
     assertEquals("ERROR CONNECTING", statusMsg, "server status returns error");
 
-    // `terra server set --name=terra-dev`
-    String serverName = "terra-dev";
+    // `terra server set --name=broad-dev`
+    String serverName = "broad-dev";
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName, "--quiet");
 
     // `terra status`
@@ -127,8 +134,8 @@ public class Server extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra server set --name=verily-cli --quiet`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=verily-cli", "--quiet");
+    // `terra server set --name=broad-dev-cli-testing --quiet`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev-cli-testing", "--quiet");
 
     // `terra auth status --format=json`
     UFAuthStatus authStatus =
@@ -138,10 +145,10 @@ public class Server extends SingleWorkspaceUnit {
     // `terra status --format=json`
     UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");
     assertNull(status.workspace, "status indicates workspace is unset");
-    assertEquals("verily-cli", status.server.name, "status indicates server is changed");
+    assertEquals("broad-dev-cli-testing", status.server.name, "status indicates server is changed");
 
-    // `terra server set --name=terra-dev`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=terra-dev");
+    // `terra server set --name=broad-dev`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev");
     // now that the auth and workspace context are cleared, we shouldn't need the --quiet flag
     // anymore
   }
@@ -154,13 +161,30 @@ public class Server extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
-    // `terra server set --name=verily-cli --quiet`
+    // `terra server set --name=broad-dev-cli-testing --quiet`
     ByteArrayInputStream stdIn = new ByteArrayInputStream("NO".getBytes(StandardCharsets.UTF_8));
-    TestCommand.Result cmd = TestCommand.runCommand(stdIn, "server", "set", "--name=verily-cli");
+    TestCommand.Result cmd =
+        TestCommand.runCommand(stdIn, "server", "set", "--name=broad-dev-cli-testing");
     assertEquals(1, cmd.exitCode, "server set command threw a user actionable exception");
     assertThat(
         "output message says the server switch was aborted",
         cmd.stdErr,
         CoreMatchers.containsString("Switching server aborted"));
+  }
+
+  @Test
+  @DisplayName("server names match json file names")
+  void serverNamesMatchFileNames() throws IOException {
+    // read in the list of servers file
+    InputStream inputStream =
+        FileUtils.getResourceFileHandle(RESOURCE_DIRECTORY + "/" + ALL_SERVERS_FILENAME);
+    List<String> allServerFileNames = JacksonMapper.getMapper().readValue(inputStream, List.class);
+
+    // loop through the file names, reading in from JSON
+    for (String serverFileName : allServerFileNames) {
+      PDServer pdServer = bio.terra.cli.businessobject.Server.fromJsonFile(serverFileName);
+
+      assertEquals(serverFileName, pdServer.name + ".json", "server name matches file name");
+    }
   }
 }


### PR DESCRIPTION
Changed all server names to include a prefix (`broad` or `verily`) to indicate where the deployment lives.

The server list has grown over time and there was no consistent naming strategy. This may be causing some confusion lately about which environment we're talking about (especially between the Broad and Verily development environments).
