### PR TITLE
[PF-1297] Update error message in test

### DIFF
--- a/src/test/java/unit/ClientExceptionHandling.java
+++ b/src/test/java/unit/ClientExceptionHandling.java
@@ -80,6 +80,6 @@ public class ClientExceptionHandling extends SingleWorkspaceUnit {
     assertThat(
         "stderr includes the WSM error message",
         stdErr,
-        CoreMatchers.containsString("A BigQuery dataset with ID " + datasetId + " already exists"));
+        CoreMatchers.containsString("A resource with matching attributes already exists"));
   }
 }


### PR DESCRIPTION
The `ClientExceptionHandling` test checked for a literal error message from WSM but a recent PR changed that message (https://github.com/DataBiosphere/terra-workspace-manager/pull/550), causing a nightly test failure. This updates the expected message to match behavior.