### PR TITLE
PF-1237: Pull NF Tower env vars from host if defined.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@
     * [Override default Docker image](#override-default-docker-image)
     * [Override context directory](#override-context-directory)
     * [Setup test users](#setup-test-users)
+    * [Automated tests](#automated-tests)
 4. [Docker](#docker)
     * [Pull an existing image](#pull-an-existing-image)
     * [Build a new image](#build-a-new-image)
@@ -218,6 +219,22 @@ invites all the test users if they do not already exist in SAM, and this require
 
 You can see the available test users on the users admin [page](https://admin.google.com/ac/users) with a
 `test.firecloud.org` GSuite account.
+
+#### Automated tests
+All unit and integration tests are run nightly via GitHub action against two environments: `broad-dev` and
+`verily-devel`. On test completion, a Slack notification is sent to the Broad `#platform-foundation-alerts` channel.
+If you kick off a full test run manually, it will not send a notification.
+
+Running the tests locally on your machine and via GitHub actions uses the same set of test users. While the nightly CLI
+tests should not leak resources (e.g. workspaces, SAM groups), this often happens when debugging something locally.
+There is a GitHub action specifically for cleaning up these leaked resources. It can be triggered manually from the
+GitHub repo UI. There is an option to run the cleanup in `dry-run` mode, which should show whether there are any leaked
+resources without actually deleting them.
+
+Some tests may start failing once the number of leaked resources gets too high. Usually, this is a
+`terra workspace list` test that does not page through more than ~30 workspaces. We could fix this test to be more
+resilient, but it's been a useful reminder to kick off the cleanup GitHub action, so we haven't done that yet. If
+you see unexpected failures around listing workspaces, try kicking off the cleanup action and re-running.
 
 ### Docker
 The `docker/` directory contains files required to build the Docker image.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ we just created.
     terra nextflow run rnaseq-nf/main.nf -profile gls
     ```
 
+- To send metrics about the workflow run to a Nextflow Tower server, first define an environment variable with the Tower
+access token. Then specify the `-with-tower` flag when kicking off the workflow.
+    ```
+    export TOWER_ACCESS_TOKEN=*****
+    terra nextflow run hello -with-tower
+    terra nextflow run rnaseq-nf/main.nf -profile gls -with-tower
+    ```
+
 - Call the Gcloud CLI tools in the current workspace context.
 This means that Gcloud is configured with the backing Google project and environment variables are defined that
 contain workspace and resource properties (e.g. bucket names, pet service account email).

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Nextflow.java
@@ -24,6 +24,15 @@ public class Nextflow extends BaseCommand {
     command.add(0, "nextflow");
     Map<String, String> envVars = new HashMap<>();
     envVars.put("NXF_MODE", "google");
+    addEnvVarIfDefinedInHost("TOWER_ACCESS_TOKEN", envVars);
+    addEnvVarIfDefinedInHost("TOWER_WORKSPACE_ID", envVars);
     Context.getConfig().getCommandRunnerOption().getRunner().runToolCommand(command, envVars);
+  }
+
+  private void addEnvVarIfDefinedInHost(String envVarName, Map<String, String> envVars) {
+    String envVarValue = System.getenv(envVarName);
+    if (envVarValue != null && !envVars.isEmpty()) {
+      envVars.put(envVarName, envVarValue);
+    }
   }
 }


### PR DESCRIPTION
Added instruction for sending workflow run metrics to a Nextflow Tower instance.

Pulled the Nextflow Tower related environment variables into the Docker container if they are defined on the host machine.

Unrelatedly, also added a section to `CONTRIBUTING.md` about automated tests.