### PR TITLE
PF-1233: Point to CLI README upon login completion.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -72,6 +72,13 @@ public class User {
   // (https://developers.google.com/adwords/api/docs/guides/authentication#create_a_client_id_and_client_secret)
   private static final String CLIENT_SECRET_FILENAME = "client_secret.json";
 
+  // URL of the landing page shown in the browser after completing the OAuth part of login
+  // ideally this should point to product documentation or perhaps the UI, but for now the CLI
+  // README seems like the best option. in the future, if we want to make this server-specific, then
+  // it should become a property of the Server
+  private static final String LOGIN_LANDING_PAGE =
+      "https://github.com/DataBiosphere/terra-cli/blob/main/README.md";
+
   /** Build an instance of this class from the serialized format on disk. */
   public User(PDUser configFromDisk) {
     this.id = configFromDisk.id;
@@ -275,7 +282,8 @@ public class User {
               USER_SCOPES,
               inputStream,
               Context.getContextDir().toFile(),
-              launchBrowserAutomatically);
+              launchBrowserAutomatically,
+              LOGIN_LANDING_PAGE);
     } catch (IOException | GeneralSecurityException ex) {
       throw new SystemException("Error fetching user credentials.", ex);
     }

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -55,13 +55,15 @@ public final class GoogleOauth {
    * @param launchBrowserAutomatically true to launch a browser automatically and listen on a local
    *     server for the token response, false to print the url to stdout and ask the user to
    *     copy/paste the token response to stdin
+   * @param loginLandingPage URL of the page to load in the browser upon completion of login
    * @return credentials object for the user
    */
   public static UserCredentials doLoginAndConsent(
       List<String> scopes,
       InputStream clientSecretFile,
       File dataStoreDir,
-      boolean launchBrowserAutomatically)
+      boolean launchBrowserAutomatically,
+      String loginLandingPage)
       throws IOException, GeneralSecurityException {
     // load client_secret.json file
     GoogleClientSecrets clientSecrets =
@@ -75,7 +77,10 @@ public final class GoogleOauth {
     Credential credential;
     if (launchBrowserAutomatically) {
       // launch a browser window on this machine and listen on a local port for the token response
-      LocalServerReceiver receiver = new LocalServerReceiver.Builder().build();
+      LocalServerReceiver receiver =
+          new LocalServerReceiver.Builder()
+              .setLandingPages(loginLandingPage, loginLandingPage)
+              .build();
       credential =
           new AuthorizationCodeInstalledApp(flow, receiver).authorize(CREDENTIAL_STORE_KEY);
     } else {


### PR DESCRIPTION
Replace the default landing page shown in the browser upon completing the OAuth login flow.
![Screen Shot 2021-12-09 at 10 01 08 AM](https://user-images.githubusercontent.com/12446128/145420691-2185b1a9-228a-4d4a-8179-55c0643a54dc.png)

Now it loads the CLI README page instead. Note that this behavior change only applies when the `browser` config property is set to `AUTO` (which launches a browser window on the current computer), not `MANUAL` (which prints a URL for the user to open in a browser themselves).
