### PR TITLE
[PF-1103] delete empty workspace when creating cloud context fails

### DIFF
--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -251,8 +251,10 @@ public class WorkspaceManagerService {
               deleteWorkspace(workspaceId);
               workspaceSuccessfullyDeleted = true;
             } catch (RuntimeException ex) {
-              logger.error("Failed to delete workspace {} when cleaning up failed creation of cloud context. ",
-                  workspaceId, ex);
+              logger.error(
+                  "Failed to delete workspace {} when cleaning up failed creation of cloud context. ",
+                  workspaceId,
+                  ex);
             }
             // if this is a spend profile access denied error, then throw a more user-friendly error
             // message
@@ -261,10 +263,14 @@ public class WorkspaceManagerService {
                     == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
               final String errorMessage;
               if (workspaceSuccessfullyDeleted) {
-                errorMessage = "Accessing the spend profile failed. Ask an administrator to grant you access.";
+                errorMessage =
+                    "Accessing the spend profile failed. Ask an administrator to grant you access.";
               } else {
-                errorMessage = String.format("Accessing the spend profile failed. Ask an administrator to grant you access. "
-                + "There was a problem cleaning up the partially created workspace ID %s", workspaceId);
+                errorMessage =
+                    String.format(
+                        "Accessing the spend profile failed. Ask an administrator to grant you access. "
+                            + "There was a problem cleaning up the partially created workspace ID %s",
+                        workspaceId);
               }
               throw new UserActionableException(errorMessage);
             }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -250,9 +250,9 @@ public class WorkspaceManagerService {
             try {
               deleteWorkspace(workspaceId);
               workspaceSuccessfullyDeleted = true;
-            } catch (SystemException ex) {
-              logger.error("Failed to delete workspace {} when cleaning up failed creation of cloud context. "
-                  + "Exception: {}", workspaceApi, ex.getMessage());
+            } catch (RuntimeException ex) {
+              logger.error("Failed to delete workspace {} when cleaning up failed creation of cloud context. ",
+                  workspaceId, ex);
             }
             // if this is a spend profile access denied error, then throw a more user-friendly error
             // message
@@ -264,8 +264,7 @@ public class WorkspaceManagerService {
                 errorMessage = "Accessing the spend profile failed. Ask an administrator to grant you access.";
               } else {
                 errorMessage = String.format("Accessing the spend profile failed. Ask an administrator to grant you access. "
-                + "Additionally, there was a problem cleaning up the workspace, and now workspace ID %s is left behind "
-                + "but won't function.", workspaceId);
+                + "There was a problem cleaning up the partially created workspace ID %s", workspaceId);
               }
               throw new UserActionableException(errorMessage);
             }

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -3,6 +3,7 @@ package unit;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -250,14 +251,21 @@ public class Workspace extends ClearContextUnit {
     // select a test user and login
     TestUsers testUser = TestUsers.chooseTestUserWithoutSpendAccess();
     testUser.login();
-
+    final String workspaceName = "bad-profile-6789";
     // `terra workspace create`
-    String stdErr = TestCommand.runCommandExpectExitCode(1, "workspace", "create");
+    String stdErr =
+        TestCommand.runCommandExpectExitCode(1, "workspace", "create", "--name=" + workspaceName);
     assertThat(
         "error message includes spend profile unauthorized",
         stdErr,
         CoreMatchers.containsString(
             "Accessing the spend profile failed. Ask an administrator to grant you access."));
+
+    // workspace was deleted
+    List<UFWorkspace> listWorkspaces =
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "workspace", "list", "--limit=100");
+    assertFalse(listWorkspaces.stream().anyMatch(w -> workspaceName.equals(w.name)));
   }
 
   @Test


### PR DESCRIPTION
Previously, when context creation failed, we simply aborted the operation, leaving a new stub workspace in the database. With this change, we'll delete such workspaces in this scenario.