### PR TITLE
[PF-1096] Split client log files by date

### DIFF
--- a/src/main/java/bio/terra/cli/utils/Logger.java
+++ b/src/main/java/bio/terra/cli/utils/Logger.java
@@ -97,7 +97,7 @@ public class Logger {
       fileAppender.rollover();
     }
 
-    StatusPrinter.print(loggerContext); // helpful for debugging
+    // StatusPrinter.print(loggerContext); // helpful for debugging
   }
 
   /**

--- a/src/main/java/bio/terra/cli/utils/Logger.java
+++ b/src/main/java/bio/terra/cli/utils/Logger.java
@@ -28,7 +28,7 @@ public class Logger {
 
   private static final long MAX_PER_FILE_SIZE = 10 * FileSize.MB_COEFFICIENT;
   private static final long MAX_TOTAL_LOG_SIZE = 100 * FileSize.MB_COEFFICIENT;
-  private static final int MAX_HISTORY_FILES = 30; // Keep up to 30 archived log files
+  private static final int MAX_HISTORY_FILES = 30;
 
   /**
    * Setup a file and console appender for the root logger. Each may use a different logging level,
@@ -55,6 +55,7 @@ public class Logger {
     SizeAndTimeBasedRollingPolicy rollingPolicy = new SizeAndTimeBasedRollingPolicy();
     rollingPolicy.setContext(loggerContext);
     rollingPolicy.setParent(fileAppender);
+    // Log files will be stored at "~/.terra/logs/terra-2021-01-01.0.log", etc.
     rollingPolicy.setFileNamePattern(
         Context.getLogFile().getParent().resolve("terra-%d{yyyy-MM-dd}.%i.log").toString());
     rollingPolicy.setMaxHistory(MAX_HISTORY_FILES);


### PR DESCRIPTION
A small quality-of-life improvement for client debugging, this change causes the CLI to create log files with a date-specific pattern. We retain the same per-file and total history filesize limit, as well as a new limit on the total # of archive files to retain.

Before:

<img width="468" alt="Screen Shot 2021-12-13 at 4 26 59 PM" src="https://user-images.githubusercontent.com/51842/145891737-953c3c4c-5066-4edf-97be-4331a4e3dc9c.png">

After:

<img width="563" alt="Screen Shot 2021-12-13 at 4 23 49 PM" src="https://user-images.githubusercontent.com/51842/145891753-ef06dade-ecf4-4f38-8803-7b75b7fab5ee.png">
