### PR TITLE
PF-1271: Update WorkspaceManagerService API call based on WSM API change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         // terra libraries
         crlPlatform = "0.2.0"
         samClient = "0.1-ffb0a89-SNAP"
-        workspaceManagerClient = "0.254.150-SNAPSHOT"
+        workspaceManagerClient = "0.254.153-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/command/resource/update/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/BqDataset.java
@@ -55,12 +55,7 @@ public class BqDataset extends BaseCommand {
           new UpdateReferencedBqDatasetParams.Builder()
               .resourceParams(resourceUpdateOptions.populateMetadataFields().build())
               .datasetId(bqDatasetNewIds.getNewBqDatasetId())
-              .projectId(bqDatasetNewIds.getNewGcpProjectId())
-              // TODO (PF-1271): remove the original reference's attributes once WSM does not
-              // require specifying dataset Id and project Id when updating reference to a BQ
-              // dataset.
-              .originalDatasetId(resource.getDatasetId())
-              .originalProjectId(resource.getProjectId());
+              .projectId(bqDatasetNewIds.getNewGcpProjectId());
       resource.updateReferenced(updateParams.build());
     } else {
       resource.updateControlled(

--- a/src/main/java/bio/terra/cli/command/resource/update/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/BqTable.java
@@ -49,13 +49,7 @@ public class BqTable extends BaseCommand {
             .resourceParams(resourceUpdateOptions.populateMetadataFields().build())
             .tableId(newBqTableId)
             .datasetId(bqDatasetNewIds.getNewBqDatasetId())
-            .projectId(bqDatasetNewIds.getNewGcpProjectId())
-            // TODO (PF-1271): remove the original reference's attributes once WSM does not require
-            // specifying tableId, datasetId and projectId when updating referencing target to a
-            // BQ table.
-            .originalTableId(resource.getDataTableId())
-            .originalDatasetId(resource.getDatasetId())
-            .originalProjectId(resource.getProjectId());
+            .projectId(bqDatasetNewIds.getNewGcpProjectId());
 
     resource.updateReferenced(bqTableParams.build());
 

--- a/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
@@ -53,12 +53,7 @@ public class GcsObject extends BaseCommand {
         new UpdateReferencedGcsObjectParams.Builder()
             .resourceFields(updateResourceParams)
             .bucketName(newBucketName.getNewBucketName())
-            .objectName(newObjectName)
-            // TODO (PF-1271): remove the original reference's attributes once WSM does not require
-            // specifying both objectName and bucketName when updating reference target.
-            .originalObjectName(resource.getObjectName())
-            .originalBucketName(resource.getBucketName())
-            .build();
+            .objectName(newObjectName).build();
     resource.updateReferenced(gcsObjectParams);
 
     formatOption.printReturnValue(new UFGcsObject(resource), GcsObject::printText);

--- a/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
@@ -53,7 +53,8 @@ public class GcsObject extends BaseCommand {
         new UpdateReferencedGcsObjectParams.Builder()
             .resourceFields(updateResourceParams)
             .bucketName(newBucketName.getNewBucketName())
-            .objectName(newObjectName).build();
+            .objectName(newObjectName)
+            .build();
     resource.updateReferenced(gcsObjectParams);
 
     formatOption.printReturnValue(new UFGcsObject(resource), GcsObject::printText);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedBqDatasetParams.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedBqDatasetParams.java
@@ -29,23 +29,10 @@ public class UpdateReferencedBqDatasetParams {
    */
   public final @Nullable String projectId;
 
-  /** The original BqDataset id that the reference is pointing to. */
-  public final String originalDatasetId;
-
-  /** The original BqDataset project id that the reference is pointing to. */
-  public final String originalProjectId;
-
   protected UpdateReferencedBqDatasetParams(UpdateReferencedBqDatasetParams.Builder builder) {
     this.resourceParams = builder.resourceFields;
     this.datasetId = builder.datasetId;
     this.projectId = builder.projectId;
-    this.originalDatasetId = builder.originalDatasetId;
-    this.originalProjectId = builder.originalProjectId;
-  }
-
-  /** Whether to update the reference to point to another BqDataset. */
-  public boolean hasNewReferenceTargetFields() {
-    return datasetId != null || projectId != null;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -54,8 +41,6 @@ public class UpdateReferencedBqDatasetParams {
     private UpdateResourceParams resourceFields;
     private String datasetId;
     private String projectId;
-    private String originalDatasetId;
-    private String originalProjectId;
 
     public UpdateReferencedBqDatasetParams.Builder resourceParams(
         UpdateResourceParams resourceFields) {
@@ -70,16 +55,6 @@ public class UpdateReferencedBqDatasetParams {
 
     public UpdateReferencedBqDatasetParams.Builder projectId(String projectId) {
       this.projectId = projectId;
-      return this;
-    }
-
-    public UpdateReferencedBqDatasetParams.Builder originalDatasetId(String originalDatasetId) {
-      this.originalDatasetId = originalDatasetId;
-      return this;
-    }
-
-    public UpdateReferencedBqDatasetParams.Builder originalProjectId(String originalProjectId) {
-      this.originalProjectId = originalProjectId;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedBqTableParams.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedBqTableParams.java
@@ -36,21 +36,11 @@ public class UpdateReferencedBqTableParams {
    */
   public final @Nullable String tableId;
 
-  /** The original BqDataset id that the reference is pointing to. */
-  public final String originalDatasetId;
-  /** The original BqDataset project id that the reference is pointing to. */
-  public final String originalProjectId;
-  /** The original BqDataset table id that the reference is pointing to. */
-  public final String originalTableId;
-
   protected UpdateReferencedBqTableParams(UpdateReferencedBqTableParams.Builder builder) {
     this.resourceParams = builder.resourceParams;
     this.datasetId = builder.datasetId;
     this.projectId = builder.projectId;
     this.tableId = builder.tableId;
-    this.originalDatasetId = builder.originalDatasetId;
-    this.originalProjectId = builder.originalProjectId;
-    this.originalTableId = builder.originalTableId;
   }
 
   /** Whether to update the target that the referenced resource is pointing to. */
@@ -65,9 +55,6 @@ public class UpdateReferencedBqTableParams {
     private @Nullable String datasetId;
     private @Nullable String projectId;
     private @Nullable String tableId;
-    private String originalDatasetId;
-    private String originalProjectId;
-    private String originalTableId;
 
     public UpdateReferencedBqTableParams.Builder resourceParams(
         UpdateResourceParams resourceParams) {
@@ -87,21 +74,6 @@ public class UpdateReferencedBqTableParams {
 
     public UpdateReferencedBqTableParams.Builder projectId(@Nullable String projectId) {
       this.projectId = projectId;
-      return this;
-    }
-
-    public UpdateReferencedBqTableParams.Builder originalTableId(String originalTableId) {
-      this.originalTableId = originalTableId;
-      return this;
-    }
-
-    public UpdateReferencedBqTableParams.Builder originalDatasetId(String originalDatasetId) {
-      this.originalDatasetId = originalDatasetId;
-      return this;
-    }
-
-    public UpdateReferencedBqTableParams.Builder originalProjectId(String originalProjectId) {
-      this.originalProjectId = originalProjectId;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedGcsObjectParams.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateReferencedGcsObjectParams.java
@@ -23,22 +23,11 @@ public class UpdateReferencedGcsObjectParams {
    * originalResource} instead.
    */
   public final @Nullable String objectName;
-  /**
-   * WSM currently requires both bucket name and object name to be specified when updating the
-   * referencing target. So when a user wants to update the reference to another object in the same
-   * bucket and didn't specify the bucket name, we will fetch the original bucketName from {@code
-   * originalResource}. Same when the user only specify new bucket name.
-   */
-  public final String originalBucketName;
-
-  public final String originalObjectName;
 
   protected UpdateReferencedGcsObjectParams(Builder builder) {
     this.resourceFields = builder.resourceFields;
     this.bucketName = builder.bucketName;
     this.objectName = builder.objectName;
-    this.originalBucketName = builder.originalBucketName;
-    this.originalObjectName = builder.originalObjectName;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -46,8 +35,6 @@ public class UpdateReferencedGcsObjectParams {
     private UpdateResourceParams resourceFields;
     private @Nullable String bucketName;
     private @Nullable String objectName;
-    private String originalBucketName;
-    private String originalObjectName;
 
     public UpdateReferencedGcsObjectParams.Builder resourceFields(
         UpdateResourceParams resourceFields) {
@@ -62,16 +49,6 @@ public class UpdateReferencedGcsObjectParams {
 
     public UpdateReferencedGcsObjectParams.Builder objectName(String objectName) {
       this.objectName = objectName;
-      return this;
-    }
-
-    public UpdateReferencedGcsObjectParams.Builder originalBucketName(String originalBucketName) {
-      this.originalBucketName = originalBucketName;
-      return this;
-    }
-
-    public UpdateReferencedGcsObjectParams.Builder originalObjectName(String originalObjectName) {
-      this.originalObjectName = originalObjectName;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -907,14 +907,9 @@ public class WorkspaceManagerService {
           .description(updateParams.resourceFields.description);
     }
 
-    if (updateParams.bucketName != null || updateParams.objectName != null) {
-      GcpGcsObjectAttributes gcsObjectAttributes = new GcpGcsObjectAttributes();
-      gcsObjectAttributes.bucketName(
-          Optional.ofNullable(updateParams.bucketName).orElse(updateParams.originalBucketName));
-      gcsObjectAttributes.fileName(
-          Optional.ofNullable(updateParams.objectName).orElse(updateParams.originalObjectName));
-      updateRequest.resourceAttributes(gcsObjectAttributes);
-    }
+    updateRequest.bucketName(updateParams.bucketName);
+    updateRequest.objectName(updateParams.objectName);
+
     callWithRetries(
         () ->
             new ReferencedGcpResourceApi(apiClient)
@@ -995,18 +990,9 @@ public class WorkspaceManagerService {
         new UpdateBigQueryDataTableReferenceRequestBody()
             .name(updateParams.resourceParams.name)
             .description(updateParams.resourceParams.description);
-    if (updateParams.hasNewReferenceTargetFields()) {
-      updateRequest.resourceAttributes(
-          new GcpBigQueryDataTableAttributes()
-              .projectId(
-                  Optional.ofNullable(updateParams.projectId)
-                      .orElse(updateParams.originalProjectId))
-              .datasetId(
-                  Optional.ofNullable(updateParams.datasetId)
-                      .orElse(updateParams.originalDatasetId))
-              .dataTableId(
-                  Optional.ofNullable(updateParams.tableId).orElse(updateParams.originalTableId)));
-    }
+    updateRequest.projectId(updateParams.projectId);
+    updateRequest.datasetId(updateParams.datasetId);
+    updateRequest.dataTableId(updateParams.tableId);
 
     callWithRetries(
         () ->
@@ -1031,16 +1017,8 @@ public class WorkspaceManagerService {
         new UpdateBigQueryDatasetReferenceRequestBody()
             .name(updateParams.resourceParams.name)
             .description(updateParams.resourceParams.description);
-    if (updateParams.hasNewReferenceTargetFields()) {
-      updateRequest.resourceAttributes(
-          new GcpBigQueryDatasetAttributes()
-              .projectId(
-                  Optional.ofNullable(updateParams.projectId)
-                      .orElse(updateParams.originalProjectId))
-              .datasetId(
-                  Optional.ofNullable(updateParams.datasetId)
-                      .orElse(updateParams.originalDatasetId)));
-    }
+    updateRequest.projectId(updateParams.projectId);
+    updateRequest.datasetId(updateParams.datasetId);
     callWithRetries(
         () ->
             new ReferencedGcpResourceApi(apiClient)

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -103,7 +103,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -933,10 +932,7 @@ public class WorkspaceManagerService {
         new UpdateGcsBucketReferenceRequestBody()
             .name(updateParams.resourceParams.name)
             .description(updateParams.resourceParams.description);
-    if (updateParams.bucketName != null) {
-      updateRequest.resourceAttributes(
-          new GcpGcsBucketAttributes().bucketName(updateParams.bucketName));
-    }
+    updateRequest.bucketName(updateParams.bucketName);
     callWithRetries(
         () ->
             new ReferencedGcpResourceApi(apiClient)


### PR DESCRIPTION
WSM no longer requires the resource attributes field when updating targeting reference. 

e.g. when updating bucket object from foo to bar within the same object, the bucket name field can be set to null. 