### PR TITLE
[PF-1269] installation without Docker support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,13 @@
 -----
 
 ### Setup development environment
-From the top-level directory:
+The TERRA_CLI_DOCKER_MODE environment variable controls Docker support. Set it to
+   DOCKER_NOT_AVAILABLE (default) to skip pulling the Docker image
+   or DOCKER_AVAILABLE to pull the image (requires Docker to be installed and running).
+Then, from the top-level directory, run:
 ```
 source tools/local-dev.sh
-terra
+build/install/terra-cli/bin/terra
 ```
 
 #### Logging
@@ -157,6 +160,9 @@ CLI installation on the same machine.
 
 - Run a single test by specifying the `--tests` option:
 `./gradlew runTestsWithTag -PtestTag=unit --tests "unit.Workspace.createFailsWithoutSpendAccess" --info`
+
+#### Docker and Tests
+The tests require the Docker daemon to be running (install mode DOCKER_AVAILABLE).
 
 #### Override default server
 The tests run against the `broad-dev` server by default. You can run them against a different server

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
 3. [Testing](#testing)
     * [Two types of tests](#two-types-of-tests)
     * [Run tests](#run-tests)
+    * [Docker and Tests](#docker-and-tests)
     * [Override default server](#override-default-server)
     * [Override default Docker image](#override-default-docker-image)
     * [Override context directory](#override-context-directory)
@@ -44,7 +45,7 @@ The TERRA_CLI_DOCKER_MODE environment variable controls Docker support. Set it t
 Then, from the top-level directory, run:
 ```
 source tools/local-dev.sh
-build/install/terra-cli/bin/terra
+terra
 ```
 
 #### Logging

--- a/README.md
+++ b/README.md
@@ -387,10 +387,16 @@ For example, a bucket within the workspace Google project. You can create these 
 
 A referenced resource is a cloud resource that is NOT managed by Terra. It exists outside the current workspace
 context. For example, a BigQuery dataset hosted outside of Terra or in another workspace. You can add these with the
-`add-ref` command.
+`add-ref` command. The workspace currently supports the following referenced resource: 
+- `gcs-bucket`
+- `gcs-object`
+- `bq-dataset`
+- `bq-table`
+- `git-repo`
 
 The `check-access` command lets you see whether you have access to a particular resource. This is useful when a
-different user created or added the resource and subsequently shared the workspace with you.
+different user created or added the resource and subsequently shared the workspace with you. `check-access` currently always 
+returns true for `git-repo` reference type because workspace doesn't support authentication to external git services yet.
 
 The list of resources in a workspace is maintained on the Terra Workspace Manager server. The CLI caches this list
 of resources locally. Third-party tools can access resource details via environment variables (e.g. $TERRA_mybucket

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/down
 ./terra
 ```
 
+By default, the CLI will be installed without support for Docker (i.e. it won't pull the Docker image).
+The TERRA_CLI_DOCKER_MODE environment variable controls Docker support. Set it to
+* DOCKER_NOT_AVAILABLE (default) to skip pulling the Docker image
+* DOCKER_AVAILABLE to pull the image (requires Docker to be installed and running).
+
 This will install the Terra CLI in the current directory. Afterwards, you may want to add it to your `$PATH` directly
 or move it to a place that is already on your `$PATH` (e.g. `/usr/local/bin`).
 
@@ -56,7 +61,7 @@ modify the `$PATH`. So if you have added it to your `$PATH`, that step needs to 
 
 #### Requirements
 1. Java 11
-2. Docker 20.10.2 (Must be running)
+2. Docker 20.10.2 (Must be running if installing in DOCKER_AVAILABLE mode)
 3. `curl`, `tar`, `gcloud` (For install only)
 
 Note: The CLI doesn't use `gcloud` directly either during install or normal operation.

--- a/README.md
+++ b/README.md
@@ -387,16 +387,10 @@ For example, a bucket within the workspace Google project. You can create these 
 
 A referenced resource is a cloud resource that is NOT managed by Terra. It exists outside the current workspace
 context. For example, a BigQuery dataset hosted outside of Terra or in another workspace. You can add these with the
-`add-ref` command. The workspace currently supports the following referenced resource: 
-- `gcs-bucket`
-- `gcs-object`
-- `bq-dataset`
-- `bq-table`
-- `git-repo`
+`add-ref` command.
 
 The `check-access` command lets you see whether you have access to a particular resource. This is useful when a
-different user created or added the resource and subsequently shared the workspace with you. `check-access` currently always 
-returns true for `git-repo` reference type because workspace doesn't support authentication to external git services yet.
+different user created or added the resource and subsequently shared the workspace with you.
 
 The list of resources in a workspace is maintained on the Terra Workspace Manager server. The CLI caches this list
 of resources locally. Third-party tools can access resource details via environment variables (e.g. $TERRA_mybucket

--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ gcloud auth login
 gcloud auth application-default login
 ```
 
-Run a Nextflow hello world example.
+#### Nextflow Examples
+Run a Nextflow hello world example (requires Docker image set and container running, or Nextflow to
+be installed locally. For Docker support, `export TERRA_CLI_DOCKER_MODE=DOCKER_AVAILABLE` before installing `terra`):
 ```
 terra nextflow run hello
 ```
@@ -208,18 +210,23 @@ access token. Then specify the `-with-tower` flag when kicking off the workflow.
 - Call the Gcloud CLI tools in the current workspace context.
 This means that Gcloud is configured with the backing Google project and environment variables are defined that
 contain workspace and resource properties (e.g. bucket names, pet service account email).
-```
-terra gcloud config get-value project
-terra gsutil ls
-terra bq version
-```
+    ```
+    terra gcloud config get-value project
+    terra gsutil ls
+    terra bq version
+    ```
 
 - See the list of supported third-party tools.
-The CLI runs these tools in a Docker image. Print the image tag that the CLI is currently using.
-```
-terra app list
-terra config get image
-```
+The CLI runs these tools in a Docker image, if `app-launch` mode is `DOCKER_CONTAINER`. If the
+`app-launch` mode is `LOCAL_PROCESS`, the CLI will assume the tools are available in the current
+shell environment and launch them there.
+    ```
+    terra app list
+    ```
+- Print the image tag that the CLI is currently using.
+    ```
+    terra config get image
+    ```
 
 ### Commands description
 ```

--- a/src/main/java/bio/terra/cli/app/utils/DockerClientWrapper.java
+++ b/src/main/java/bio/terra/cli/app/utils/DockerClientWrapper.java
@@ -243,11 +243,12 @@ public class DockerClientWrapper {
         ex.getCause() != null
             && ex.getCause() instanceof IOException
             && ex.getCause().getMessage() != null
-            && (ex.getCause().getMessage().contains("Connection refused")
+            && (ex.getCause().getMessage().toLowerCase().contains("connection refused")
                 || ex.getCause().getMessage().contains("native connect() failed"));
     if (isDockerConnectionFailed) {
       return new UserActionableException(
-          "Connecting to Docker daemon failed. Check that Docker is installed and running.", ex);
+          "Connecting to Docker daemon failed. Check that Docker is installed and running. "
+              + "To run apps without Docker, use the LOCAL_PROCESS app launch mode (terra config set app-launch LOCAL_PROCESS).", ex);
     } else {
       return ex;
     }

--- a/src/main/java/bio/terra/cli/app/utils/DockerClientWrapper.java
+++ b/src/main/java/bio/terra/cli/app/utils/DockerClientWrapper.java
@@ -248,7 +248,8 @@ public class DockerClientWrapper {
     if (isDockerConnectionFailed) {
       return new UserActionableException(
           "Connecting to Docker daemon failed. Check that Docker is installed and running. "
-              + "To run apps without Docker, use the LOCAL_PROCESS app launch mode (terra config set app-launch LOCAL_PROCESS).", ex);
+              + "To run apps without Docker, use the LOCAL_PROCESS app launch mode (terra config set app-launch LOCAL_PROCESS).",
+          ex);
     } else {
       return ex;
     }

--- a/src/main/java/bio/terra/cli/businessobject/Config.java
+++ b/src/main/java/bio/terra/cli/businessobject/Config.java
@@ -130,11 +130,6 @@ public class Config {
     this.dockerImageId = dockerImageId;
     if (!new DockerClientWrapper().checkImageExists(dockerImageId)) {
       logger.warn("image not found: {}", dockerImageId);
-      throw new UserActionableException(
-          String.format(
-              "Docker image %s was not found on the local machine. "
-                  + "Do `docker pull %s` to obtain it.",
-              dockerImageId, dockerImageId));
     }
     Context.synchronizeToDisk();
   }

--- a/src/main/java/bio/terra/cli/businessobject/Config.java
+++ b/src/main/java/bio/terra/cli/businessobject/Config.java
@@ -109,15 +109,6 @@ public class Config {
   }
 
   public void setCommandRunnerOption(CommandRunnerOption commandRunnerOption) {
-    if (CommandRunnerOption.DOCKER_CONTAINER == commandRunnerOption) {
-      if (new DockerClientWrapper().checkImageExists(getDockerImageId())) {
-        throw new UserActionableException(
-            String.format(
-                "Docker image %s was not found on the local machine. "
-                    + "Do `docker pull %s` to obtain it.",
-                getDockerImageId(), getDockerImageId()));
-      }
-    }
     this.commandRunnerOption = commandRunnerOption;
     Context.synchronizeToDisk();
   }

--- a/src/main/java/bio/terra/cli/businessobject/Config.java
+++ b/src/main/java/bio/terra/cli/businessobject/Config.java
@@ -109,6 +109,15 @@ public class Config {
   }
 
   public void setCommandRunnerOption(CommandRunnerOption commandRunnerOption) {
+    if (CommandRunnerOption.DOCKER_CONTAINER == commandRunnerOption) {
+      if (new DockerClientWrapper().checkImageExists(getDockerImageId())) {
+        throw new UserActionableException(
+            String.format(
+                "Docker image %s was not found on the local machine. "
+                    + "Do `docker pull %s` to obtain it.",
+                getDockerImageId(), getDockerImageId()));
+      }
+    }
     this.commandRunnerOption = commandRunnerOption;
     Context.synchronizeToDisk();
   }
@@ -123,7 +132,7 @@ public class Config {
       logger.warn("image not found: {}", dockerImageId);
       throw new UserActionableException(
           String.format(
-              "Either Docker is not available or docker image %s was not found on the local machine. "
+              "Docker image %s was not found on the local machine. "
                   + "Do `docker pull %s` to obtain it.",
               dockerImageId, dockerImageId));
     }

--- a/src/main/java/bio/terra/cli/businessobject/Config.java
+++ b/src/main/java/bio/terra/cli/businessobject/Config.java
@@ -6,7 +6,6 @@ import bio.terra.cli.app.LocalProcessCommandRunner;
 import bio.terra.cli.app.utils.DockerClientWrapper;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.Format.FormatOptions;
-import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.persisted.PDConfig;
 import bio.terra.cli.utils.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/bio/terra/cli/businessobject/Config.java
+++ b/src/main/java/bio/terra/cli/businessobject/Config.java
@@ -6,6 +6,7 @@ import bio.terra.cli.app.LocalProcessCommandRunner;
 import bio.terra.cli.app.utils.DockerClientWrapper;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.Format.FormatOptions;
+import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.persisted.PDConfig;
 import bio.terra.cli.utils.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,6 +121,11 @@ public class Config {
     this.dockerImageId = dockerImageId;
     if (!new DockerClientWrapper().checkImageExists(dockerImageId)) {
       logger.warn("image not found: {}", dockerImageId);
+      throw new UserActionableException(
+          String.format(
+              "Either Docker is not available or docker image %s was not found on the local machine. "
+                  + "Do `docker pull %s` to obtain it.",
+              dockerImageId, dockerImageId));
     }
     Context.synchronizeToDisk();
   }

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -128,7 +128,7 @@ public class User {
     currentUser.ifPresent(User::loadExistingCredentials);
 
     // populate the current user object or build a new one
-    User user = currentUser.orElseGet(() -> new User());
+    User user = currentUser.orElseGet(User::new);
 
     // do the login flow if the current user is undefined or has expired credentials
     if (currentUser.isEmpty() || currentUser.get().requiresReauthentication()) {

--- a/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
+++ b/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
@@ -1,6 +1,8 @@
 package bio.terra.cli.command.config.set;
 
+import bio.terra.cli.app.utils.DockerClientWrapper;
 import bio.terra.cli.businessobject.Config;
+import bio.terra.cli.businessobject.Config.CommandRunnerOption;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
 import picocli.CommandLine;
@@ -18,6 +20,15 @@ public class AppLaunch extends BaseCommand {
   protected void execute() {
     Config config = Context.getConfig();
     Config.CommandRunnerOption prevAppLaunchOption = config.getCommandRunnerOption();
+    if (CommandRunnerOption.DOCKER_CONTAINER == mode) {
+      String imageId = Context.getConfig().getDockerImageId();
+      if (!new DockerClientWrapper().checkImageExists(Config.getDefaultImageId())) {
+        OUT.printf(
+            "WARNING: Either the Docker daemon isn't running or image %s was not found on the local machine. "
+                + "Do `docker pull %s` to obtain it.%n",
+            imageId, imageId);
+      }
+    }
     config.setCommandRunnerOption(mode);
 
     OUT.println(

--- a/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
+++ b/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
@@ -22,7 +22,7 @@ public class AppLaunch extends BaseCommand {
     Config.CommandRunnerOption prevAppLaunchOption = config.getCommandRunnerOption();
     if (CommandRunnerOption.DOCKER_CONTAINER == mode) {
       String imageId = Context.getConfig().getDockerImageId();
-      if (!new DockerClientWrapper().checkImageExists(Config.getDefaultImageId())) {
+      if (!new DockerClientWrapper().checkImageExists(imageId)) {
         OUT.printf(
             "WARNING: Image %s was not found on the local machine. "
                 + "Do `docker pull %s` to obtain it.%n",

--- a/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
+++ b/src/main/java/bio/terra/cli/command/config/set/AppLaunch.java
@@ -24,7 +24,7 @@ public class AppLaunch extends BaseCommand {
       String imageId = Context.getConfig().getDockerImageId();
       if (!new DockerClientWrapper().checkImageExists(Config.getDefaultImageId())) {
         OUT.printf(
-            "WARNING: Either the Docker daemon isn't running or image %s was not found on the local machine. "
+            "WARNING: Image %s was not found on the local machine. "
                 + "Do `docker pull %s` to obtain it.%n",
             imageId, imageId);
       }

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -30,7 +30,7 @@ public class Image extends BaseCommand {
     String newImageId = argGroup.useDefault ? Config.getDefaultImageId() : argGroup.imageId;
     if (!new DockerClientWrapper().checkImageExists(newImageId)) {
       OUT.printf(
-          "WARNING: Either the Docker daemon isn't running or image %s was not found on the local machine. "
+          "WARNING: Image %s was not found on the local machine. "
               + "Do `docker pull %s` to obtain it.%n",
           newImageId, newImageId);
     }

--- a/src/main/java/bio/terra/cli/command/config/set/Image.java
+++ b/src/main/java/bio/terra/cli/command/config/set/Image.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.command.config.set;
 
+import bio.terra.cli.app.utils.DockerClientWrapper;
 import bio.terra.cli.businessobject.Config;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.BaseCommand;
@@ -27,6 +28,12 @@ public class Image extends BaseCommand {
     Config config = Context.getConfig();
     String prevImageId = config.getDockerImageId();
     String newImageId = argGroup.useDefault ? Config.getDefaultImageId() : argGroup.imageId;
+    if (!new DockerClientWrapper().checkImageExists(newImageId)) {
+      OUT.printf(
+          "WARNING: Either the Docker daemon isn't running or image %s was not found on the local machine. "
+              + "Do `docker pull %s` to obtain it.%n",
+          newImageId, newImageId);
+    }
     config.setDockerImageId(newImageId);
 
     if (config.getDockerImageId().equals(prevImageId)) {

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -23,6 +23,7 @@ if [ "$terraCliVersion" == "latest" ]; then
 else
   releaseTarUrl="$ghRepoReleasesUrl/download/$terraCliVersion/$installPackageFileName"
 fi
+
 archiveFileName="terra-cli.tar"
 curl -L "$releaseTarUrl" > $archiveFileName
 if [ ! -f "${archiveFileName}" ]; then

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -24,7 +24,7 @@ else
   releaseTarUrl="$ghRepoReleasesUrl/download/$terraCliVersion/$installPackageFileName"
 fi
 archiveFileName="terra-cli.tar"
-curl -L $releaseTarUrl > $archiveFileName
+curl -L "$releaseTarUrl" > $archiveFileName
 if [ ! -f "${archiveFileName}" ]; then
     echo "Error downloading release: ${archiveFileName}"
     exit 1
@@ -32,8 +32,8 @@ fi
 
 echo "--  Unarchiving release"
 archiveDir=$PWD/terra-cli
-mkdir -p $archiveDir
-tar -C $archiveDir --strip-components=1 -xf $archiveFileName
+mkdir -p "$archiveDir"
+tar -C "$archiveDir" --strip-components=1 -xf $archiveFileName
 if [ ! -f "$archiveDir/install.sh" ]; then
     echo "Error unarchiving release: ${archiveFileName}"
     exit 1
@@ -41,9 +41,9 @@ fi
 
 echo "--  Running the install script inside the release directory"
 currentDir=$PWD
-cd $archiveDir
+cd "$archiveDir"
 ./install.sh
-cd $currentDir
+cd "$currentDir"
 
 echo "-- Deleting the release archive"
 rm $archiveFileName

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -26,7 +26,7 @@ if [ "$installMode" = "SOURCE_CODE" ]; then
   $terra config set image --default
 
   echo "Pulling the default Docker image"
-  /usr/local/bin/docker pull $($terra config get image)
+  docker pull $($terra config get image)
 
 elif [ "$installMode" = "GITHUB_RELEASE" ]; then
   echo "Creating a new build/test-install directory"

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -15,6 +15,7 @@ if [ $(basename $PWD) != 'terra-cli' ]; then
   exit 1
 fi
 
+# Tests currently assume Docker is available and running.
 installMode=$1
 echo "installMode: $installMode"
 if [ "$installMode" = "SOURCE_CODE" ]; then
@@ -25,7 +26,7 @@ if [ "$installMode" = "SOURCE_CODE" ]; then
   $terra config set image --default
 
   echo "Pulling the default Docker image"
-  docker pull $($terra config get image)
+  /usr/local/bin/docker pull $($terra config get image)
 
 elif [ "$installMode" = "GITHUB_RELEASE" ]; then
   echo "Creating a new build/test-install directory"

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -33,8 +33,10 @@ elif [ "$installMode" = "GITHUB_RELEASE" ]; then
   mkdir -p $(pwd)/build/test-install/
   cd build/test-install/
 
+  export TERRA_CLI_VERSION=jaycarlton_test5
+  export TERRA_CLI_DOCKER_MODE=DOCKER_AVAILABLE
   echo "Downloading the install script from GitHub and running it"
-  curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash
+  curl -L https://github.com/DataBiosphere/terra-cli/releases/download/jaycarlton_test5/download-install.sh | bash
 
 else
   echo "Usage: tools/install-for-testing.sh [installMode]"

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -33,10 +33,9 @@ elif [ "$installMode" = "GITHUB_RELEASE" ]; then
   mkdir -p $(pwd)/build/test-install/
   cd build/test-install/
 
-  export TERRA_CLI_VERSION=jaycarlton_test5
   export TERRA_CLI_DOCKER_MODE=DOCKER_AVAILABLE
   echo "Downloading the install script from GitHub and running it"
-  curl -L https://github.com/DataBiosphere/terra-cli/releases/download/jaycarlton_test5/download-install.sh | bash
+  curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash
 
 else
   echo "Usage: tools/install-for-testing.sh [installMode]"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -47,7 +47,7 @@ echo "--  Deleting the archive directory"
 cd "$archiveDir"/..
 rm -R "$archiveDir"
 
-if [ "$terraCliInstallationMode" == "DOCKER_NOT_AVAILABLE" ]; then
+if [ "$terraCliDockerMode" == "DOCKER_NOT_AVAILABLE" ]; then
   echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
   ./terra config set app-launch LOCAL_PROCESS
 else

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 set -e
 ## This script installs the Terra CLI from an unarchived release directory.
-## TERRA_CLI_INSTALLATION_MODE environment variable controls docker support. Set to
+## TERRA_CLI_DOCKER_MODE environment variable controls docker support. Set to
 ##     SUPPORT_DOCKER (default) or LOCAL_ONLY to skip docker steps.
 # # Dependencies: docker, gcloud
 ## Usage: ./install.sh
 
-echo "--  Determining Docker availability mode"
-if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
-  terraCliInstallationMode="DOCKER_AVAILABLE"
-elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
+if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
   terraCliInstallationMode="DOCKER_NOT_AVAILABLE"
+elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
+  terraCliInstallationMode="DOCKER_AVAILABLE"
 else
   echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1
 fi
 
-echo "Docker availability mode is $terraCliInstallationMode"
+echo "-- Docker availability mode is $terraCliInstallationMode"
 
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD
@@ -53,7 +52,7 @@ if [ "$terraCliInstallationMode" == "DOCKER_NOT_AVAILABLE" ]; then
 else
   echo "Setting the Docker image id to the default"
   ./terra config set image --default
-
+  ./terra config set app-launch DOCKER_CONTAINER
   echo "Pulling the default Docker image"
   defaultDockerImage=$(terra config get image)
   docker pull "$defaultDockerImage"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,20 +2,21 @@
 set -e
 ## This script installs the Terra CLI from an unarchived release directory.
 ## TERRA_CLI_DOCKER_MODE environment variable controls docker support. Set to
-##     SUPPORT_DOCKER (default) or LOCAL_ONLY to skip docker steps.
+##     DOCKER_NOT_AVAILABLE (default) to skip pulling the Docker image
+#      or DOCKER_AVAILABLE to pull the image (requires Docker to be installed and running).
 # # Dependencies: docker, gcloud
 ## Usage: ./install.sh
 
 if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
-  terraCliInstallationMode="DOCKER_NOT_AVAILABLE"
+  terraCliDockerMode="DOCKER_NOT_AVAILABLE"
 elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
-  terraCliInstallationMode="DOCKER_AVAILABLE"
+  terraCliDockerMode="DOCKER_AVAILABLE"
 else
   echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1
 fi
 
-echo "-- Docker availability mode is $terraCliInstallationMode"
+echo "-- Docker availability mode is $terraCliDockerMode"
 
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -4,6 +4,13 @@ set -e
 ## Dependencies: docker, gcloud
 ## Usage: ./install.sh
 
+echo "--  Determining installation mode"
+if [[ -z "$TERRA_CLI_INSTALLATION_MODE" ]]; then
+  terraCliInstallationMode="SUPPORT_DOCKER"
+else
+  terraCliInstallationMode="LOCAL_ONLY"
+fi
+
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD
 if [ ! -f "$archiveDir/install.sh" ]; then
@@ -13,7 +20,7 @@ fi
 
 echo "--  Checking for application directory"
 applicationDir="${HOME}/.terra"
-mkdir -p $applicationDir
+mkdir -p "$applicationDir"
 if [ ! -d "${applicationDir}" ]; then
     echo "Error creating application directory: ${applicationDir}"
     exit 1
@@ -21,28 +28,32 @@ fi
 
 echo "--  Moving JARs to application directory"
 if [ -f "${applicationDir}/lib" ] || [ -d "${applicationDir}/lib" ]; then
-  rm -R "${applicationDir}/lib"
+  rm -R "${applicationDir:?}/lib"
 fi
-cp -R $archiveDir/lib $applicationDir/lib
+cp -R "$archiveDir"/lib "$applicationDir"/lib
 
 echo "--  Moving run script and README out of archive directory"
-cp $archiveDir/bin/terra $archiveDir/../terra
-cp $archiveDir/README.md $archiveDir/../README.md
+cp "$archiveDir"/bin/terra "$archiveDir"/../terra
+cp "$archiveDir"/README.md "$archiveDir"/../README.md
 
 echo "--  Deleting the archive directory"
-cd $archiveDir/..
-rm -R $archiveDir
+cd "$archiveDir"/..
+rm -R "$archiveDir"
 
 echo "--  Setting the Docker image id to the default"
 ./terra config set image --default
 
-echo "--  Pulling the default Docker image"
-defaultDockerImage=$(./terra config get image)
-docker pull $defaultDockerImage
+if [ "$terraCliInstallationMode" == "SUPPORT_DOCKER" ]; then
+  echo "--  Pulling the default Docker image"
+  defaultDockerImage=$(./terra config get image)
+  docker pull "$defaultDockerImage"
+else
+  echo "-- No Docker support required. Will not pull image."
+fi
 
 echo "-- Setting the server to its current value, to pull any changes"
 currentServer=$(./terra config get server)
-./terra config set server --name=$currentServer
+./terra config set server --name="$currentServer"
 
 echo "--  Install complete"
 echo "You can add the ./terra executable to your \$PATH"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -49,10 +49,10 @@ rm -R "$archiveDir"
 
 if [ "$terraCliInstallationMode" == "DOCKER_NOT_AVAILABLE" ]; then
   echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
-  terra config set app-launch LOCAL_PROCESS
+  ./terra config set app-launch LOCAL_PROCESS
 else
   echo "Setting the Docker image id to the default"
-  terra config set image --default
+  ./terra config set image --default
 
   echo "Pulling the default Docker image"
   defaultDockerImage=$(terra config get image)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -16,7 +16,7 @@ else
   exit 1
 fi
 
-echo "-- Docker availability mode is $terraCliDockerMode"
+echo "--  Docker availability mode is $terraCliDockerMode"
 
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD
@@ -51,18 +51,18 @@ if [ "$terraCliDockerMode" == "DOCKER_NOT_AVAILABLE" ]; then
   echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
   ./terra config set app-launch LOCAL_PROCESS
 else
-  echo "Setting the Docker image id to the default"
+  echo "--   Setting the Docker image id to the default"
   ./terra config set image --default
   ./terra config set app-launch DOCKER_CONTAINER
-  echo "Pulling the default Docker image"
+  echo "--   Pulling the default Docker image"
   defaultDockerImage=$(./terra config get image)
   docker pull "$defaultDockerImage"
 fi
 
-echo "-- Setting the server to its current value, to pull any changes"
+echo "--   Setting the server to its current value, to pull any changes"
 currentServer=$(./terra config get server)
 ./terra config set server --name="$currentServer"
 
-echo "--  Install complete"
+echo "--   Install complete"
 echo "You can add the ./terra executable to your \$PATH"
 echo "Run \"./terra\" to see usage"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -6,7 +6,7 @@ set -e
 # # Dependencies: docker, gcloud
 ## Usage: ./install.sh
 
-echo "Determining installation mode"
+echo "--  Determining Docker availability mode"
 if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
   terraCliInstallationMode="DOCKER_AVAILABLE"
 elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
@@ -15,6 +15,8 @@ else
   echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1
 fi
+
+echo "Docker availability mode is $terraCliInstallationMode"
 
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -54,7 +54,7 @@ else
   ./terra config set image --default
   ./terra config set app-launch DOCKER_CONTAINER
   echo "Pulling the default Docker image"
-  defaultDockerImage=$(terra config get image)
+  defaultDockerImage=$(./terra config get image)
   docker pull "$defaultDockerImage"
 fi
 

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -11,7 +11,7 @@ if [ "$(basename "$PWD")" != 'terra-cli' ]; then
   exit 1
 fi
 
-echo "Determining installation mode"
+echo "Determining Docker availability mode"
 if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
   terraCliInstallationMode="DOCKER_AVAILABLE"
 elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -12,16 +12,16 @@ if [ "$(basename "$PWD")" != 'terra-cli' ]; then
 fi
 
 echo "Determining installation mode"
-if [ -z "$TERRA_CLI_INSTALLATION_MODE" ] || [ "$TERRA_CLI_INSTALLATION_MODE" == "SUPPORT_DOCKER" ]; then
-  terraCliInstallationMode="SUPPORT_DOCKER"
-elif [ "$TERRA_CLI_INSTALLATION_MODE" == "LOCAL_ONLY" ]; then
-  terraCliInstallationMode="LOCAL_ONLY"
+if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
+  terraCliInstallationMode="DOCKER_AVAILABLE"
+elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
+  terraCliInstallationMode="DOCKER_NOT_AVAILABLE"
 else
-  echo "Unsupported TERRA_CLI_INSTALLATION_MODE specified: $TERRA_CLI_INSTALLATION_MODE"
+  echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1
 fi
 
-echo "Installation mode is $terraCliInstallationMode"
+echo "Docker availability mode is $terraCliInstallationMode"
 
 echo "Building Java code"
 ./gradlew clean install
@@ -29,11 +29,13 @@ echo "Building Java code"
 echo "Aliasing JAR file"
 alias terra="$(pwd)"/build/install/terra-cli/bin/terra
 
-if [ "$terraCliInstallationMode" == "LOCAL_ONLY" ]; then
-  echo "Installing without docker support"
+if [ "$terraCliInstallationMode" == "DOCKER_NOT_AVAILABLE" ]; then
+  echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
+  terra config set app-launch LOCAL_PROCESS
 else
   echo "Setting the Docker image id to the default"
   terra config set image --default
+
   echo "Pulling the default Docker image"
   defaultDockerImage=$(terra config get image)
   docker pull "$defaultDockerImage"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -2,10 +2,7 @@
 
 set -e
 ## This script sets up the environment for local development.
-## TERRA_CLI_DOCKER_MODE environment variable controls docker support. Set to
-##     DOCKER_NOT_AVAILABLE (default) to skip pulling the Docker image
-#      or DOCKER_AVAILABLE to pull the image (requires Docker to be installed and running).
-# # Dependencies: docker, chmod
+## Dependencies: docker, chmod
 ## Usage: source tools/local-dev.sh
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
@@ -14,34 +11,18 @@ if [ "$(basename "$PWD")" != 'terra-cli' ]; then
   exit 1
 fi
 
-if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
-  terraCliDockerMode="DOCKER_NOT_AVAILABLE"
-elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
-  terraCliDockerMode="DOCKER_AVAILABLE"
-else
-  echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
-  exit 1
-fi
-
-echo "Docker availability mode is $terraCliDockerMode"
-
 echo "Building Java code"
 ./gradlew clean install
 
 echo "Aliasing JAR file"
 alias terra="$(pwd)"/build/install/terra-cli/bin/terra
 
-if [ "$terraCliDockerMode" == "DOCKER_NOT_AVAILABLE" ]; then
-  echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
-  terra config set app-launch LOCAL_PROCESS
-else
-  echo "Setting the Docker image id to the default"
-  terra config set image --default
-  terra config set app-launch DOCKER_CONTAINER
-  echo "Pulling the default Docker image"
-  defaultDockerImage=$(terra config get image)
-  docker pull "$defaultDockerImage"
-fi
+echo "Setting the Docker image id to the default"
+terra config set image --default
+terra config set app-launch DOCKER_CONTAINER
+echo "Pulling the default Docker image"
+defaultDockerImage=$(terra config get image)
+docker pull "$defaultDockerImage"
 
 echo "Setting the server to its current value, to pull any changes"
 currentServer=$(terra config get server)

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -11,11 +11,10 @@ if [ "$(basename "$PWD")" != 'terra-cli' ]; then
   exit 1
 fi
 
-echo "Determining Docker availability mode"
-if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
-  terraCliInstallationMode="DOCKER_AVAILABLE"
-elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
+if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
   terraCliInstallationMode="DOCKER_NOT_AVAILABLE"
+elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
+  terraCliInstallationMode="DOCKER_AVAILABLE"
 else
   echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1


### PR DESCRIPTION
Since we have a config option to run apps locally instead of in the docker container, we technically can install the CLI without docker. This changes mainly the bash installation scripts to make this possible.

Also changed some bash code based on IDE suggestions, primarily around double quoting expanded variables.