### PR TITLE
[PF-1289] Stop running nightly tests against Verily deployment

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -8,7 +8,7 @@ jobs:
   tests-against-source-code-and-latest-install:
     strategy:
       matrix:
-        testServer: [ "broad-dev", "verily-devel" ]
+        testServer: [ "broad-dev" ]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,8 +236,7 @@ For each test user, store refresh token in vault:
 - Create GHA secret. Update workflows `Render config` jobs to read secrets.
 
 #### Automated tests
-All unit and integration tests are run nightly via GitHub action against two environments: `broad-dev` and
-`verily-devel`. On test completion, a Slack notification is sent to the Broad `#platform-foundation-alerts` channel.
+All unit and integration tests are run nightly via GitHub action against `broad-dev`. On test completion, a Slack notification is sent to the Broad `#platform-foundation-alerts` channel.
 If you kick off a full test run manually, it will not send a notification.
 
 Running the tests locally on your machine and via GitHub actions uses the same set of test users. While the nightly CLI

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -103,17 +103,17 @@ public class Config extends SingleWorkspaceUnit {
     // It's fine that this test hard-codes server names. We're just testing server configuration is
     // saved correctly; we're not actually making calls to the server.
 
-    // `terra server set --name=broad-autopush`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-autopush", "--quiet");
+    // `terra server set --name=verily-devel`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=verily-devel", "--quiet");
 
     // `terra config get server`
     UFServer getValue =
         TestCommand.runAndParseCommandExpectSuccess(UFServer.class, "config", "get", "server");
-    assertEquals("broad-autopush", getValue.name, "server set affects config get");
+    assertEquals("verily-devel", getValue.name, "server set affects config get");
 
     // `terra config list`
     UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals("broad-autopush", config.serverName, "server set affects config list");
+    assertEquals("verily-devel", config.serverName, "server set affects config list");
 
     // `terra config set server --name=broad-dev`
     TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev", "--quiet");

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -100,17 +100,20 @@ public class Config extends SingleWorkspaceUnit {
   @Test
   @DisplayName("config server set and server set are equivalent")
   void server() throws IOException {
-    // `terra server set --name=verily-devel`
-    TestCommand.runCommandExpectSuccess("server", "set", "--name=verily-devel", "--quiet");
+    // It's fine that this test hard-codes server names. We're just testing server configuration is
+    // saved correctly; we're not actually making calls to the server.
+
+    // `terra server set --name=broad-autopush`
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-autopush", "--quiet");
 
     // `terra config get server`
     UFServer getValue =
         TestCommand.runAndParseCommandExpectSuccess(UFServer.class, "config", "get", "server");
-    assertEquals("verily-devel", getValue.name, "server set affects config get");
+    assertEquals("broad-autopush", getValue.name, "server set affects config get");
 
     // `terra config list`
     UFConfig config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals("verily-devel", config.serverName, "server set affects config list");
+    assertEquals("broad-autopush", config.serverName, "server set affects config list");
 
     // `terra config set server --name=broad-dev`
     TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev", "--quiet");

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -48,7 +48,7 @@ public class Server extends SingleWorkspaceUnit {
   @DisplayName("status, server list reflect server set")
   void statusListReflectSet() throws JsonProcessingException {
     // `terra server set --name=$serverName1`
-    String serverName1 = "broad-autopush";
+    String serverName1 = "verily-devel";
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName1, "--quiet");
 
     // `terra status`

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -27,7 +27,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-/** Tests for the `terra server` commands. */
+/**
+ * Tests for the `terra server` commands.
+ *
+ * <p>It's fine that these tests hard-code server names. We're just testing server configuration is
+ * saved correctly; we're not actually making calls to the server.
+ */
 @Tag("unit")
 public class Server extends SingleWorkspaceUnit {
   @Test
@@ -43,7 +48,7 @@ public class Server extends SingleWorkspaceUnit {
   @DisplayName("status, server list reflect server set")
   void statusListReflectSet() throws JsonProcessingException {
     // `terra server set --name=$serverName1`
-    String serverName1 = "verily-devel";
+    String serverName1 = "broad-autopush";
     TestCommand.runCommandExpectSuccess("server", "set", "--name=" + serverName1, "--quiet");
 
     // `terra status`


### PR DESCRIPTION
Verily repo has been running against Verily deployment for a while now.