### PR TITLE
[PF-1309] Removed use of pet SA to call WSM.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -176,7 +176,7 @@ public abstract class Resource {
   public abstract String resolve();
 
   /**
-   * Check whether a user can access a resource.
+   * Check whether a user's pet SA can access a resource.
    *
    * @return true if the user can access the referenced resource with the given credentials
    * @throws UserActionableException if the resource is CONTROLLED

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -176,9 +176,9 @@ public abstract class Resource {
   public abstract String resolve();
 
   /**
-   * Check whether a user's pet SA can access a resource.
+   * Check whether a user can access a resource.
    *
-   * @return true if the user's pet SA can access the referenced resource with the given credentials
+   * @return true if the user can access the referenced resource with the given credentials
    * @throws UserActionableException if the resource is CONTROLLED
    */
   public boolean checkAccess() {
@@ -187,7 +187,7 @@ public abstract class Resource {
           "Unexpected stewardship type. Checking access is intended for REFERENCED resources only.");
     }
     // call WSM to check access to the resource
-    return WorkspaceManagerService.fromContextForPetSa()
+    return WorkspaceManagerService.fromContext()
         .checkAccess(Context.requireWorkspace().getId(), id);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -278,7 +278,7 @@ public class Workspace {
    */
   public ClonedWorkspace clone(@Nullable String name, @Nullable String description) {
     CloneWorkspaceResult result =
-        WorkspaceManagerService.fromContextForPetSa().cloneWorkspace(id, name, description);
+        WorkspaceManagerService.fromContext().cloneWorkspace(id, name, description);
     return result.getWorkspace();
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
@@ -78,12 +78,8 @@ public class BqDataset extends Resource {
   public static BqDataset addReferenced(CreateBqDatasetParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference. use the pet SA credentials instead of the end user's
-    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
-    // scope to perform its access check before adding the reference. note that this means a user
-    // cannot add a reference unless their pet SA has access to it.
     GcpBigQueryDatasetResource addedResource =
-        WorkspaceManagerService.fromContextForPetSa()
+        WorkspaceManagerService.fromContext()
             .createReferencedBigQueryDataset(Context.requireWorkspace().getId(), createParams);
     logger.info("Created BQ dataset: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
@@ -72,12 +72,8 @@ public class BqTable extends Resource {
   public static BqTable addReferenced(AddBqTableParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference. use the pet SA credentials instead of the end user's
-    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
-    // scope to perform its access check before adding the reference. note that this means a user
-    // cannot add a reference unless their pet SA has access to it.
     GcpBigQueryDataTableResource addedResource =
-        WorkspaceManagerService.fromContextForPetSa()
+        WorkspaceManagerService.fromContext()
             .createReferencedBigQueryDataTable(Context.requireWorkspace().getId(), createParams);
     logger.info("Created BQ data table: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
@@ -69,12 +69,8 @@ public class GcsBucket extends Resource {
   public static GcsBucket addReferenced(CreateGcsBucketParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference. use the pet SA credentials instead of the end user's
-    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
-    // scope to perform its access check before adding the reference. note that this means a user
-    // cannot add a reference unless their pet SA has access to it.
     GcpGcsBucketResource addedResource =
-        WorkspaceManagerService.fromContextForPetSa()
+        WorkspaceManagerService.fromContext()
             .createReferencedGcsBucket(Context.requireWorkspace().getId(), createParams);
     logger.info("Created GCS bucket: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
@@ -68,12 +68,8 @@ public class GcsObject extends Resource {
   public static GcsObject addReferenced(AddGcsObjectParams createParams) {
     validateEnvironmentVariableName(createParams.resourceFields.name);
 
-    // call WSM to add the reference. use the pet SA credentials instead of the end user's
-    // credentials, because they include the cloud-platform scope. WSM needs the cloud-platform
-    // scope to perform its access check before adding the reference. note that this means a user
-    // cannot add a reference unless their pet SA has access to it.
     GcpGcsObjectResource addedResource =
-        WorkspaceManagerService.fromContextForPetSa()
+        WorkspaceManagerService.fromContext()
             .createReferencedGcsObject(Context.requireWorkspace().getId(), createParams);
     logger.info("Created GCS bucket object: {}", addedResource);
 

--- a/src/main/java/bio/terra/cli/command/auth/Status.java
+++ b/src/main/java/bio/terra/cli/command/auth/Status.java
@@ -36,8 +36,7 @@ public class Status extends BaseCommand {
               !currentUser.requiresReauthentication());
     }
 
-    formatOption.printReturnValue(
-        authStatusReturnValue, returnValue -> this.printText(returnValue));
+    formatOption.printReturnValue(authStatusReturnValue, this::printText);
   }
 
   /** Print this command's output in text format. */

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -148,19 +148,6 @@ public class WorkspaceManagerService {
   }
 
   /**
-   * Factory method for class that talks to WSM. Pulls the current server and user from the context.
-   * Uses the pet SA credentials instead of the end user credentials. This is useful for when an
-   * endpoint needs to be called with a cloud platform scope. The CLI does not request any cloud
-   * platform scopes from the end user when they login to the CLI, but it does grant the full
-   * cloud-platform scope to the pet SA credentials. The WSM endpoints to create and check access to
-   * referenced resources currently use this.
-   */
-  public static WorkspaceManagerService fromContextForPetSa() {
-    return new WorkspaceManagerService(
-        Context.requireUser().getPetSaAccessToken(), Context.getServer());
-  }
-
-  /**
    * Constructor for class that talks to WSM. If the access token is null, only unauthenticated
    * endpoints can be called.
    */


### PR DESCRIPTION
As of https://github.com/DataBiosphere/terra-workspace-manager/pull/443, we no longer need to use the pet SA on the client side to interact with WSM. It's still useful when making calls directly to GCP, though.