### PR TITLE
Fix enable pet call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ dependencies {
         // terra libraries
         crlPlatform = "0.2.0"
         samClient = "0.1-ffb0a89-SNAP"
-        workspaceManagerClient = "0.254.161-SNAPSHOT"
+        workspaceManagerClient = "0.254.182-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
 
         // needed for WSM client library

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -203,8 +203,8 @@ public class Workspace {
    *
    * @return Email identifier of the pet SA the current user can now actAs.
    */
-  public String enablePet() {
-    return WorkspaceManagerService.fromContext().enablePet(id);
+  public void enablePet() {
+    WorkspaceManagerService.fromContext().enablePet(id);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -351,8 +351,8 @@ public class WorkspaceManagerService {
    * @param workspaceId the id of the workspace to enable pet impersonation in
    * @return the email identifier of the pet SA which the user can now impersonate
    */
-  public String enablePet(UUID workspaceId) {
-    return callWithRetries(
+  public void enablePet(UUID workspaceId) {
+    callWithRetries(
         () -> new WorkspaceApi(apiClient).enablePet(workspaceId), "Error enabling user's pet SA");
   }
 


### PR DESCRIPTION
A change to `enablePet()` made it return void instead of `String`.  This broke CLI compilation when I upgraded the workspace manager client lib.