### PR TITLE
[PF-1075] use case-insensitive enum flag

### DIFF
--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -71,6 +71,7 @@ public class Main implements Runnable {
     cmd.setExecutionStrategy(new CommandLine.RunLast());
     cmd.setExecutionExceptionHandler(new UserActionableAndSystemExceptionHandler());
     cmd.setColorScheme(colorScheme);
+    cmd.setCaseInsensitiveEnumValuesAllowed(true);
 
     // set the output and error streams to the defaults: stdout, stderr
     // save pointers to these streams in a singleton class, so we can access them throughout the

--- a/src/test/java/unit/Syntax.java
+++ b/src/test/java/unit/Syntax.java
@@ -1,0 +1,41 @@
+package unit;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import harness.TestCommand;
+import harness.TestCommand.Result;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for syntax variations */
+@Tag("unit")
+public class Syntax {
+
+  @Test
+  @DisplayName("format options are accepted in any case")
+  void formatOptions() {
+    Result resultLowercase = TestCommand.runCommand("status", "--format=json");
+    assertThat(resultLowercase.stdOut, containsString("\"workspace\" :"));
+
+    Result resultUppercase = TestCommand.runCommand("status", "--format=JSON");
+    assertThat(resultUppercase.stdOut, containsString("\"workspace\" :"));
+
+    Result resultMixed = TestCommand.runCommand("status", "--format=jSON");
+    assertThat(resultMixed.stdOut, containsString("\"workspace\" :"));
+  }
+
+  @Test
+  @DisplayName("config value enums are accepted in any case")
+  void configOptions() {
+    Result resultLowercase = TestCommand.runCommand("config", "set", "browser", "manual");
+    assertThat(resultLowercase.stdOut, containsString("Browser launch mode for login is MANUAL"));
+
+    Result resultUppercase = TestCommand.runCommand("config", "set", "browser", "MANUAL");
+    assertThat(resultUppercase.stdOut, containsString("Browser launch mode for login is MANUAL"));
+
+    Result resultMixed = TestCommand.runCommand("config", "set", "browser", "mAnual");
+    assertThat(resultMixed.stdOut, containsString("Browser launch mode for login is MANUAL"));
+  }
+}

--- a/src/test/java/unit/Syntax.java
+++ b/src/test/java/unit/Syntax.java
@@ -5,13 +5,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import harness.TestCommand;
 import harness.TestCommand.Result;
+import harness.baseclasses.ClearContextUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Tests for syntax variations */
 @Tag("unit")
-public class Syntax {
+public class Syntax extends ClearContextUnit {
 
   @Test
   @DisplayName("format options are accepted in any case")

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -136,10 +136,11 @@ public class Workspace extends ClearContextUnit {
     // `terra workspace create --format=json --name=$newName --description=$newDescription`
     String newName = "NEW_statusDescribeListReflectUpdate";
     String newDescription = "NEW status describe list reflect update";
+    // verify mixed case enum works
     TestCommand.runCommandExpectSuccess(
         "workspace",
         "update",
-        "--format=json",
+        "--format=jSON",
         "--name=" + newName,
         "--description=" + newDescription);
 

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -136,11 +136,10 @@ public class Workspace extends ClearContextUnit {
     // `terra workspace create --format=json --name=$newName --description=$newDescription`
     String newName = "NEW_statusDescribeListReflectUpdate";
     String newDescription = "NEW status describe list reflect update";
-    // verify mixed case enum works
     TestCommand.runCommandExpectSuccess(
         "workspace",
         "update",
-        "--format=jSON",
+        "--format=json",
         "--name=" + newName,
         "--description=" + newDescription);
 


### PR DESCRIPTION
Allow any case enum options, e.g. `terra workspace list --format=JSon`