### PR TITLE
[PF-1395] Support `gcloud alpha storage` in Docker mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
     * [Config](#config)
     * [Git](#git)
     * [Groups](#groups)
+    * [gsutil](#gsutil)
     * [Notebooks](#notebooks)
     * [Resources](#resources)
     * [Server](#server)
@@ -287,6 +288,7 @@ The other commands are groupings of sub-commands, described in the sections belo
 * `config` [Config](#config)
 * `git` [Git](#Git)
 * `group` [Groups](#groups)
+* `gsutil` [gsutil](#gsutil)
 * `notebook` [Notebooks](#notebooks)
 * `resource` [Resources](#resources)
 * `server` [Server](#server)
@@ -422,6 +424,12 @@ Say a Terra group's email is `mygroup@mydomain.com`. `name` is `mygroup`, not `m
 ```
 > terra group list-users --name=mygroup
 ```
+
+#### gsutil
+
+You can run `terra gsutil` or `terra gcloud alpha storage`. `gcloud alpha storage`
+is a newer version of `gsutil`. It doesn't support everything, but what it does
+support [may be significantly faster](https://stackoverflow.com/collectives/google-cloud/articles/68475140/faster-cloud-storage-transfers-using-the-gcloud-command-line).
 
 #### Notebooks
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr
 RUN apt-get update \
     && apt-get install -y \
     curl \
-    python \
+    python3 \
     git
 
 # install Google Cloud SDK (gcloud, gsutil, bq)
@@ -22,7 +22,9 @@ RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cl
     tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
     mv google-cloud-sdk/ /usr/local/ && \
-    gcloud config set component_manager/disable_update_check true
+    gcloud config set component_manager/disable_update_check true && \
+    # For gcloud alpha storage \
+    gcloud components install alpha --quiet
 
 # install Nextflow
 ENV NXF_VER 21.10.6

--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -20,8 +20,8 @@ import org.slf4j.LoggerFactory;
 public abstract class CommandRunner {
   private static final Logger logger = LoggerFactory.getLogger(CommandRunner.class);
 
-  // Only unit tests set this.
-  @VisibleForTesting public static final String TEST_USER_ACCESS_TOKEN = "TEST_USER_ACCESS_TOKEN";
+  // Only tests set this.
+  @VisibleForTesting public static final String IS_TEST = "IS_TEST";
 
   /**
    * Utility method for concatenating a command and its arguments.
@@ -124,14 +124,15 @@ public abstract class CommandRunner {
   }
 
   /**
-   * If this is a test and there is a user, returns test user access token. If this is not a test,
-   * returns empty Optional.
+   * If this is a test and there is a user and workspace, returns pet SA access token. Else, returns
+   * empty.
    */
-  public static Optional<String> getTestUserAccessToken() {
-    String testUserAccessToken = System.getProperty(TEST_USER_ACCESS_TOKEN);
-    if (testUserAccessToken == null || testUserAccessToken.isEmpty()) {
-      return Optional.empty();
+  public static Optional<String> getTestPetSaAccessToken() {
+    if (System.getProperty(IS_TEST) != null
+        && Context.getUser().isPresent()
+        && Context.getWorkspace().isPresent()) {
+      return Optional.of(Context.getUser().get().getPetSaAccessToken().getTokenValue());
     }
-    return Optional.of(testUserAccessToken);
+    return Optional.empty();
   }
 }

--- a/src/main/java/bio/terra/cli/app/DockerCommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/DockerCommandRunner.java
@@ -77,8 +77,8 @@ public class DockerCommandRunner extends CommandRunner {
     // For unit tests, set CLOUDSDK_AUTH_ACCESS_TOKEN. This is how to programmatically authenticate
     // as test user, without SA key file
     // (https://cloud.google.com/sdk/docs/release-notes#cloud_sdk_2).
-    if (getTestUserAccessToken().isPresent()) {
-      envVars.put("CLOUDSDK_AUTH_ACCESS_TOKEN", getTestUserAccessToken().get());
+    if (getTestPetSaAccessToken().isPresent()) {
+      envVars.put("CLOUDSDK_AUTH_ACCESS_TOKEN", getTestPetSaAccessToken().get());
     } else { // this is normal operation
       // check that the ADC match the user or their pet SA
       AppDefaultCredentialUtils.throwIfADCDontMatchContext();

--- a/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
@@ -59,7 +59,7 @@ public class LocalProcessCommandRunner extends CommandRunner {
 
     // Don't enforce ADC for tests. (`gcloud auth activate-service-account` requires a key file,
     // which we don't want for security reasons.)
-    if (!getTestUserAccessToken().isPresent()) {
+    if (System.getProperty(CommandRunner.IS_TEST) != null) {
 
       // check that the ADC match the user or their pet SA
       AppDefaultCredentialUtils.throwIfADCDontMatchContext();

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -3,7 +3,6 @@ package harness;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.cli.app.CommandRunner;
-import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.Main;
 import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -48,11 +47,7 @@ public class TestCommand {
         new PrintStream(stdErr, true, StandardCharsets.UTF_8),
         stdIn);
 
-    if (Context.getUser().isPresent()) {
-      System.setProperty(
-          CommandRunner.TEST_USER_ACCESS_TOKEN,
-          Context.requireUser().getUserAccessToken().getTokenValue());
-    }
+    System.setProperty(CommandRunner.IS_TEST, "true");
 
     // execute the command from the top-level Main class
     System.out.println("COMMAND: " + String.join(" ", args));

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -129,24 +129,30 @@ public class PassthroughApps extends SingleWorkspaceUnit {
   }
 
   @Test
-  @DisplayName("gsutil bucket size = 0")
-  void gsutilBucketSize() throws IOException {
+  @DisplayName("`gsutil ls` and `gcloud alpha storage ls`")
+  void gsutilGcloudAlphaStorageLs() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
-    String name = "gsutilBucketSize";
+    String name = "resourceName";
     String bucketName = UUID.randomUUID().toString();
     TestCommand.runCommandExpectSuccess(
         "resource", "create", "gcs-bucket", "--name=" + name, "--bucket-name=" + bucketName);
 
-    // `terra gsutil du -s \$TERRA_$name`
-    TestCommand.Result cmd = TestCommand.runCommand("gsutil", "du", "-s", "$TERRA_" + name);
+    // `terra gsutil ls`
+    TestCommand.Result cmd = TestCommand.runCommand("gsutil", "ls");
     assertTrue(
-        cmd.stdOut.matches("(?s).*0\\s+" + ExternalGCSBuckets.getGsPath(bucketName) + ".*"),
-        "gsutil says bucket size = 0");
+        cmd.stdOut.contains(ExternalGCSBuckets.getGsPath(bucketName)),
+        "`gsutil ls` returns bucket");
+
+    // `terra gcloud alpha storage ls`
+    cmd = TestCommand.runCommand("gcloud", "alpha", "storage", "ls");
+    assertTrue(
+        cmd.stdOut.contains(ExternalGCSBuckets.getGsPath(bucketName)),
+        "`gcloud alpha storage ls` returns bucket");
 
     // `terra resource delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");


### PR DESCRIPTION
`gcloud alpha storage` works in local mode. This PR makes it work in Docker mode.

Before:
```
~/terra-cli (main): /usr/local/bin/terra gcloud alpha storage ls
Mar 14, 2022 3:25:27 PM com.google.auth.oauth2.DefaultCredentialsProvider warnAboutProblematicCredentials
WARNING: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/.
Setting the gcloud project to the workspace project
Updated property [core/project].

You do not currently have this command group installed.  Using it
requires the installation of components: [alpha]


Your current Cloud SDK version is: 371.0.0
Installing components from version: 371.0.0

┌──────────────────────────────────────────────┐
│     These components will be installed.      │
├───────────────────────┬────────────┬─────────┤
│          Name         │  Version   │   Size  │
├───────────────────────┼────────────┼─────────┤
│ gcloud Alpha Commands │ 2022.01.28 │ < 1 MiB │
└───────────────────────┴────────────┴─────────┘

For the latest full release notes, please visit:
  https://cloud.google.com/sdk/release_notes

Do you want to continue (Y/n)?
ERROR: (gcloud) This prompt could not be answered because you are not in an interactive session.  You can re-run the command with the --quiet flag to accept default answers for all prompts.
```

After:
```
~/terra-cli (mc/gcloud-alpha-storage): terra gcloud alpha storage ls
Setting the gcloud project to the workspace project
Updated property [core/project].

gs://melchangbucketwithnounderscore/
gs://terra_39b40817_37d0_4cae_8147_e677490353f9_bucket/
```

This PR uncovered a bug in my previous PRs. Tools should be run as pet SA, not user. See my changes to CONTRIBUTING.md. So I changed tests to use pet access token instead of user access token.