### PR TITLE
[PF-1501] Specify correct cloning defaults

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 5 * * *' # 5AM UTC = 12AM EST
 
 jobs:
-  tests-against-source-code-and-latest-install:
+  test-source-and-install:
     strategy:
       matrix:
         testServer: [ "broad-dev" ]

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
@@ -4,12 +4,10 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferenceCreation;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateBqDatasetParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
-import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /** This class corresponds to the fourth-level "terra resource add-ref bq-dataset" command. */

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.ReferenceCreation;
 import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateBqDatasetParams;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
   @CommandLine.Mixin BqDatasetsIds bigQueryIds;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
@@ -28,9 +29,7 @@ public class BqDataset extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        resourceCreationOptions
-            .populateMetadataFields()
-            .stewardshipType(StewardshipType.REFERENCED);
+        referenceCreationOptions.populateMetadataFields();
     CreateBqDatasetParams.Builder createParams =
         new CreateBqDatasetParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
@@ -16,8 +16,7 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
-  @CommandLine.Mixin
-  ReferencedResourceCreation referencedResourceCreationOptions;
+  @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin BqDatasetsIds bigQueryIds;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
-import bio.terra.cli.command.shared.options.ReferenceCreation;
+import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateBqDatasetParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -16,7 +16,8 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery dataset.",
     showDefaultValues = true)
 public class BqDataset extends BaseCommand {
-  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
+  @CommandLine.Mixin
+  ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin BqDatasetsIds bigQueryIds;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
@@ -27,7 +28,7 @@ public class BqDataset extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions.populateMetadataFields();
+        referencedResourceCreationOptions.populateMetadataFields();
     CreateBqDatasetParams.Builder createParams =
         new CreateBqDatasetParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
@@ -4,12 +4,10 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferenceCreation;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFBqTable;
-import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /** This class corresponds to the fourth-level "terra resource add-ref bq-table" command. */
@@ -36,8 +34,7 @@ public class BqTable extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParamsBuilder =
-        referenceCreationOptions
-            .populateMetadataFields();
+        referenceCreationOptions.populateMetadataFields();
     AddBqTableParams.Builder createParamsBuilder =
         new AddBqTableParams.Builder()
             .resourceFields(createResourceParamsBuilder.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
-import bio.terra.cli.command.shared.options.ReferenceCreation;
+import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -16,7 +16,8 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery Data Table.",
     showDefaultValues = true)
 public class BqTable extends BaseCommand {
-  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
+  @CommandLine.Mixin
+  ReferencedResourceCreation referencedResourceCreationOptions;
 
   @CommandLine.Option(
       names = "--table-id",
@@ -34,7 +35,7 @@ public class BqTable extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParamsBuilder =
-        referenceCreationOptions.populateMetadataFields();
+        referencedResourceCreationOptions.populateMetadataFields();
     AddBqTableParams.Builder createParamsBuilder =
         new AddBqTableParams.Builder()
             .resourceFields(createResourceParamsBuilder.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.ReferenceCreation;
 import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery Data Table.",
     showDefaultValues = true)
 public class BqTable extends BaseCommand {
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
 
   @CommandLine.Option(
       names = "--table-id",
@@ -35,9 +36,8 @@ public class BqTable extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParamsBuilder =
-        resourceCreationOptions
-            .populateMetadataFields()
-            .stewardshipType(StewardshipType.REFERENCED);
+        referenceCreationOptions
+            .populateMetadataFields();
     AddBqTableParams.Builder createParamsBuilder =
         new AddBqTableParams.Builder()
             .resourceFields(createResourceParamsBuilder.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
@@ -16,8 +16,7 @@ import picocli.CommandLine;
     description = "Add a referenced BigQuery Data Table.",
     showDefaultValues = true)
 public class BqTable extends BaseCommand {
-  @CommandLine.Mixin
-  ReferencedResourceCreation referencedResourceCreationOptions;
+  @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
 
   @CommandLine.Option(
       names = "--table-id",

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
@@ -4,12 +4,10 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
 import bio.terra.cli.command.shared.options.ReferenceCreation;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateGcsBucketParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
-import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /** This class corresponds to the fourth-level "terra resource add-ref gcs-bucket" command. */
@@ -29,8 +27,7 @@ public class GcsBucket extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions
-            .populateMetadataFields();
+        referenceCreationOptions.populateMetadataFields();
     CreateGcsBucketParams.Builder createParams =
         new CreateGcsBucketParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
@@ -16,8 +16,7 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket.",
     showDefaultValues = true)
 public class GcsBucket extends BaseCommand {
-  @CommandLine.Mixin
-  ReferencedResourceCreation referencedResourceCreationOptions;
+  @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
-import bio.terra.cli.command.shared.options.ReferenceCreation;
+import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateGcsBucketParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -16,7 +16,8 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket.",
     showDefaultValues = true)
 public class GcsBucket extends BaseCommand {
-  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
+  @CommandLine.Mixin
+  ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
@@ -27,7 +28,7 @@ public class GcsBucket extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions.populateMetadataFields();
+        referencedResourceCreationOptions.populateMetadataFields();
     CreateGcsBucketParams.Builder createParams =
         new CreateGcsBucketParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
+import bio.terra.cli.command.shared.options.ReferenceCreation;
 import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateGcsBucketParams;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket.",
     showDefaultValues = true)
 public class GcsBucket extends BaseCommand {
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
@@ -28,9 +29,8 @@ public class GcsBucket extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        resourceCreationOptions
-            .populateMetadataFields()
-            .stewardshipType(StewardshipType.REFERENCED);
+        referenceCreationOptions
+            .populateMetadataFields();
     CreateGcsBucketParams.Builder createParams =
         new CreateGcsBucketParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
-import bio.terra.cli.command.shared.options.ReferenceCreation;
+import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGcsObjectParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -16,7 +16,8 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket object.",
     showDefaultValues = true)
 public class GcsObject extends BaseCommand {
-  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
+  @CommandLine.Mixin
+  ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
 
   @CommandLine.Option(
@@ -35,7 +36,7 @@ public class GcsObject extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions.populateMetadataFields();
+        referencedResourceCreationOptions.populateMetadataFields();
     AddGcsObjectParams.Builder createParams =
         new AddGcsObjectParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
@@ -16,8 +16,7 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket object.",
     showDefaultValues = true)
 public class GcsObject extends BaseCommand {
-  @CommandLine.Mixin
-  ReferencedResourceCreation referencedResourceCreationOptions;
+  @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
@@ -4,12 +4,10 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
 import bio.terra.cli.command.shared.options.ReferenceCreation;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGcsObjectParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsObject;
-import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /** This class corresponds to the fourth-level "terra resource add-ref gcs-object" command. */
@@ -37,8 +35,7 @@ public class GcsObject extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions
-            .populateMetadataFields();
+        referenceCreationOptions.populateMetadataFields();
     AddGcsObjectParams.Builder createParams =
         new AddGcsObjectParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
@@ -3,6 +3,7 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
+import bio.terra.cli.command.shared.options.ReferenceCreation;
 import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGcsObjectParams;
@@ -17,7 +18,7 @@ import picocli.CommandLine;
     description = "Add a referenced GCS bucket object.",
     showDefaultValues = true)
 public class GcsObject extends BaseCommand {
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
 
   @CommandLine.Option(
@@ -36,9 +37,8 @@ public class GcsObject extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        resourceCreationOptions
-            .populateMetadataFields()
-            .stewardshipType(StewardshipType.REFERENCED);
+        referenceCreationOptions
+            .populateMetadataFields();
     AddGcsObjectParams.Builder createParams =
         new AddGcsObjectParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
@@ -15,8 +15,7 @@ import picocli.CommandLine;
     description = "Add a referenced git repository.",
     showDefaultValues = true)
 public class GitRepo extends BaseCommand {
-  @CommandLine.Mixin
-  ReferencedResourceCreation referencedResourceCreationOptions;
+  @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
 
   @CommandLine.Option(
       names = "--repo-url",

--- a/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
@@ -3,12 +3,10 @@ package bio.terra.cli.command.resource.addref;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferenceCreation;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGitRepoParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGitRepo;
-import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /** This class corresponds to the fourth-level "terra resource add-ref git-repo" command. */
@@ -34,8 +32,7 @@ public class GitRepo extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions
-            .populateMetadataFields();
+        referenceCreationOptions.populateMetadataFields();
     AddGitRepoParams.Builder createParams =
         new AddGitRepoParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.resource.addref;
 
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
-import bio.terra.cli.command.shared.options.ReferenceCreation;
+import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGitRepoParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -15,7 +15,8 @@ import picocli.CommandLine;
     description = "Add a referenced git repository.",
     showDefaultValues = true)
 public class GitRepo extends BaseCommand {
-  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
+  @CommandLine.Mixin
+  ReferencedResourceCreation referencedResourceCreationOptions;
 
   @CommandLine.Option(
       names = "--repo-url",
@@ -32,7 +33,7 @@ public class GitRepo extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        referenceCreationOptions.populateMetadataFields();
+        referencedResourceCreationOptions.populateMetadataFields();
     AddGitRepoParams.Builder createParams =
         new AddGitRepoParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.resource.addref;
 
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.ReferenceCreation;
 import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.AddGitRepoParams;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
     description = "Add a referenced git repository.",
     showDefaultValues = true)
 public class GitRepo extends BaseCommand {
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ReferenceCreation referenceCreationOptions;
 
   @CommandLine.Option(
       names = "--repo-url",
@@ -33,9 +34,8 @@ public class GitRepo extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to add
     CreateResourceParams.Builder createResourceParams =
-        resourceCreationOptions
-            .populateMetadataFields()
-            .stewardshipType(StewardshipType.REFERENCED);
+        referenceCreationOptions
+            .populateMetadataFields();
     AddGitRepoParams.Builder createParams =
         new AddGitRepoParams.Builder()
             .resourceFields(createResourceParams.build())

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -1,8 +1,8 @@
 package bio.terra.cli.command.resource.create;
 
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.ControlledResourceCreation;
 import bio.terra.cli.command.shared.options.Format;
-import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateGcpNotebookParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
@@ -29,7 +29,7 @@ public class GcpNotebook extends BaseCommand {
 
   // Use CreateResource instead of createControlledResource because only private notebooks are
   // supported and we don't want to provide options that are not useful.
-  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+  @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
 
   @CommandLine.Option(
       names = "--instance-id",
@@ -223,7 +223,7 @@ public class GcpNotebook extends BaseCommand {
     workspaceOption.overrideIfSpecified();
     // build the resource object to create. force the resource to be private
     CreateResourceParams.Builder createResourceParams =
-        resourceCreationOptions
+        controlledResourceCreationOptions
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
             .accessScope(AccessScope.PRIVATE_ACCESS);

--- a/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
@@ -32,7 +32,8 @@ public class ControlledResourceCreation {
    * metadata fields populated.
    */
   public CreateResourceParams.Builder populateMetadataFields() {
-    return resourceCreationOption.populateMetadataFields()
+    return resourceCreationOption
+        .populateMetadataFields()
         .accessScope(access)
         .cloningInstructions(cloning);
   }

--- a/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ControlledResourceCreation.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
 import picocli.CommandLine;
 
 /**
@@ -18,11 +19,21 @@ public class ControlledResourceCreation {
       description = "Access scope for the resource: ${COMPLETION-CANDIDATES}.")
   public AccessScope access = AccessScope.SHARED_ACCESS;
 
+  // Cloning option must have a different default for referenced resources (REFERENCE) than
+  // for controlled resources (RESOURCE).
+  @CommandLine.Option(
+      names = "--cloning",
+      description =
+          "Instructions for handling when cloning the workspace: ${COMPLETION-CANDIDATES}.")
+  public CloningInstructionsEnum cloning = CloningInstructionsEnum.RESOURCE;
+
   /**
    * Helper method to return a {@link CreateResourceParams.Builder} with the controlled resource
    * metadata fields populated.
    */
   public CreateResourceParams.Builder populateMetadataFields() {
-    return resourceCreationOption.populateMetadataFields().accessScope(access);
+    return resourceCreationOption.populateMetadataFields()
+        .accessScope(access)
+        .cloningInstructions(cloning);
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/ReferenceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ReferenceCreation.java
@@ -1,0 +1,36 @@
+package bio.terra.cli.command.shared.options;
+
+import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
+import bio.terra.workspace.model.CloningInstructionsEnum;
+import bio.terra.workspace.model.StewardshipType;
+import picocli.CommandLine;
+
+/**
+ * Command helper class that defines the relevant options for creating a new referenced
+ * Terra resource.
+ *
+ * <p>This class is meant to be used as a {@link CommandLine.Mixin}
+ */
+public class ReferenceCreation {
+  @CommandLine.Mixin ResourceCreation resourceCreationOptions;
+
+  // Cloning option must have a different default for referenced resources (REFERENCE) than
+  // for controlled resources (RESOURCE).
+  @CommandLine.Option(
+      names = "--cloning",
+      description =
+          "Instructions for handling when cloning the workspace: ${COMPLETION-CANDIDATES}.")
+  public CloningInstructionsEnum cloningInstructionsOption = CloningInstructionsEnum.REFERENCE;
+
+  /**
+   * Helper method to return a {@link CreateResourceParams.Builder} with the referenced resource
+   * metadata fields populated.
+   */
+  public CreateResourceParams.Builder populateMetadataFields() {
+    return new CreateResourceParams.Builder()
+        .name(resourceCreationOptions.resourceNameOption.name)
+        .description(resourceCreationOptions.resourceDescriptionOption.description)
+        .cloningInstructions(cloningInstructionsOption)
+        .stewardshipType(StewardshipType.REFERENCED);
+  }
+}

--- a/src/main/java/bio/terra/cli/command/shared/options/ReferenceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ReferenceCreation.java
@@ -6,8 +6,8 @@ import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
 
 /**
- * Command helper class that defines the relevant options for creating a new referenced
- * Terra resource.
+ * Command helper class that defines the relevant options for creating a new referenced Terra
+ * resource.
  *
  * <p>This class is meant to be used as a {@link CommandLine.Mixin}
  */

--- a/src/main/java/bio/terra/cli/command/shared/options/ReferencedResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ReferencedResourceCreation.java
@@ -11,7 +11,7 @@ import picocli.CommandLine;
  *
  * <p>This class is meant to be used as a {@link CommandLine.Mixin}
  */
-public class ReferenceCreation {
+public class ReferencedResourceCreation {
   @CommandLine.Mixin ResourceCreation resourceCreationOptions;
 
   // Cloning option must have a different default for referenced resources (REFERENCE) than

--- a/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
@@ -8,18 +8,12 @@ import picocli.CommandLine;
  * Command helper class that defines the relevant options for create a new controlled or referenced
  * Terra resource: {@link ResourceName} and {@link ResourceDescription}, --cloning.
  *
- * <p>This class is meant to be used as a @CommandLine.Mixin.
+ * <p>This class is meant to be used as a {@link CommandLine.Mixin}.
  */
 public class ResourceCreation {
   @CommandLine.Mixin ResourceName resourceNameOption;
 
   @CommandLine.Mixin ResourceDescription resourceDescriptionOption;
-
-  @CommandLine.Option(
-      names = "--cloning",
-      description =
-          "Instructions for handling when cloning the workspace or resource: ${COMPLETION-CANDIDATES}.")
-  public CloningInstructionsEnum cloning = CloningInstructionsEnum.NOTHING;
 
   /**
    * Helper method to return a {@link CreateResourceParams.Builder} with the resource metadata
@@ -28,7 +22,6 @@ public class ResourceCreation {
   public CreateResourceParams.Builder populateMetadataFields() {
     return new CreateResourceParams.Builder()
         .name(resourceNameOption.name)
-        .description(resourceDescriptionOption.description)
-        .cloningInstructions(cloning);
+        .description(resourceDescriptionOption.description);
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/ResourceCreation.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
-import bio.terra.workspace.model.CloningInstructionsEnum;
 import picocli.CommandLine;
 
 /**

--- a/src/test/java/unit/CloneWorkspace.java
+++ b/src/test/java/unit/CloneWorkspace.java
@@ -120,8 +120,7 @@ public class CloneWorkspace extends ClearContextUnit {
             "create",
             "gcs-bucket",
             "--name=" + "bucket_1",
-            "--bucket-name=" + UUID.randomUUID(),
-            "--cloning=COPY_RESOURCE");
+            "--bucket-name=" + UUID.randomUUID()); // cloning defaults  to COPY_RESOURCE
 
     // Add another bucket resource with COPY_NOTHING
     UFGcsBucket copyNothingBucket =

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -134,7 +134,7 @@ public class GcpNotebookControlled extends SingleWorkspaceUnit {
     // --cloning=$cloning --description=$description
     // --location=$location --instance-id=$instanceId`
     String name = "overrideLocationAndInstanceId";
-    CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
+    CloningInstructionsEnum cloning = CloningInstructionsEnum.RESOURCE;
     String description = "\"override default location and instance id\"";
     String location = "us-central1-b";
     String instanceId = "a" + UUID.randomUUID().toString(); // instance id must start with a letter

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -205,7 +205,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     String name = "createWithAllOptionsExceptLifecycle";
     String bucketName = UUID.randomUUID().toString();
     AccessScope access = AccessScope.PRIVATE_ACCESS;
-    CloningInstructionsEnum cloning = CloningInstructionsEnum.REFERENCE;
+    CloningInstructionsEnum cloning = CloningInstructionsEnum.RESOURCE;
     String description = "\"create with all options except lifecycle\"";
     String location = "US";
     GcsStorageClass storage = GcsStorageClass.NEARLINE;


### PR DESCRIPTION
Unlike other parameters, `cloning` has two defaults. For referenced resources it should be `REFERENCE`, and for controlled resources it should be `RESOURCE`.

Also shortened a test job name so that it can fit the whole name + matrix argument in the GHA UI.
![Screen Shot 2022-04-15 at 9 31 05 AM](https://user-images.githubusercontent.com/53479492/163603469-db9730dc-ac65-4e05-a649-4ee02738e852.png)
