### PR TITLE
PF-1219: Remove location parameter from workspace clone command.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -274,14 +274,11 @@ public class Workspace {
    *
    * @param name - name of the new workspace
    * @param description - description of the new workspace
-   * @param location - location for resources in the new workspace
    * @return - ClonedWorkspace structure with details on each resource
    */
-  public ClonedWorkspace clone(
-      @Nullable String name, @Nullable String description, @Nullable String location) {
+  public ClonedWorkspace clone(@Nullable String name, @Nullable String description) {
     CloneWorkspaceResult result =
-        WorkspaceManagerService.fromContextForPetSa()
-            .cloneWorkspace(id, name, description, location);
+        WorkspaceManagerService.fromContextForPetSa().cloneWorkspace(id, name, description);
     return result.getWorkspace();
   }
 

--- a/src/main/java/bio/terra/cli/command/workspace/Clone.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Clone.java
@@ -22,12 +22,6 @@ import picocli.CommandLine.Command;
 @Command(name = "clone", description = "Clone an existing workspace.")
 public class Clone extends BaseCommand {
 
-  @CommandLine.Option(
-      names = "--location",
-      required = false,
-      description = "Location for newly created resources.")
-  private String location;
-
   @CommandLine.Mixin private WorkspaceNameAndDescription workspaceNameAndDescription;
 
   @CommandLine.Mixin private Format formatOption;
@@ -41,9 +35,7 @@ public class Clone extends BaseCommand {
 
     ClonedWorkspace clonedWorkspace =
         sourceWorkspace.clone(
-            workspaceNameAndDescription.displayName,
-            workspaceNameAndDescription.description,
-            location);
+            workspaceNameAndDescription.displayName, workspaceNameAndDescription.description);
     Workspace destinationWorkspaceHydrated =
         Workspace.get(clonedWorkspace.getDestinationWorkspaceId());
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -331,20 +331,17 @@ public class WorkspaceManagerService {
    * @param workspaceId - workspace ID to clone
    * @param displayName - optional name of new cloned workspace
    * @param description - optional description for new workspace
-   * @param location - optional location for workspace resources
    * @return object with information about the clone job success and destination workspace
    */
   public CloneWorkspaceResult cloneWorkspace(
-      UUID workspaceId,
-      @Nullable String displayName,
-      @Nullable String description,
-      @Nullable String location) {
+      UUID workspaceId, @Nullable String displayName, @Nullable String description) {
     var request =
         new CloneWorkspaceRequest()
             .spendProfile(Context.getServer().getWsmDefaultSpendProfile())
             .displayName(displayName)
             .description(description)
-            .location(location);
+            // force location to null until we have an implementation of a workspace-wide location
+            .location(null);
     WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);
     CloneWorkspaceResult initialResult =
         callWithRetries(


### PR DESCRIPTION
Per discussion in stand-up on 11/22/21, removed the location parameter from the workspace clone command in the CLI because it's not fully implemented in WSM. The intent of this parameter was to provide an override location for the cloned resources. However, each resource type has a different set of possible location values. There is no single concept of location in GCP. We expect that we'll want a concept of workspace location, both for cloning and for a default location. We will hold off exposing this parameter in the CLI workspace clone command until we have this concept implemented in WSM.

Note that the location parameter still makes sense for cloning individual resources, but the CLI does not expose those WSM endpoints -- only the full workspace clone.