### PR TITLE
PF-1224: Remove private resource email and iam roles options.

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
@@ -36,7 +36,6 @@ public class BqDataset extends BaseCommand {
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    controlledResourceCreationOptions.validateAccessOptions();
 
     // build the resource object to create
     CreateResourceParams.Builder createResourceParams =

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -10,13 +10,11 @@ import bio.terra.cli.serialization.userfacing.input.CreateGcpNotebookParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGcpNotebook;
 import bio.terra.workspace.model.AccessScope;
-import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.StewardshipType;
 import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import picocli.CommandLine;
@@ -237,13 +235,7 @@ public class GcpNotebook extends BaseCommand {
         resourceCreationOptions
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
-            .accessScope(AccessScope.PRIVATE_ACCESS)
-            .privateUserName(Context.requireUser().getEmail())
-            .privateUserRoles(
-                List.of(
-                    ControlledResourceIamRole.EDITOR,
-                    ControlledResourceIamRole.WRITER,
-                    ControlledResourceIamRole.READER));
+            .accessScope(AccessScope.PRIVATE_ACCESS);
     CreateGcpNotebookParams.Builder createParams =
         new CreateGcpNotebookParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
@@ -43,7 +43,6 @@ public class GcsBucket extends BaseCommand {
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    controlledResourceCreationOptions.validateAccessOptions();
 
     // build the resource object to create
     CreateResourceParams.Builder createResourceParams =

--- a/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
@@ -1,15 +1,12 @@
 package bio.terra.cli.command.shared.options;
 
-import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.workspace.model.AccessScope;
-import bio.terra.workspace.model.ControlledResourceIamRole;
-import java.util.List;
 import picocli.CommandLine;
 
 /**
  * Command helper class that defines the relevant options for create a new controlled Terra
- * resource: {@link ResourceCreation} and --access, --email, --iam-roles.
+ * resource: {@link ResourceCreation} and --access.
  *
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
@@ -21,41 +18,11 @@ public class ControlledResourceCreation {
       description = "Access scope for the resource: ${COMPLETION-CANDIDATES}.")
   public AccessScope access = AccessScope.SHARED_ACCESS;
 
-  @CommandLine.Option(
-      names = "--email",
-      description = "[PRIVATE ACCESS ONLY] Email address for user of private resource.")
-  public String privateUserEmail;
-
-  @CommandLine.Option(
-      names = "--iam-roles",
-      split = ",",
-      description =
-          "[PRIVATE ACCESS ONLY] IAM roles to grant user of private resource: ${COMPLETION-CANDIDATES}.")
-  public List<ControlledResourceIamRole> privateIamRoles;
-
-  /** Helper method to validate conditional required options. */
-  public void validateAccessOptions() {
-    if (access.equals(AccessScope.PRIVATE_ACCESS)) {
-      if (privateUserEmail == null || privateUserEmail.isEmpty()) {
-        throw new UserActionableException(
-            "An email address (--email) is required for private resources.");
-      }
-      if (privateIamRoles == null || privateIamRoles.isEmpty()) {
-        throw new UserActionableException(
-            "IAM roles (--iam-roles) are required for private resources.");
-      }
-    }
-  }
-
   /**
    * Helper method to return a {@link CreateResourceParams.Builder} with the controlled resource
    * metadata fields populated.
    */
   public CreateResourceParams.Builder populateMetadataFields() {
-    return resourceCreationOption
-        .populateMetadataFields()
-        .accessScope(access)
-        .privateUserName(privateUserEmail)
-        .privateUserRoles(privateIamRoles);
+    return resourceCreationOption.populateMetadataFields().accessScope(access);
   }
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/input/CreateResourceParams.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/input/CreateResourceParams.java
@@ -2,13 +2,11 @@ package bio.terra.cli.serialization.userfacing.input;
 
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
-import bio.terra.workspace.model.ControlledResourceIamRole;
 import bio.terra.workspace.model.ResourceType;
 import bio.terra.workspace.model.StewardshipType;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import java.util.List;
 
 /**
  * Parameters for creating a workspace resource. This class is not currently user-facing, but could
@@ -25,8 +23,6 @@ public class CreateResourceParams {
   public final StewardshipType stewardshipType;
   public final CloningInstructionsEnum cloningInstructions;
   public final AccessScope accessScope;
-  public final String privateUserName;
-  public final List<ControlledResourceIamRole> privateUserRoles;
 
   protected CreateResourceParams(Builder builder) {
     this.name = builder.name;
@@ -35,8 +31,6 @@ public class CreateResourceParams {
     this.stewardshipType = builder.stewardshipType;
     this.cloningInstructions = builder.cloningInstructions;
     this.accessScope = builder.accessScope;
-    this.privateUserName = builder.privateUserName;
-    this.privateUserRoles = builder.privateUserRoles;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -47,8 +41,6 @@ public class CreateResourceParams {
     private StewardshipType stewardshipType;
     private CloningInstructionsEnum cloningInstructions;
     private AccessScope accessScope;
-    private String privateUserName;
-    private List<ControlledResourceIamRole> privateUserRoles;
 
     public Builder name(String name) {
       this.name = name;
@@ -77,16 +69,6 @@ public class CreateResourceParams {
 
     public Builder accessScope(AccessScope accessScope) {
       this.accessScope = accessScope;
-      return this;
-    }
-
-    public Builder privateUserName(String privateUserName) {
-      this.privateUserName = privateUserName;
-      return this;
-    }
-
-    public Builder privateUserRoles(List<ControlledResourceIamRole> privateUserRoles) {
-      this.privateUserRoles = privateUserRoles;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -63,8 +63,6 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.JobReport.StatusEnum;
 import bio.terra.workspace.model.ManagedBy;
-import bio.terra.workspace.model.PrivateResourceIamRoles;
-import bio.terra.workspace.model.PrivateResourceUser;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceList;
@@ -783,19 +781,11 @@ public class WorkspaceManagerService {
    */
   private static ControlledResourceCommonFields createCommonFields(
       CreateResourceParams createParams) {
-    PrivateResourceIamRoles privateResourceIamRoles = new PrivateResourceIamRoles();
-    if (createParams.privateUserRoles != null) {
-      privateResourceIamRoles.addAll(createParams.privateUserRoles);
-    }
     return new ControlledResourceCommonFields()
         .name(createParams.name)
         .description(createParams.description)
         .cloningInstructions(createParams.cloningInstructions)
         .accessScope(createParams.accessScope)
-        .privateResourceUser(
-            new PrivateResourceUser()
-                .userName(createParams.privateUserName)
-                .privateResourceIamRoles(privateResourceIamRoles))
         .managedBy(ManagedBy.USER);
   }
 

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.workspace.model.AccessScope;
@@ -186,14 +185,12 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
             UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
 
     // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId --access=$access
-    // --cloning=$cloning --description=$description --email=$email --iam-roles=$iamRole
-    // --location=$location --format=json`
+    // --cloning=$cloning --description=$description --location=$location --format=json`
     String name = "createWithAllOptions";
     String datasetId = randomDatasetId();
     AccessScope access = AccessScope.PRIVATE_ACCESS;
     CloningInstructionsEnum cloning = CloningInstructionsEnum.DEFINITION;
     String description = "\"create with all options\"";
-    WorkspaceUser.Role role = WorkspaceUser.Role.READER;
     String location = "us-east1";
     UFBqDataset createdDataset =
         TestCommand.runAndParseCommandExpectSuccess(
@@ -206,8 +203,6 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
             "--access=" + access,
             "--cloning=" + cloning,
             "--description=" + description,
-            "--email=" + workspaceCreator.email,
-            "--iam-roles=" + role,
             "--location=" + location);
 
     // check that the properties match

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import bio.terra.cli.businessobject.WorkspaceUser;
 import bio.terra.cli.serialization.userfacing.input.GcsStorageClass;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.workspace.model.AccessScope;
@@ -161,14 +160,13 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
     // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --access=$access
-    // --cloning=$cloning --description=$description --email=$email --iam-roles=$iamRole
-    // --location=$location --storage=$storage --format=json`
+    // --cloning=$cloning --description=$description --location=$location --storage=$storage
+    // --format=json`
     String name = "createWithAllOptionsExceptLifecycle";
     String bucketName = UUID.randomUUID().toString();
     AccessScope access = AccessScope.PRIVATE_ACCESS;
     CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
     String description = "\"create with all options except lifecycle\"";
-    WorkspaceUser.Role role = WorkspaceUser.Role.WRITER;
     String location = "US";
     GcsStorageClass storage = GcsStorageClass.NEARLINE;
     UFGcsBucket createdBucket =
@@ -182,8 +180,6 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
             "--access=" + access,
             "--cloning=" + cloning,
             "--description=" + description,
-            "--email=" + workspaceCreator.email,
-            "--iam-roles=" + role,
             "--location=" + location,
             "--storage=" + storage);
 


### PR DESCRIPTION
For controlled BQ datasets and GCS buckets, users can create a private resource, instead of a shared one. Previously, the CLI exposed two WSM parameters for setting the email of the private resource user and which roles they should have. WSM no longer supports these things, so we need to stop specifying them in order for controlled resource creation to succeed again.