### PR TITLE
Make test installs lock to the current source version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ dependencies {
 task runInstallForTesting(type: Exec){
     boolean testInstallFromGitHub = project.hasProperty("testInstallFromGitHub");
     String installMode = testInstallFromGitHub ? "GITHUB_RELEASE" : "SOURCE_CODE"
-    commandLine "bash", "./tools/install-for-testing.sh", installMode
+    commandLine "bash", "./tools/install-for-testing.sh", installMode, "${project.version}"
 
     dependsOn installDist
 }

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -29,17 +29,26 @@ if [ "$installMode" = "SOURCE_CODE" ]; then
   docker pull $($terra config get image)
 
 elif [ "$installMode" = "GITHUB_RELEASE" ]; then
+
+  if [ -z "$2" ]; then
+    versionPath="latest/download"
+  else
+    # We want to download the specificed version of the install script AND
+    # set this environment variable for when we run it.
+    export TERRA_CLI_VERSION="$2"
+    versionPath="download/$2"
+  fi
+
   echo "Creating a new build/test-install directory"
   mkdir -p $(pwd)/build/test-install/
   cd build/test-install/
 
   export TERRA_CLI_DOCKER_MODE=DOCKER_AVAILABLE
   echo "Downloading the install script from GitHub and running it"
-  curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash
+  curl -L https://github.com/DataBiosphere/terra-cli/releases/$versionPath/download-install.sh | bash
 
 else
   echo "Usage: tools/install-for-testing.sh [installMode]"
   echo "       installMode = SOURCE_CODE, GITHUB_RELEASE"
   exit 1
 fi
-


### PR DESCRIPTION
This makes the "install from github" test option pull the version matched to the code.