### PR TITLE
[PF-1333] use ADC when available for log into terra CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ if (hasProperty('buildScan')) {
 }
 
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.141.0'
+version = '0.142.0'
 group = 'terra-cli'
 sourceCompatibility = JavaVersion.VERSION_11
 

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -60,7 +60,7 @@ public class AppDefaultCredentialUtils {
    * current user or their pet SA
    */
   public static void throwIfADCDontMatchContext() {
-    if (!doADCMatchContext()) {
+    if (!doAdcMatchContext()) {
       throw new UserActionableException(
           "Application default credentials do not match the user or pet SA emails.");
     }
@@ -71,7 +71,7 @@ public class AppDefaultCredentialUtils {
    * user+workspace, or if they are end-user credentials, which we can't validate directly. Throw an
    * exception if they are not defined.
    */
-  private static boolean doADCMatchContext() {
+  private static boolean doAdcMatchContext() {
     GoogleCredentials appDefaultCreds = getApplicationDefaultCredentials();
 
     if (appDefaultCreds instanceof UserCredentials) {

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -72,7 +72,7 @@ public class AppDefaultCredentialUtils {
    * exception if they are not defined.
    */
   private static boolean doADCMatchContext() {
-    GoogleCredentials appDefaultCreds = getADC();
+    GoogleCredentials appDefaultCreds = getApplicationDefaultCredentials();
 
     if (appDefaultCreds instanceof UserCredentials) {
       logger.info("ADC are end-user credentials. Skipping account/email validation.");
@@ -91,7 +91,7 @@ public class AppDefaultCredentialUtils {
   }
 
   /** Get the application default credentials. Throw an exception if they are not defined. */
-  public static GoogleCredentials getADC() {
+  public static GoogleCredentials getApplicationDefaultCredentials() {
     try {
       return GoogleCredentials.getApplicationDefault();
     } catch (IOException ioEx) {

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -91,7 +91,7 @@ public class AppDefaultCredentialUtils {
   }
 
   /** Get the application default credentials. Throw an exception if they are not defined. */
-  private static GoogleCredentials getADC() {
+  public static GoogleCredentials getADC() {
     try {
       return GoogleCredentials.getApplicationDefault();
     } catch (IOException ioEx) {

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -59,8 +59,6 @@ public class User {
   // service account google credentials pulled from app-default-credentials.
   private GoogleCredentials googleCredentials;
 
-  private boolean useAppDefaultCredentials;
-
   // these are the same scopes requested by Terra service swagger pages
   @VisibleForTesting
   public static final List<String> USER_SCOPES = ImmutableList.of("openid", "email", "profile");
@@ -181,7 +179,6 @@ public class User {
 
   private void checkForAppDefaultCredentials() {
     if (googleCredentials == null) {
-      useAppDefaultCredentials = true;
       googleCredentials = AppDefaultCredentialUtils.getADC().createScoped(PET_SA_SCOPES);
     }
   }

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -161,14 +161,18 @@ public class User {
   }
 
   private void checkForAppDefaultCredentials() {
-    googleCredentials = AppDefaultCredentialUtils.getADC().createScoped(PET_SA_SCOPES);
+    if (googleCredentials == null) {
+      googleCredentials = AppDefaultCredentialUtils.getADC().createScoped(PET_SA_SCOPES);
+    }
   }
 
   /** Delete all credentials associated with this user. */
   public void logout() {
     deleteOauthCredentials();
     deletePetSaCredentials();
-    GoogleOauth.revokeToken(googleCredentials);
+    if (googleCredentials != null) {
+      GoogleOauth.revokeToken(googleCredentials);
+    }
 
     // unset the current user in the global context
     Context.setUser(null);
@@ -372,6 +376,7 @@ public class User {
 
   /** Return true if the user credentials are expired or do not exist on disk. */
   public boolean requiresReauthentication() {
+    checkForAppDefaultCredentials();
     if (googleCredentials == null) {
       return true;
     }

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -122,7 +122,7 @@ public class User {
   }
 
   /**
-   * Load any existing credneitals for the user. Prompt for login if they are expired or do not
+   * Load any existing credentials for the user. Prompt for login if they are expired or do not
    * exist. Do not use application default credentials for logging in.
    */
   public static void login() {
@@ -144,7 +144,7 @@ public class User {
 
     if (useAdc) {
       try {
-        user.checkForAppDefaultCredentials();
+        user.loadAppDefaultCredentials();
       } catch (UserActionableException e) {
         logger.debug("Failed to get app default credentials, do oauth login flow instead");
         // do the login flow if the current user is undefined or has expired credentials
@@ -177,7 +177,7 @@ public class User {
     }
   }
 
-  private void checkForAppDefaultCredentials() {
+  private void loadAppDefaultCredentials() {
     if (googleCredentials == null) {
       googleCredentials =
           AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(PET_SA_SCOPES);
@@ -394,7 +394,7 @@ public class User {
 
   /** Return true if the user credentials are expired or do not exist on disk. */
   public boolean requiresReauthentication() {
-    checkForAppDefaultCredentials();
+    loadAppDefaultCredentials();
     if (googleCredentials == null) {
       return true;
     }

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -93,6 +93,7 @@ public class User {
     this.email = configFromDisk.email;
     this.proxyGroupEmail = configFromDisk.proxyGroupEmail;
     this.petSAEmail = configFromDisk.petSAEmail;
+    this.useApplicationDefaultCredentials = configFromDisk.useApplicationDefaultCredentials;
   }
 
   /** Build an empty instance of this class. */
@@ -397,6 +398,10 @@ public class User {
 
   public GoogleCredentials getPetSACredentials() {
     return GoogleCredentials.create(getPetSaAccessToken());
+  }
+
+  public boolean isUseApplicationDefaultCredentials() {
+    return useApplicationDefaultCredentials;
   }
 
   /** Return true if the user credentials are expired or do not exist on disk. */

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -179,7 +179,8 @@ public class User {
 
   private void checkForAppDefaultCredentials() {
     if (googleCredentials == null) {
-      googleCredentials = AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(PET_SA_SCOPES);
+      googleCredentials =
+          AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(PET_SA_SCOPES);
     }
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -179,7 +179,7 @@ public class User {
 
   private void checkForAppDefaultCredentials() {
     if (googleCredentials == null) {
-      googleCredentials = AppDefaultCredentialUtils.getADC().createScoped(PET_SA_SCOPES);
+      googleCredentials = AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(PET_SA_SCOPES);
     }
   }
 

--- a/src/main/java/bio/terra/cli/command/auth/Login.java
+++ b/src/main/java/bio/terra/cli/command/auth/Login.java
@@ -13,11 +13,16 @@ import picocli.CommandLine.Command;
     showDefaultValues = true)
 public class Login extends BaseCommand {
 
+  public enum LogInMode {
+    BROWSER,
+    APP_DEFAULT_CREDENTIALS
+  }
+
   @CommandLine.Option(
-      names = "--use-app-default-credentials",
-      description = "Use application default credentials to log into terra CLI instead of browser.",
-      defaultValue = "false")
-  private boolean useAppDefaultCreds;
+      names = "--mode",
+      description = "Set the log in mode: ${COMPLETION-CANDIDATES}. Default to BROWSER",
+      defaultValue = "BROWSER")
+  private LogInMode mode;
 
   /** Login the user and print out a success message. */
   @Override
@@ -27,7 +32,7 @@ public class Login extends BaseCommand {
       Context.requireUser().logout();
     }
 
-    User.login(useAppDefaultCreds);
+    User.login(mode);
     OUT.println("Login successful: " + Context.requireUser().getEmail());
   }
 

--- a/src/main/java/bio/terra/cli/command/auth/Login.java
+++ b/src/main/java/bio/terra/cli/command/auth/Login.java
@@ -9,12 +9,14 @@ import picocli.CommandLine.Command;
 /** This class corresponds to the third-level "terra auth login" command. */
 @Command(
     name = "login",
-    description = "Authorize the CLI to access Terra APIs and data with user credentials.")
+    description = "Authorize the CLI to access Terra APIs and data with user credentials.",
+    showDefaultValues = true)
 public class Login extends BaseCommand {
 
   @CommandLine.Option(
       names = "--use-app-default-credentials",
-      description = "Use application default credentials to log into terra CLI instead of browser.")
+      description = "Use application default credentials to log into terra CLI instead of browser.",
+      defaultValue = "false")
   private boolean useAppDefaultCreds;
 
   /** Login the user and print out a success message. */

--- a/src/main/java/bio/terra/cli/command/auth/Login.java
+++ b/src/main/java/bio/terra/cli/command/auth/Login.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.auth;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.User;
 import bio.terra.cli.command.shared.BaseCommand;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra auth login" command. */
@@ -10,6 +11,11 @@ import picocli.CommandLine.Command;
     name = "login",
     description = "Authorize the CLI to access Terra APIs and data with user credentials.")
 public class Login extends BaseCommand {
+
+  @CommandLine.Option(
+      names = "--use-app-default-credentials",
+      description = "Use application default credentials to log into terra CLI instead of browser.")
+  private boolean useAppDefaultCreds;
 
   /** Login the user and print out a success message. */
   @Override
@@ -19,7 +25,7 @@ public class Login extends BaseCommand {
       Context.requireUser().logout();
     }
 
-    User.login();
+    User.login(useAppDefaultCreds);
     OUT.println("Login successful: " + Context.requireUser().getEmail());
   }
 

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
@@ -17,6 +17,7 @@ public class PDUser {
   public final String email;
   public final String proxyGroupEmail;
   public final String petSAEmail;
+  public final boolean useApplicationDefaultCredentials;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDUser(User internalObj) {
@@ -24,6 +25,7 @@ public class PDUser {
     this.email = internalObj.getEmail();
     this.proxyGroupEmail = internalObj.getProxyGroupEmail();
     this.petSAEmail = internalObj.getPetSaEmail();
+    this.useApplicationDefaultCredentials = internalObj.isUseApplicationDefaultCredentials();
   }
 
   private PDUser(PDUser.Builder builder) {
@@ -31,6 +33,7 @@ public class PDUser {
     this.email = builder.email;
     this.proxyGroupEmail = builder.proxyGroupEmail;
     this.petSAEmail = builder.petSAEmail;
+    this.useApplicationDefaultCredentials = builder.useApplicationDefaultCredentials;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -39,6 +42,7 @@ public class PDUser {
     private String email;
     private String proxyGroupEmail;
     private String petSAEmail;
+    private boolean useApplicationDefaultCredentials;
 
     public Builder id(String id) {
       this.id = id;
@@ -57,6 +61,11 @@ public class PDUser {
 
     public Builder petSAEmail(String petSAEmail) {
       this.petSAEmail = petSAEmail;
+      return this;
+    }
+
+    public Builder useApplicationDefaultCredentials(boolean useApplicationDefaultCredentials) {
+      this.useApplicationDefaultCredentials = useApplicationDefaultCredentials;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDUser.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.serialization.persisted;
 
 import bio.terra.cli.businessobject.User;
+import bio.terra.cli.command.auth.Login.LogInMode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 
@@ -17,7 +18,7 @@ public class PDUser {
   public final String email;
   public final String proxyGroupEmail;
   public final String petSAEmail;
-  public final boolean useApplicationDefaultCredentials;
+  public final LogInMode useApplicationDefaultCredentials;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDUser(User internalObj) {
@@ -25,7 +26,7 @@ public class PDUser {
     this.email = internalObj.getEmail();
     this.proxyGroupEmail = internalObj.getProxyGroupEmail();
     this.petSAEmail = internalObj.getPetSaEmail();
-    this.useApplicationDefaultCredentials = internalObj.isUseApplicationDefaultCredentials();
+    this.useApplicationDefaultCredentials = internalObj.getLogInMode();
   }
 
   private PDUser(PDUser.Builder builder) {
@@ -42,7 +43,7 @@ public class PDUser {
     private String email;
     private String proxyGroupEmail;
     private String petSAEmail;
-    private boolean useApplicationDefaultCredentials;
+    private LogInMode useApplicationDefaultCredentials;
 
     public Builder id(String id) {
       this.id = id;
@@ -64,7 +65,7 @@ public class PDUser {
       return this;
     }
 
-    public Builder useApplicationDefaultCredentials(boolean useApplicationDefaultCredentials) {
+    public Builder useApplicationDefaultCredentials(LogInMode useApplicationDefaultCredentials) {
       this.useApplicationDefaultCredentials = useApplicationDefaultCredentials;
       return this;
     }

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -275,16 +275,18 @@ public final class GoogleOauth {
    * @param credential credentials object
    */
   public static void revokeToken(GoogleCredentials credential) {
-    String endpoint = "https://oauth2.googleapis.com/revoke";
-    Map<String, String> headers =
-        ImmutableMap.of("Content-type", "application/x-www-form-urlencoded");
-    Map<String, String> params =
-        ImmutableMap.of("token", credential.getAccessToken().getTokenValue());
+    if (credential.getAccessToken() != null) {
+      String endpoint = "https://oauth2.googleapis.com/revoke";
+      Map<String, String> headers =
+          ImmutableMap.of("Content-type", "application/x-www-form-urlencoded");
+      Map<String, String> params =
+          ImmutableMap.of("token", credential.getAccessToken().getTokenValue());
 
-    try {
-      HttpUtils.sendHttpRequest("https://oauth2.googleapis.com/revoke", "POST", headers, params);
-    } catch (IOException ioEx) {
-      throw new SystemException("Unable to revoke token", ioEx);
+      try {
+        HttpUtils.sendHttpRequest(endpoint, "POST", headers, params);
+      } catch (IOException ioEx) {
+        throw new SystemException("Unable to revoke token", ioEx);
+      }
     }
   }
 }

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -31,6 +31,7 @@ import java.security.GeneralSecurityException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -274,13 +275,13 @@ public final class GoogleOauth {
    *
    * @param credential credentials object
    */
-  public static void revokeToken(GoogleCredentials credential) {
-    if (credential.getAccessToken() != null) {
+  public static void revokeToken(Optional<GoogleCredentials> credential) {
+    if (credential.isPresent() && credential.get().getAccessToken() != null) {
       String endpoint = "https://oauth2.googleapis.com/revoke";
       Map<String, String> headers =
           ImmutableMap.of("Content-type", "application/x-www-form-urlencoded");
       Map<String, String> params =
-          ImmutableMap.of("token", credential.getAccessToken().getTokenValue());
+          ImmutableMap.of("token", credential.get().getAccessToken().getTokenValue());
 
       try {
         HttpUtils.sendHttpRequest(endpoint, "POST", headers, params);


### PR DESCRIPTION
terra auth login currently requires user authenticating through browser oauth flow. 

I added a flag --use-app-default-credentials that allows logging into terra with application default credentials when it is available. If the flag is on but the app default credential is not available, we will still open the browser as a fallback. 

This is to log into terra as the Pet service account when creating a notebook instance to simplify end user's setup. 