### PR TITLE
PF-1092, PF-1094, PF-1095, PF-1098: Minor text output string changes for auth commands.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -257,6 +257,8 @@ public class User {
       throw new SystemException(
           "Failed to delete pet SA key file sub-directory: " + jsonKeysDir.getAbsolutePath());
     }
+
+    this.petSAEmail = null;
   }
 
   /**

--- a/src/main/java/bio/terra/cli/command/auth/Revoke.java
+++ b/src/main/java/bio/terra/cli/command/auth/Revoke.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command.auth;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.User;
 import bio.terra.cli.command.shared.BaseCommand;
 import picocli.CommandLine.Command;
 
@@ -12,8 +11,12 @@ public class Revoke extends BaseCommand {
   /** Logout the user and print out a success message. */
   @Override
   protected void execute() {
-    Context.getUser().ifPresent(User::logout);
-    OUT.println("Logout successful.");
+    if (Context.getUser().isPresent()) {
+      Context.requireUser().logout();
+      OUT.println("Logout successful.");
+    } else {
+      OUT.println("No user logged in.");
+    }
   }
 
   /** This command never requires login. */

--- a/src/main/java/bio/terra/cli/command/auth/Status.java
+++ b/src/main/java/bio/terra/cli/command/auth/Status.java
@@ -44,12 +44,15 @@ public class Status extends BaseCommand {
   private void printText(UFAuthStatus returnValue) {
     // check if current user is defined
     if (returnValue.userEmail == null) {
-      OUT.println("No current Terra user defined.");
+      OUT.println("NO USER LOGGED IN");
     } else {
-      OUT.println("Current user: " + returnValue.userEmail);
-      OUT.println("Proxy group for current user: " + returnValue.proxyGroupEmail);
+      OUT.println("User email: " + returnValue.userEmail);
+      OUT.println("Proxy group email: " + returnValue.proxyGroupEmail);
       OUT.println(
-          "Service account for current user and workspace: " + returnValue.serviceAccountEmail);
+          "Service account email for current workspace: "
+              + (returnValue.serviceAccountEmail == null
+                  ? "(undefined)"
+                  : returnValue.serviceAccountEmail));
 
       // check if the current user needs to re-authenticate (i.e. is logged out)
       OUT.println("LOGGED " + (returnValue.loggedIn ? "IN" : "OUT"));


### PR DESCRIPTION
Several small text output string changes for the `auth status` and `auth revoke` commands. One bug fix for the pet SA email not getting cleared in the locally stored context when deleting the current workspace.

- PF-1092: In `terra auth status` text output, change "No current Terra user defined" -> "NO USER LOGGED IN", to make it similar to the text when a user is logged in.
- PF-1094: In `terra auth status` text output, change "Current user" -> "User email" and "Proxy group for current user" -> "Proxy group email", to make it similar to the property names in the JSON output.
- PF-1095: In `terra auth status` text output, change "null" -> "(undefined)" for the pet SA email. Also fix a bug where the pet SA email isn't cleared when the current workspace is deleted.
- PF-1098: In `terra auth revoke` output, print "No user logged in." if there was no current user, instead of always printing "Logout successful." regardless of whether a logout was actually performed.
