### PR TITLE
[PF-1253] Invalidate refresh/access token when user runs terra auth revoke

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -158,6 +158,7 @@ public class User {
   public void logout() {
     deleteOauthCredentials();
     deletePetSaCredentials();
+    GoogleOauth.revokeToken(userCredentials);
 
     // unset the current user in the global context
     Context.setUser(null);

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -284,7 +284,7 @@ public final class GoogleOauth {
     try {
       HttpUtils.sendHttpRequest("https://oauth2.googleapis.com/revoke", "POST", headers, params);
     } catch (IOException ioEx) {
-      throw new SystemException("Unable to revoke token");
+      throw new SystemException("Unable to revoke token", ioEx);
     }
   }
 }

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -1,5 +1,7 @@
 package bio.terra.cli.service;
 
+import bio.terra.cli.exception.SystemException;
+import bio.terra.cli.service.utils.HttpUtils;
 import bio.terra.cli.utils.UserIO;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.oauth2.StoredCredential;
@@ -17,6 +19,7 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.auth.oauth2.UserCredentials;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,6 +30,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,5 +264,27 @@ public final class GoogleOauth {
       // error when we try to re-use it anyway, and this log statement may help with debugging.
     }
     return credential.getAccessToken();
+  }
+
+  /**
+   * Revoke token (https://developers.google.com/identity/protocols/oauth2/web-server#tokenrevoke).
+   *
+   * <p>Google Java OAuth library doesn't support revoking tokens
+   * (https://github.com/googleapis/google-oauth-java-client/issues/250), so make the call ourself.
+   *
+   * @param credential credentials object
+   */
+  public static void revokeToken(GoogleCredentials credential) {
+    String endpoint = "https://oauth2.googleapis.com/revoke";
+    Map<String, String> headers =
+        ImmutableMap.of("Content-type", "application/x-www-form-urlencoded");
+    Map<String, String> params =
+        ImmutableMap.of("token", credential.getAccessToken().getTokenValue());
+
+    try {
+      HttpUtils.sendHttpRequest("https://oauth2.googleapis.com/revoke", "POST", headers, params);
+    } catch (IOException ioEx) {
+      throw new SystemException("Unable to revoke token");
+    }
   }
 }

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -3,6 +3,7 @@ package bio.terra.cli.service.utils;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.utils.UserIO;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.common.collect.ImmutableMap;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -54,6 +55,27 @@ public class HttpUtils {
   public static HttpResponse sendHttpRequest(
       String urlStr, String requestType, String accessToken, Map<String, String> params)
       throws IOException {
+    Map<String, String> headers = ImmutableMap.of("accept", "*/*");
+    if (accessToken != null) {
+      headers.put("Authorization", "Bearer " + accessToken);
+    }
+
+    return sendHttpRequest(urlStr, requestType, headers, params);
+  }
+
+  /**
+   * Sends an HTTP request using Java's HTTPURLConnection class.
+   *
+   * @param urlStr where to direct the request
+   * @param requestType the type of request, GET/PUT/POST/DELETE
+   * @param headers map of request headers
+   * @param params map of request parameters
+   * @return a POJO that includes the HTTP status code and the raw JSON response body
+   * @throws IOException
+   */
+  public static HttpResponse sendHttpRequest(
+      String urlStr, String requestType, Map<String, String> headers, Map<String, String> params)
+      throws IOException {
     // build parameter string
     boolean hasParams = params != null && params.size() > 0;
     String paramsStr = "";
@@ -78,11 +100,9 @@ public class HttpUtils {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
 
     // set header properties
-    //    con.setRequestProperty("Content-Type", "*/*");
     con.setRequestMethod(requestType);
-    con.setRequestProperty("accept", "*/*");
-    if (accessToken != null) {
-      con.setRequestProperty("Authorization", "Bearer " + accessToken);
+    for (Map.Entry<String, String> headerEntry : headers.entrySet()) {
+      con.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
     }
 
     // for other request types, write the parameters to the request body

--- a/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/HttpUtils.java
@@ -3,7 +3,6 @@ package bio.terra.cli.service.utils;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.utils.UserIO;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.common.collect.ImmutableMap;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -14,6 +13,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -55,7 +55,8 @@ public class HttpUtils {
   public static HttpResponse sendHttpRequest(
       String urlStr, String requestType, String accessToken, Map<String, String> params)
       throws IOException {
-    Map<String, String> headers = ImmutableMap.of("accept", "*/*");
+    Map<String, String> headers = new HashMap<>();
+    headers.put("accept", "*/*");
     if (accessToken != null) {
       headers.put("Authorization", "Bearer " + accessToken);
     }


### PR DESCRIPTION
Before this PR: After `terra auth revoke`, still able to make calls using access token, such as calling WSM api/workspaces/v1 via swagger

After this PR: After `terra auth revoke`, calling api/workspaces/v1 returns 401. Note that it can take up to a minute for the revoke to take effect.