### PR TITLE
Remove stored credentials if login fails

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -132,9 +132,9 @@ public class User {
     if (currentUser.isEmpty()) {
       try {
         user.fetchUserInfo();
-      } catch (SystemException sysEx) {
+      } catch (Exception exception) {
         user.deleteOauthCredentials();
-        throw sysEx;
+        throw exception;
       }
 
       // update the global context on disk


### PR DESCRIPTION
Previously some classes of exceptions would result in credentials being
left in local storage, meaning subsequent login attempts would not
re-prompt to select an account.  This widens the catch to delete
credentials on any kind of exception.