### PR TITLE
[PF-1368] remove numResources from workspace JSON output

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -234,11 +234,7 @@ public class Context {
   }
 
   public static Workspace requireWorkspace() {
-    return getWorkspace()
-        .orElseThrow(
-            () -> {
-              throw new UserActionableException("No workspace set.");
-            });
+    return getWorkspace().orElseThrow(() -> new UserActionableException("No workspace set."));
   }
 
   public static void setWorkspace(Workspace workspace) {

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -36,13 +36,13 @@ import org.slf4j.LoggerFactory;
 public class Workspace {
   private static final Logger logger = LoggerFactory.getLogger(Workspace.class);
 
-  private final UUID id;
+  private UUID id;
   private String name; // not unique
   private String description;
   private String googleProjectId;
 
   // name of the server where this workspace exists
-  private final String serverName;
+  private String serverName;
 
   // email of the user that loaded the workspace to this machine
   private String userEmail;
@@ -50,14 +50,9 @@ public class Workspace {
   // list of resources (controlled & referenced)
   private List<Resource> resources;
 
-  // true if we've populated the resources. It may still be an empty array, if the workspace
-  // actually has no resources. false if we haven't populated the array (even if the workspace
-  // actually does have resources). This is necessary because the WorkspaceDefinition
-  private final boolean resourcesPopulated;
-
   // true if the workspace metadata was fetched. false when a user sets the workspace without being
   // logged in; in that case, we can't request the metadata from WSM without valid credentials.
-  private final boolean isLoaded;
+  private boolean isLoaded;
 
   /** Build an instance of this class from the WSM client library WorkspaceDescription object. */
   private Workspace(WorkspaceDescription wsmObject) {
@@ -70,7 +65,6 @@ public class Workspace {
     this.userEmail = Context.requireUser().getEmail();
     this.resources = new ArrayList<>();
     this.isLoaded = true;
-    this.resourcesPopulated = false;
   }
 
   /** Build an instance of this class from the serialized format on disk. */
@@ -86,7 +80,6 @@ public class Workspace {
             .map(PDResource::deserializeToInternal)
             .collect(Collectors.toList());
     this.isLoaded = configFromDisk.isLoaded;
-    this.resourcesPopulated = true;
   }
 
   /**
@@ -98,7 +91,6 @@ public class Workspace {
     this.serverName = serverName;
     this.resources = new ArrayList<>();
     this.isLoaded = false;
-    this.resourcesPopulated = false;
   }
 
   /**
@@ -256,20 +248,8 @@ public class Workspace {
         () -> new UserActionableException("Resource not found: " + name));
   }
 
-  /**
-   * If the resources array was populated (even if empty) when this workspace was created, return
-   * its size.
-   */
-  public Optional<Integer> getNumResourcesIfKnown() {
-    if (resourcesPopulated) {
-      return Optional.of(resources.size());
-    } else {
-      return Optional.empty();
-    }
-  }
-
   /** Populate the list of resources for this workspace. Does not sync to disk. */
-  public void populateResources() {
+  private void populateResources() {
     List<ResourceDescription> wsmObjects =
         WorkspaceManagerService.fromContext()
             .enumerateAllResources(id, Context.getConfig().getResourcesCacheSize());

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
@@ -25,7 +25,7 @@ public class UFWorkspace {
   public final String userEmail;
 
   // only expose the number of resources in the text output mode
-  @JsonIgnore public final Integer numResources;
+  @JsonIgnore public final long numResources;
 
   /** Serialize an instance of the internal class to the disk format. */
   public UFWorkspace(Workspace internalObj) {
@@ -35,8 +35,8 @@ public class UFWorkspace {
     this.googleProjectId = internalObj.getGoogleProjectId();
     this.serverName = internalObj.getServerName();
     this.userEmail = internalObj.getUserEmail();
-    // This may slow down workspace list...
-    internalObj.populateResources();
+    // This number may be zero for Workspace objects loaded from `WorkspaceDescription`s,
+    // as those don't have any resources associated with them.
     this.numResources = internalObj.getResources().size();
   }
 
@@ -48,7 +48,7 @@ public class UFWorkspace {
     this.googleProjectId = builder.googleProjectId;
     this.serverName = builder.serverName;
     this.userEmail = builder.userEmail;
-    this.numResources = 99;
+    this.numResources = builder.numResources;
   }
 
   /** Print out a workspace object in text format. */
@@ -61,11 +61,13 @@ public class UFWorkspace {
     OUT.println(
         "Cloud console: https://console.cloud.google.com/home/dashboard?project="
             + googleProjectId);
-    // Handle the case where this UFWorkspace was built from a Workspace built from a
-    // WorkspaceDescription, which does not provide the resources or their count.
+    // Unfortunately, this UFWorkspace may have been built from a Workspace object built from a
+    // WorkspaceDescription, which does not provide the resources or their count. In that
+    // situation, the number of resources will be zero, which may be false.
     // Currently, this only happens in `terra workspace list`, which prints separately,
-    // so the user should not see "unknown" here.
-    OUT.println("# Resources: " + (null == numResources ? "unknown" : numResources.toString()));
+    // so the user should not see it. `numResources` was removed from JSON output for
+    // this reason (as we use the same JSON structure for list and describe).
+    OUT.println("# Resources: " + numResources);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")


### PR DESCRIPTION
When we build a UFWorkspace object during `terra workspace list`, the backing API object doesn't have a resources list. This causes the  `numResources` field to be zero, which is incorrect. In the text output for workspace list, we don't show that field, so it's no issue, but the JSON was unreliable. Rather than try to make that field nullable and intelligently track whether the resources array in the `Workspace` class was actually populated versus just initialized with an empty list, I decided to just drop the field from the JSON.

This is a breaking fix for CLI users unfortunately.