### PR TITLE
[PF-1088] Point verily preprod/prod at new billing account

### DIFF
--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -5,5 +5,5 @@
   "samUri": "https://terra-preprod-sam.api.verily.com",
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-preprod-wsm.api.verily.com",
-  "wsmDefaultSpendProfile": "wm-temp-spend-profile"
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -5,5 +5,5 @@
   "samUri": "https://terra-sam.api.verily.com",
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-wsm.api.verily.com",
-  "wsmDefaultSpendProfile": "wm-temp-spend-profile"
+  "wsmDefaultSpendProfile": "wm-default-spend-profile"
 }


### PR DESCRIPTION
This updates the Verily preprod + prod servers to use the correct billing account now that GCP permissions are sorted out. I've also created the appropriate spend profile in each environment and granted permissions to the same users as the current `wm-temp-spend-profile`.