### PR TITLE
Hide ADC warning, so users won't get confused

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 ### Install and run
 To install the latest version:
 ```
-curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash
+curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && export SUPPRESS_GCLOUD_CREDS_WARNING=true
 ./terra
 ```
 


### PR DESCRIPTION
Before:

```
> gcloud auth application-default login
> terra gsutil ls
gsutil version: 5.6
Mar 14, 2022 2:56:11 PM com.google.auth.oauth2.DefaultCredentialsProvider warnAboutProblematicCredentials
WARNING: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/.
Setting the gcloud project to the workspace project
Updated property [core/project].
gs://melchangbucketwithnounderscore/
gs://terra_39b40817_37d0_4cae_8147_e677490353f9_bucket/
Restoring the original gcloud project configuration: terra-vdevel-buoyant-plum-9341
Updated property [core/project].
```

After:

```
> terra gsutil ls
gsutil version: 5.6
Setting the gcloud project to the workspace project
Updated property [core/project].
gs://melchangbucketwithnounderscore/
gs://terra_39b40817_37d0_4cae_8147_e677490353f9_bucket/
Restoring the original gcloud project configuration: terra-vdevel-buoyant-plum-9341
Updated property [core/project].
```

See why we show warning [here](https://github.com/DataBiosphere/terra-cli/blob/main/CONTRIBUTING.md#auth-overview).

Apparently it's not possible to set an environment variable in Java (in current process, not child process) or in `build.gradle`, so I changed `README`.