### PR TITLE
[PF-1321] increase limit when fetching workspace list

### DIFF
--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -318,12 +318,14 @@ public class Workspace extends ClearContextUnit {
 
   /**
    * Helper method to call `terra workspace list` and filter the results on the specified workspace
-   * id.
+   * id. Use a high limit to ensure that leaked workspaces in the list don't cause the one we care
+   * about to page out.
    */
   static List<UFWorkspace> listWorkspacesWithId(UUID workspaceId) throws JsonProcessingException {
-    // `terra workspace list --format=json`
+    // `terra workspace list --format=json --limit=500`
     List<UFWorkspace> listWorkspaces =
-        TestCommand.runAndParseCommandExpectSuccess(new TypeReference<>() {}, "workspace", "list");
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "workspace", "list", "--limit=500");
 
     return listWorkspaces.stream()
         .filter(workspace -> workspace.id.equals(workspaceId))


### PR DESCRIPTION
Stopgap to work around an issue caused by many leaked workspaces in `dev`. When fetching the workspace list, if there were too many workspaces, the one we care about might not be returned in the first page, as the test expects. Solution for now is to use a much larger `limit` parameter than the default.