### PR TITLE
PF-1170: log all the CLI commands in DEBUG level.

### DIFF
--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -60,6 +60,7 @@ public class Main implements Runnable {
           .stackTraces(CommandLine.Help.Ansi.Style.italic)
           .build();
 
+  /** List of user input command and arguments. */
   private static List<String> argList = List.of();
 
   /**
@@ -108,13 +109,14 @@ public class Main implements Runnable {
    * @param args from stdin
    */
   public static void main(String... args) {
+    // Save the user input args so that {@link BaseCommand} can log the command and arguments being
+    // executed.
     argList = Arrays.asList(args);
     // run the command
     int exitCode = runCommand(args);
 
     // set the exit code and terminate the process
     System.exit(exitCode);
-    resetArgList();
   }
 
   /** Required method to implement Runnable, but not actually called by picocli. */
@@ -124,11 +126,6 @@ public class Main implements Runnable {
   /** Get the user input arguments */
   public static List<String> getArgList() {
     return argList;
-  }
-
-  /** Resets the arg list after executing the command. */
-  private static void resetArgList() {
-    argList = List.of();
   }
 
   /**

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -10,6 +10,8 @@ import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.utils.UserIO;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -58,6 +60,8 @@ public class Main implements Runnable {
           .stackTraces(CommandLine.Help.Ansi.Style.italic)
           .build();
 
+  private static List<String> argList = List.of();
+
   /**
    * Create and execute the top-level command. Tests call this method instead of {@link
    * #main(String...)} so that the process isn't terminated.
@@ -104,16 +108,28 @@ public class Main implements Runnable {
    * @param args from stdin
    */
   public static void main(String... args) {
+    argList = Arrays.asList(args);
     // run the command
     int exitCode = runCommand(args);
 
     // set the exit code and terminate the process
     System.exit(exitCode);
+    resetArgList();
   }
 
   /** Required method to implement Runnable, but not actually called by picocli. */
   @Override
   public void run() {}
+
+  /** Get the user input arguments */
+  public static List<String> getArgList() {
+    return argList;
+  }
+
+  /** Resets the arg list after executing the command. */
+  private static void resetArgList() {
+    argList = List.of();
+  }
 
   /**
    * Custom handler class that intercepts all exceptions.

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -2,11 +2,13 @@ package bio.terra.cli.command.shared;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.User;
+import bio.terra.cli.command.Main;
 import bio.terra.cli.utils.Logger;
 import bio.terra.cli.utils.UserIO;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.PrintStream;
 import java.util.concurrent.Callable;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 /**
@@ -31,6 +33,7 @@ import picocli.CommandLine;
             + "the command classes, we can't set the output streams in the constructor and make them "
             + "static.")
 public abstract class BaseCommand implements Callable<Integer> {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(BaseCommand.class);
   // output streams for commands to write to
   protected static PrintStream OUT;
   protected static PrintStream ERR;
@@ -55,6 +58,7 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     // execute the command
+    logger.debug("terra " + String.join(" ", Main.getArgList()));
     execute();
 
     // set the command exit code

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -58,7 +58,7 @@ public abstract class BaseCommand implements Callable<Integer> {
     }
 
     // execute the command
-    logger.debug("terra " + String.join(" ", Main.getArgList()));
+    logger.debug("[COMMAND RUN] terra " + String.join(" ", Main.getArgList()));
     execute();
 
     // set the command exit code


### PR DESCRIPTION
```
09:40:41.247 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra config get server
09:40:42.101 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra config set server --name=broad-dev
09:40:42.105 [main] DEBUG bio.terra.cli.utils.JacksonMapper - Serializing object with Jackson to file: /Users/yuhuyoyo/.terra/context.json
09:40:57.988 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra version
09:41:02.261 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra server list
09:41:12.162 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra auth login
09:41:16.186 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - Request attempt #1
09:41:16.596 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - Result: class UserStatusInfo {
    userSubjectId: 26358800255744b36459f
    userEmail: yuhuyoyo@google.com
    enabled: true
}
09:41:16.596 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - polling with retries completed. jobCompleted = true, timedOut = false
09:41:16.599 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - Request attempt #1
09:41:16.901 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - Result: PROXY_26358800255744b36459f@dev.test.firecloud.org
09:41:16.902 [main] DEBUG bio.terra.cli.service.utils.HttpUtils - polling with retries completed. jobCompleted = true, timedOut = false
09:41:16.906 [main] DEBUG bio.terra.cli.utils.JacksonMapper - Serializing object with Jackson to file: /Users/yuhuyoyo/.terra/context.json
09:41:24.576 [main] DEBUG bio.terra.cli.businessobject.User - Current workspace is either not defined or not loaded, so there are no pet SA credentials.
09:41:24.579 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra server list
09:41:38.817 [main] DEBUG bio.terra.cli.businessobject.User - Current workspace is either not defined or not loaded, so there are no pet SA credentials.
09:41:38.819 [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra server set --name=verily-devel
09:41:40.374 [main] DEBUG bio.terra.cli.utils.JacksonMapper - Serializing object with Jackson to file: /Users/yuhuyoyo/.terra/context.json
09:41:40.394 [main] DEBUG bio.terra.cli.utils.JacksonMapper - Serializing object with Jackson to file: /Users/yuhuyoyo/.terra/context.json
```