### PR TITLE
[PF-1341] When setting metadata to the notebook, still append the default metadata unless specified to be override

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -228,9 +228,9 @@ public class GcpNotebook extends BaseCommand {
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
             .accessScope(AccessScope.PRIVATE_ACCESS);
-    Map<String, String> metadatas = defaultMetadata(Context.requireWorkspace().getId());
+    Map<String, String> allMetadata = defaultMetadata(Context.requireWorkspace().getId());
     if (metadata != null) {
-      metadatas.putAll(metadata);
+      allMetadata.putAll(metadata);
     }
     CreateGcpNotebookParams.Builder createParams =
         new CreateGcpNotebookParams.Builder()
@@ -239,7 +239,7 @@ public class GcpNotebook extends BaseCommand {
             .location(location)
             .machineType(machineType)
             .postStartupScript(postStartupScript)
-            .metadata(metadatas);
+            .metadata(allMetadata);
 
     if (acceleratorConfig != null) {
       createParams

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -227,6 +227,9 @@ public class GcpNotebook extends BaseCommand {
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
             .accessScope(AccessScope.PRIVATE_ACCESS);
+    if (metadata != null) {
+      metadata.putAll(defaultMetadata(Context.requireWorkspace().getId()));
+    }
     CreateGcpNotebookParams.Builder createParams =
         new CreateGcpNotebookParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -67,8 +67,8 @@ public class GcpNotebook extends BaseCommand {
   @CommandLine.Option(
       names = "--metadata",
       description =
-          "Custom metadata to apply to this instance.\nBy default sets some jupyterlab extensions "
-              + "(installed-extensions=jupyterlab_bigquery-latest.tar.gz,jupyterlab_gcsfilebrowser-latest.tar.gz,jupyterlab_gcpscheduler-latest.tar.gz) "
+          "Custom metadata to apply to this instance.\n"
+              + "By default set Terra CLI server terra-cli-server=[CLI_SERVER_ID]\n"
               + "and the Terra workspace id (terra-workspace-id=[WORKSPACE_ID]).")
   private Map<String, String> metadata;
 
@@ -227,8 +227,9 @@ public class GcpNotebook extends BaseCommand {
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
             .accessScope(AccessScope.PRIVATE_ACCESS);
+    Map<String, String> metadatas = defaultMetadata(Context.requireWorkspace().getId());
     if (metadata != null) {
-      metadata.putAll(defaultMetadata(Context.requireWorkspace().getId()));
+      metadatas.putAll(metadata);
     }
     CreateGcpNotebookParams.Builder createParams =
         new CreateGcpNotebookParams.Builder()
@@ -237,8 +238,7 @@ public class GcpNotebook extends BaseCommand {
             .location(location)
             .machineType(machineType)
             .postStartupScript(postStartupScript)
-            .metadata(
-                metadata == null ? defaultMetadata(Context.requireWorkspace().getId()) : metadata);
+            .metadata(metadatas);
 
     if (acceleratorConfig != null) {
       createParams


### PR DESCRIPTION
the default metadata are workspace id and server id. Unless specifically override by user input, we should still append those when some arbitray metadata is appended.