### PR TITLE
[PF-1428] Fix/remove tests

### DIFF
--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -435,35 +435,4 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // clean up
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + newName, "--quiet");
   }
-
-  @Test
-  @DisplayName(
-      "Attempt to add reference to buckets while the user only have access to externalSharedbucket")
-  void addBucketRefWithPartialAccess() throws IOException {
-    workspaceCreator.login();
-    // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
-
-    shareeUser.login();
-    // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
-
-    String succeedName = "addBucketRefWithPartialAccess_withAccess";
-    // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName
-    TestCommand.runCommandExpectSuccess(
-        "resource",
-        "add-ref",
-        "gcs-bucket",
-        "--name=" + succeedName,
-        "--bucket-name=" + externalSharedBucket.getName());
-
-    String failureName = "addBucketRefWithPartialAccess_withNoAccess";
-    TestCommand.runCommandExpectExitCode(
-        2,
-        "resource",
-        "add-ref",
-        "gcs-bucket",
-        "--name=" + failureName,
-        "--bucket-name=" + externalPrivateBucket.getName());
-  }
 }


### PR DESCRIPTION
Now that access checks on reference creation and update have been removed, these tests started failing because of expected failures that turned into successes. Deleted two of them in the interest of saving time, as we already have coverage of updating references.