### PR TITLE
[PF-1585, PF-1586] Surface userFacingId instead of uuid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,8 @@
     * [Build a new image](#build-a-new-image)
     * [Publish a new image](#publish-a-new-image)
     * [Update the default image](#update-the-default-image)
-5. [Code structure](#code-structure)
+5. [Code](#code)
+    * [Code structure](#code-structure)
     * [Top-level package](#top-level-package)
     * [Supported tools](#supported-tools)
         * [Adding a new supported tool](#add-a-new-supported-tool)
@@ -31,6 +32,7 @@
     * [Serialization](#serialization)
     * [Terra and cloud services](#terra-and-cloud-services)
     * [Servers](#servers)
+    * [Workspace IDs](#workspace-ids)
 6. [Command style guide](#command-style-guide)
     * [Options instead of parameters](#options-instead-of-parameters)
     * [Always specify a description](#always-specify-a-description)
@@ -164,7 +166,7 @@ CLI installation on the same machine.
 `./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub`
 
 - Run a single test by specifying the `--tests` option:
-  `./gradlew runTestsWithTag -PtestTag=unit --tests "unit.Workspace.createFailsWithoutSpendAccess" --info`
+  `./gradlew runTestsWithTag -PtestTag=unit --tests Workspace.createFailsWithoutSpendAccess`
 
 #### Docker and Tests
 
@@ -360,7 +362,9 @@ It's best to do this as part of a release, but if it's necessary to update the d
 2. Update the `DockerAppsRunner.defaultImageId` method in the Java code to return a hard-coded string.
 
 
-### Code structure
+### Code
+
+#### Code structure
 Below is an outline of the package structure. More details are included in the sub-sections below.
 ```
 bio.terra.cli      
@@ -372,14 +376,6 @@ bio.terra.cli
     service        # helper/wrapper classes for talking to Terra and cloud services
     utils          # uncategorized
 ```
-
-* [Business logic](#business-logic)
-* [Supported tools](#supported-tools)
-    * [Adding a new supported tool](#add-a-new-supported-tool)
-* [Commands](#commands)
-* [Serialization](#serialization)
-* [Terra and cloud services](#terra-and-cloud-services)
-* [Servers](#servers)
 
 #### Business logic
 The `businessobjects` package contains objects that represent the internal state (e.g. `Config`, `Server`, `User`, 
@@ -467,6 +463,18 @@ class here.
 To add a new server specification, create a new file in this directory and add the file name to the `all-servers.json` 
 file.
 
+#### Workspace IDs
+
+In WSM db, `workspace` table has 2 ID columns: `workspace_id` and `user_facing_id`.
+
+|               | What is this                                | Name in codebase | What CLI user sees                   |
+|---------------|---------------------------------------------|------------------|--------------------------------------|
+|workspace_id   | UUID; db primary key                        | `uuid`           | N/A, user doesn't see this.          |
+|user_facing_id | A human-settable, mutable, ID. Also unique. | `userFacingId`   | `ID`                                 |
+
+For simplicity, user only sees `user_facing_id`; for example in `terra workspace describe.`
+
+`uuid` does appear in `context.json` (and `.terra/logs/terra.log`). We need `uuid` because WSM APIs take `uuid`, not `userFacingId`. 
 
 ### Command style guide
 Below are guidelines for adding or modifying commands. The goal is to have a consistent presentation across commands.

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
         // terra libraries
         crlPlatform = "0.2.0"
         samClient = "0.1-ffb0a89-SNAP"
-        workspaceManagerClient = "0.254.238-SNAPSHOT"
+        workspaceManagerClient = "0.254.242-SNAPSHOT"
         externalCredsClient = "0.82.0-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
         janitor = "0.113.5-SNAPSHOT"

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,14 +217,14 @@ public class Context {
     synchronizeToDisk();
   }
 
-  public static void useOverrideWorkspace(UUID id) {
-    if (currentWorkspace != null && id.equals(currentWorkspace.getId())) {
+  public static void useOverrideWorkspace(String userFacingId) {
+    if (currentWorkspace != null && userFacingId.equals(currentWorkspace.getUserFacingId())) {
       // If the user provides the --workspace argument with the same ID as their current workspace,
       // ignore it. We should still update the current context so that the user does not see out
       // of date workspace information.
       return;
     }
     useOverrideWorkspace = true;
-    Workspace.load(id);
+    Workspace.load(userFacingId);
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -192,7 +192,7 @@ public abstract class Resource {
     }
     // call WSM to check access to the resource
     return WorkspaceManagerService.fromContext()
-        .checkAccess(Context.requireWorkspace().getId(), id);
+        .checkAccess(Context.requireWorkspace().getUuid(), id);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -193,7 +193,7 @@ public class User {
       UserIO.getErr()
           .println(
               "Error loading workspace information for the logged in user (workspace id: "
-                  + Context.requireWorkspace().getId()
+                  + Context.requireWorkspace().getUserFacingId()
                   + ").");
     }
   }

--- a/src/main/java/bio/terra/cli/businessobject/WorkspaceUser.java
+++ b/src/main/java/bio/terra/cli/businessobject/WorkspaceUser.java
@@ -71,12 +71,13 @@ public class WorkspaceUser {
    */
   public static WorkspaceUser add(String email, Role role, Workspace workspace) {
     // call WSM to add a user + role to the workspace
-    WorkspaceManagerService.fromContext().grantIamRole(workspace.getId(), email, role.getWsmRole());
+    WorkspaceManagerService.fromContext()
+        .grantIamRole(workspace.getUuid(), email, role.getWsmRole());
     logger.info(
         "Added user to workspace: user={}, role={}, workspaceId={}",
         email,
         role,
-        workspace.getId());
+        workspace.getUuid());
 
     // return a WorkspaceUser = email + all roles (not just the one that was added here)
     return getUser(email, workspace);
@@ -93,12 +94,12 @@ public class WorkspaceUser {
   public static WorkspaceUser remove(String email, Role role, Workspace workspace) {
     // call WSM to remove a user + role from the current workspace
     WorkspaceManagerService.fromContext()
-        .removeIamRole(workspace.getId(), email, role.getWsmRole());
+        .removeIamRole(workspace.getUuid(), email, role.getWsmRole());
     logger.info(
         "Removed user from workspace: user={}, role={}, workspaceId={}",
         email,
         role,
-        workspace.getId());
+        workspace.getUuid());
 
     // return a WorkspaceUser = email + all roles (not just the one that was removed here)
     return getUser(email, workspace);
@@ -129,7 +130,7 @@ public class WorkspaceUser {
   private static Map<String, WorkspaceUser> listUsersInMap(Workspace workspace) {
     // call WSM to get the users + roles for the existing workspace
     RoleBindingList roleBindings =
-        WorkspaceManagerService.fromContext().getRoles(workspace.getId());
+        WorkspaceManagerService.fromContext().getRoles(workspace.getUuid());
 
     // convert the WSM objects (role -> list of emails) to CLI objects (email -> list of roles)
     Map<String, WorkspaceUser> workspaceUsers = new HashMap<>();

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
@@ -80,7 +80,7 @@ public class BqDataset extends Resource {
 
     GcpBigQueryDatasetResource addedResource =
         WorkspaceManagerService.fromContext()
-            .createReferencedBigQueryDataset(Context.requireWorkspace().getId(), createParams);
+            .createReferencedBigQueryDataset(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created BQ dataset: {}", addedResource);
 
     // convert the WSM object to a CLI object
@@ -99,7 +99,7 @@ public class BqDataset extends Resource {
     // call WSM to create the resource
     GcpBigQueryDatasetResource createdResource =
         WorkspaceManagerService.fromContext()
-            .createControlledBigQueryDataset(Context.requireWorkspace().getId(), createParams);
+            .createControlledBigQueryDataset(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created BQ dataset: {}", createdResource);
 
     // convert the WSM object to a CLI object
@@ -119,7 +119,7 @@ public class BqDataset extends Resource {
       this.datasetId = updateParams.datasetId;
     }
     WorkspaceManagerService.fromContext()
-        .updateReferencedBigQueryDataset(Context.requireWorkspace().getId(), id, updateParams);
+        .updateReferencedBigQueryDataset(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceParams);
   }
 
@@ -129,7 +129,7 @@ public class BqDataset extends Resource {
       validateEnvironmentVariableName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
-        .updateControlledBigQueryDataset(Context.requireWorkspace().getId(), id, updateParams);
+        .updateControlledBigQueryDataset(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceFields);
   }
 
@@ -137,14 +137,14 @@ public class BqDataset extends Resource {
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
-        .deleteReferencedBigQueryDataset(Context.requireWorkspace().getId(), id);
+        .deleteReferencedBigQueryDataset(Context.requireWorkspace().getUuid(), id);
   }
 
   /** Delete a BigQuery dataset controlled resource in the workspace. */
   protected void deleteControlled() {
     // call WSM to delete the resource
     WorkspaceManagerService.fromContext()
-        .deleteControlledBigQueryDataset(Context.requireWorkspace().getId(), id);
+        .deleteControlledBigQueryDataset(Context.requireWorkspace().getUuid(), id);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
@@ -74,7 +74,7 @@ public class BqTable extends Resource {
 
     GcpBigQueryDataTableResource addedResource =
         WorkspaceManagerService.fromContext()
-            .createReferencedBigQueryDataTable(Context.requireWorkspace().getId(), createParams);
+            .createReferencedBigQueryDataTable(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created BQ data table: {}", addedResource);
 
     // convert the WSM object to a CLI object
@@ -97,7 +97,7 @@ public class BqTable extends Resource {
       this.dataTableId = updateParams.tableId;
     }
     WorkspaceManagerService.fromContext()
-        .updateReferencedBigQueryDataTable(Context.requireWorkspace().getId(), id, updateParams);
+        .updateReferencedBigQueryDataTable(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceParams);
   }
 
@@ -105,7 +105,7 @@ public class BqTable extends Resource {
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
-        .deleteReferencedBigQueryDataTable(Context.requireWorkspace().getId(), id);
+        .deleteReferencedBigQueryDataTable(Context.requireWorkspace().getUuid(), id);
   }
 
   /** Delete a BigQuery data table controlled resource in the workspace. */

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
@@ -81,7 +81,8 @@ public class GcpNotebook extends Resource {
     // call WSM to create the resource
     GcpAiNotebookInstanceResource createdResource =
         WorkspaceManagerService.fromContext()
-            .createControlledGcpNotebookInstance(Context.requireWorkspace().getId(), createParams);
+            .createControlledGcpNotebookInstance(
+                Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created GCP notebook: {}", createdResource);
 
     // convert the WSM object to a CLI object
@@ -98,7 +99,7 @@ public class GcpNotebook extends Resource {
   protected void deleteControlled() {
     // call WSM to delete the resource
     WorkspaceManagerService.fromContext()
-        .deleteControlledGcpNotebookInstance(Context.requireWorkspace().getId(), id);
+        .deleteControlledGcpNotebookInstance(Context.requireWorkspace().getUuid(), id);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
@@ -71,7 +71,7 @@ public class GcsBucket extends Resource {
 
     GcpGcsBucketResource addedResource =
         WorkspaceManagerService.fromContext()
-            .createReferencedGcsBucket(Context.requireWorkspace().getId(), createParams);
+            .createReferencedGcsBucket(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created GCS bucket: {}", addedResource);
 
     // convert the WSM object to a CLI object
@@ -90,7 +90,7 @@ public class GcsBucket extends Resource {
     // call WSM to create the resource
     GcpGcsBucketResource createdResource =
         WorkspaceManagerService.fromContext()
-            .createControlledGcsBucket(Context.requireWorkspace().getId(), createParams);
+            .createControlledGcsBucket(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created GCS bucket: {}", createdResource);
 
     // convert the WSM object to a CLI object
@@ -107,7 +107,7 @@ public class GcsBucket extends Resource {
       this.bucketName = updateParams.bucketName;
     }
     WorkspaceManagerService.fromContext()
-        .updateReferencedGcsBucket(Context.requireWorkspace().getId(), id, updateParams);
+        .updateReferencedGcsBucket(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceParams);
   }
 
@@ -117,7 +117,7 @@ public class GcsBucket extends Resource {
       validateEnvironmentVariableName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
-        .updateControlledGcsBucket(Context.requireWorkspace().getId(), id, updateParams);
+        .updateControlledGcsBucket(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceFields);
   }
 
@@ -125,14 +125,14 @@ public class GcsBucket extends Resource {
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
-        .deleteReferencedGcsBucket(Context.requireWorkspace().getId(), id);
+        .deleteReferencedGcsBucket(Context.requireWorkspace().getUuid(), id);
   }
 
   /** Delete a GCS bucket controlled resource in the workspace. */
   protected void deleteControlled() {
     // call WSM to delete the resource
     WorkspaceManagerService.fromContext()
-        .deleteControlledGcsBucket(Context.requireWorkspace().getId(), id);
+        .deleteControlledGcsBucket(Context.requireWorkspace().getUuid(), id);
   }
 
   /** Resolve a GCS bucket resource to its cloud identifier. */

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
@@ -70,7 +70,7 @@ public class GcsObject extends Resource {
 
     GcpGcsObjectResource addedResource =
         WorkspaceManagerService.fromContext()
-            .createReferencedGcsObject(Context.requireWorkspace().getId(), createParams);
+            .createReferencedGcsObject(Context.requireWorkspace().getUuid(), createParams);
     logger.info("Created GCS bucket object: {}", addedResource);
 
     // convert the WSM object to a CLI object
@@ -85,7 +85,7 @@ public class GcsObject extends Resource {
       validateEnvironmentVariableName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
-        .updateReferencedGcsObject(Context.requireWorkspace().getId(), id, updateParams);
+        .updateReferencedGcsObject(Context.requireWorkspace().getUuid(), id, updateParams);
     if (updateParams.bucketName != null) {
       this.bucketName = updateParams.bucketName;
     }
@@ -99,7 +99,7 @@ public class GcsObject extends Resource {
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
-        .deleteReferencedGcsObject(Context.requireWorkspace().getId(), id);
+        .deleteReferencedGcsObject(Context.requireWorkspace().getUuid(), id);
   }
 
   protected void deleteControlled() {

--- a/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
@@ -64,7 +64,7 @@ public class GitRepo extends Resource {
     // call WSM to add the reference.
     GitRepoResource addedResource =
         WorkspaceManagerService.fromContext()
-            .createReferencedGitRepo(Context.requireWorkspace().getId(), addGitRepoParams);
+            .createReferencedGitRepo(Context.requireWorkspace().getUuid(), addGitRepoParams);
     logger.info("Created Git repo reference: {}", addedResource);
     // convert the WSM object to a CLI object
     Context.requireWorkspace().listResourcesAndSync();
@@ -80,7 +80,7 @@ public class GitRepo extends Resource {
       this.gitRepoUrl = updateParams.gitRepoUrl;
     }
     WorkspaceManagerService.fromContext()
-        .updateReferencedGitRepo(Context.requireWorkspace().getId(), id, updateParams);
+        .updateReferencedGitRepo(Context.requireWorkspace().getUuid(), id, updateParams);
     super.updatePropertiesAndSync(updateParams.resourceFields);
   }
 
@@ -88,7 +88,7 @@ public class GitRepo extends Resource {
   protected void deleteReferenced() {
     // call WSM to delete the reference
     WorkspaceManagerService.fromContext()
-        .deleteReferencedGitRepo(Context.requireWorkspace().getId(), id);
+        .deleteReferencedGitRepo(Context.requireWorkspace().getUuid(), id);
   }
 
   @Override

--- a/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/WorkspaceOverride.java
@@ -1,7 +1,6 @@
 package bio.terra.cli.command.shared.options;
 
 import bio.terra.cli.businessobject.Context;
-import java.util.UUID;
 import picocli.CommandLine;
 
 /**
@@ -18,12 +17,12 @@ public class WorkspaceOverride {
   @CommandLine.Option(
       names = "--workspace",
       description = "Workspace id to use for this command only.")
-  private UUID id;
+  private String userFacingId;
 
   /** Helper method to override the current workspace if the `--workspace` flag specifies an id. */
   public void overrideIfSpecified() {
-    if (id != null) {
-      Context.useOverrideWorkspace(id);
+    if (userFacingId != null && !userFacingId.isEmpty()) {
+      Context.useOverrideWorkspace(userFacingId);
     }
   }
 }

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -146,7 +146,7 @@ public class BreakGlass extends BaseCommand {
     rowContent.put("granteeProxyGroupEmail", granteeProxyGroupEmail);
     rowContent.put("serverName", Context.getServer().getName());
     rowContent.put("serverWsmUri", Context.getServer().getWorkspaceManagerUri());
-    rowContent.put("workspaceId", Context.requireWorkspace().getId().toString());
+    rowContent.put("workspaceId", Context.requireWorkspace().getUuid().toString());
     rowContent.put("googleProjectId", Context.requireWorkspace().getGoogleProjectId());
     rowContent.put("workspaceName", Context.requireWorkspace().getName());
     rowContent.put("workspaceDescription", Context.requireWorkspace().getDescription());

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -59,7 +59,9 @@ public class List extends BaseCommand {
     // instead of a null predicate).
     Predicate<UFWorkspaceLight> isHighlighted =
         Context.getWorkspace()
-            .map(current -> (Predicate<UFWorkspaceLight>) (ufw -> current.getId().equals(ufw.id)))
+            .map(
+                current ->
+                    (Predicate<UFWorkspaceLight>) (ufw -> current.getUserFacingId().equals(ufw.id)))
             .orElse(ufw -> false);
     TablePrinter<UFWorkspaceLight> printer = Columns::values;
     String text = printer.print(returnValue, isHighlighted);
@@ -68,9 +70,9 @@ public class List extends BaseCommand {
 
   /** Column information for table output with `terra workspace list` */
   private enum Columns implements ColumnDefinition<UFWorkspaceLight> {
+    ID("ID", w -> w.id, 36, RIGHT),
     NAME("NAME", w -> w.name, 30, LEFT),
     GOOGLE_PROJECT("GOOGLE PROJECT", w -> w.googleProjectId, 30, LEFT),
-    ID("ID", w -> w.id.toString(), 36, RIGHT),
     DESCRIPTION("DESCRIPTION", w -> w.description, 40, LEFT);
 
     private final String columnLabel;

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -4,23 +4,21 @@ import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
-import java.util.UUID;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace set" command. */
 @Command(name = "set", description = "Set the workspace to an existing one.")
 public class Set extends BaseCommand {
-
   @CommandLine.Option(names = "--id", required = true, description = "Workspace id.")
-  private UUID id;
+  private String userFacingId;
 
   @CommandLine.Mixin Format formatOption;
 
   /** Load an existing workspace. */
   @Override
   protected void execute() {
-    Workspace workspace = Workspace.load(id);
+    Workspace workspace = Workspace.load(userFacingId);
     formatOption.printReturnValue(new UFWorkspace(workspace), this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
@@ -17,7 +17,8 @@ import java.util.stream.Collectors;
  */
 @JsonDeserialize(builder = PDWorkspace.Builder.class)
 public class PDWorkspace {
-  public final UUID id;
+  public final UUID uuid;
+  public final String userFacingId;
   public final String name;
   public final String description;
   public final String googleProjectId;
@@ -27,7 +28,8 @@ public class PDWorkspace {
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDWorkspace(Workspace internalObj) {
-    this.id = internalObj.getId();
+    this.uuid = internalObj.getUuid();
+    this.userFacingId = internalObj.getUserFacingId();
     this.name = internalObj.getName();
     this.description = internalObj.getDescription();
     this.googleProjectId = internalObj.getGoogleProjectId();
@@ -40,7 +42,8 @@ public class PDWorkspace {
   }
 
   private PDWorkspace(PDWorkspace.Builder builder) {
-    this.id = builder.id;
+    this.uuid = builder.uuid;
+    this.userFacingId = builder.userFacingId;
     this.name = builder.name;
     this.description = builder.description;
     this.googleProjectId = builder.googleProjectId;
@@ -51,7 +54,8 @@ public class PDWorkspace {
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
-    private UUID id;
+    private UUID uuid;
+    private String userFacingId;
     private String name;
     private String description;
     private String googleProjectId;
@@ -59,8 +63,13 @@ public class PDWorkspace {
     private String userEmail;
     private List<PDResource> resources;
 
-    public Builder id(UUID id) {
-      this.id = id;
+    public Builder uuid(UUID uuid) {
+      this.uuid = uuid;
+      return this;
+    }
+
+    public Builder userFacingId(String userFacingId) {
+      this.userFacingId = userFacingId;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFConfig.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * External representation of a configuration for command input/output.
@@ -29,7 +28,8 @@ public class UFConfig {
   public final Logger.LogLevel fileLoggingLevel;
   public final Logger.LogLevel consoleLoggingLevel;
   public final String serverName;
-  public final UUID workspaceId;
+  // "id" instead of "userFacingId" because user sees this with "terra config list"
+  public final String workspaceId;
   public final Format.FormatOptions format;
 
   /** Serialize an instance of the internal class to the command format. */
@@ -42,7 +42,7 @@ public class UFConfig {
     this.fileLoggingLevel = internalConfig.getFileLoggingLevel();
     this.consoleLoggingLevel = internalConfig.getConsoleLoggingLevel();
     this.serverName = internalServer.getName();
-    this.workspaceId = internalWorkspace.map(Workspace::getId).orElse(null);
+    this.workspaceId = internalWorkspace.map(Workspace::getUserFacingId).orElse(null);
     this.format = internalConfig.getFormat();
   }
 
@@ -91,7 +91,8 @@ public class UFConfig {
     private Logger.LogLevel fileLoggingLevel;
     private Logger.LogLevel consoleLoggingLevel;
     private String serverName;
-    private UUID workspaceId;
+    // "id" instead of "userFacingId" because user sees this with "terra config list"
+    private String workspaceId;
     private Format.FormatOptions format;
 
     public Builder browserLaunchOption(Config.BrowserLaunchOption browserLaunchOption) {
@@ -129,7 +130,7 @@ public class UFConfig {
       return this;
     }
 
-    public Builder workspaceId(UUID workspaceId) {
+    public Builder workspaceId(String workspaceId) {
       this.workspaceId = workspaceId;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
@@ -5,7 +5,6 @@ import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
-import java.util.UUID;
 
 /**
  * External representation of a workspace for command input/output.
@@ -48,7 +47,7 @@ public class UFWorkspace extends UFWorkspaceLight {
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
-    private UUID id;
+    private String id;
     private String name;
     private String description;
     private String googleProjectId;
@@ -56,7 +55,7 @@ public class UFWorkspace extends UFWorkspaceLight {
     private String userEmail;
     private long numResources;
 
-    public Builder id(UUID id) {
+    public Builder id(String id) {
       this.id = id;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -4,10 +4,11 @@ import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
-import java.util.UUID;
 
 public class UFWorkspaceLight {
-  public UUID id;
+  // "id" instead of "userFacingId" because user sees this with "terra workspace describe
+  // --format=json"
+  public String id;
   public String name;
   public String description;
   public String googleProjectId;
@@ -21,7 +22,7 @@ public class UFWorkspaceLight {
    * @param internalObj
    */
   public UFWorkspaceLight(Workspace internalObj) {
-    this.id = internalObj.getId();
+    this.id = internalObj.getUserFacingId();
     this.name = internalObj.getName();
     this.description = internalObj.getDescription();
     this.googleProjectId = internalObj.getGoogleProjectId();
@@ -52,8 +53,10 @@ public class UFWorkspaceLight {
   /** Print out a workspace object in text format. */
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    OUT.println("Terra workspace id: " + id);
-    OUT.println("Display name: " + name);
+    // "id" instead of "userFacingId" because user sees this with "terra workspace describe
+    // --format=json"
+    OUT.println("ID: " + id);
+    OUT.println("Name: " + name);
     OUT.println("Description: " + description);
     OUT.println("Google project: " + googleProjectId);
     OUT.println(
@@ -63,14 +66,16 @@ public class UFWorkspaceLight {
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
-    private UUID id;
+    // "id" instead of "userFacingId" because user sees this with "terra workspace describe
+    // --format=json"
+    private String id;
     private String name;
     private String description;
     private String googleProjectId;
     private String serverName;
     private String userEmail;
 
-    public UFWorkspaceLight.Builder id(UUID id) {
+    public UFWorkspaceLight.Builder id(String id) {
       this.id = id;
       return this;
     }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -298,21 +298,39 @@ public class WorkspaceManagerService {
   /**
    * Call the Workspace Manager GET "/api/workspaces/v1/{id}" endpoint to fetch an existing
    * workspace.
-   *
-   * @param workspaceId the id of the workspace to fetch
-   * @return the Workspace Manager workspace description object
    */
-  public WorkspaceDescription getWorkspace(UUID workspaceId) {
+  public WorkspaceDescription getWorkspace(UUID uuid) {
     WorkspaceDescription workspaceWithContext =
         callWithRetries(
-            () -> new WorkspaceApi(apiClient).getWorkspace(workspaceId),
+            () -> new WorkspaceApi(apiClient).getWorkspace(uuid), "Error fetching workspace");
+    String googleProjectId =
+        (workspaceWithContext.getGcpContext() == null)
+            ? null
+            : workspaceWithContext.getGcpContext().getProjectId();
+    logger.info(
+        "Workspace context: userFacingId {}, project id: {}",
+        workspaceWithContext.getUserFacingId(),
+        googleProjectId);
+    return workspaceWithContext;
+  }
+
+  /**
+   * Call the Workspace Manager GET "/api/workspaces/v1/workspaceByUserFacingId/{userFacingId}"
+   * endpoint to fetch an existing workspace.
+   */
+  public WorkspaceDescription getWorkspaceByUserFacingId(String userFacingId) {
+    WorkspaceDescription workspaceWithContext =
+        callWithRetries(
+            () -> new WorkspaceApi(apiClient).getWorkspaceByUserFacingId(userFacingId),
             "Error fetching workspace");
     String googleProjectId =
         (workspaceWithContext.getGcpContext() == null)
             ? null
             : workspaceWithContext.getGcpContext().getProjectId();
     logger.info(
-        "Workspace context: {}, project id: {}", workspaceWithContext.getId(), googleProjectId);
+        "Workspace context: {}, project id: {}",
+        workspaceWithContext.getUserFacingId(),
+        googleProjectId);
     return workspaceWithContext;
   }
 

--- a/src/test/java/harness/CRLJanitor.java
+++ b/src/test/java/harness/CRLJanitor.java
@@ -1,7 +1,6 @@
 package harness;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.utils.JacksonMapper;
 import bio.terra.cloudres.common.ClientConfig;
 import bio.terra.cloudres.common.JanitorException;
@@ -23,10 +22,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -101,7 +97,7 @@ public class CRLJanitor {
    * If Janitor is enabled, register the given workspace to be cleaned up. Otherwise return
    * immediately.
    */
-  public static void registerWorkspaceForCleanup(UFWorkspace workspace, TestUser testUser) {
+  public static void registerWorkspaceForCleanup(UUID uuid, TestUser testUser) {
     if (!TestConfig.get().useJanitor()) {
       return;
     }
@@ -112,7 +108,7 @@ public class CRLJanitor {
                 new CloudResourceUid()
                     .terraWorkspace(
                         new TerraWorkspaceUid()
-                            .workspaceId(workspace.id)
+                            .workspaceId(uuid)
                             .workspaceManagerInstance(wsmInstance)))
             .resourceMetadata(new ResourceMetadata().workspaceOwner(testUser.email))
             .creation(OffsetDateTime.now())

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -5,7 +5,6 @@ import harness.TestCommand;
 import harness.TestContext;
 import harness.TestUser;
 import harness.utils.WorkspaceUtils;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -17,10 +16,10 @@ import org.junit.jupiter.api.BeforeAll;
  */
 public class SingleWorkspaceUnit extends ClearContextUnit {
   protected static final TestUser workspaceCreator = TestUser.chooseTestUserWithSpendAccess();
-  private static UUID workspaceId;
+  private static String userFacingId;
 
-  protected static UUID getWorkspaceId() {
-    return workspaceId;
+  protected static String getUserFacingId() {
+    return userFacingId;
   }
 
   @BeforeAll
@@ -31,7 +30,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
     workspaceCreator.login();
 
     UFWorkspace createdWorkspace = WorkspaceUtils.createWorkspace(workspaceCreator);
-    workspaceId = createdWorkspace.id;
+    userFacingId = createdWorkspace.id;
   }
 
   @AfterAll
@@ -43,7 +42,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + workspaceId);
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + userFacingId);
 
     // `terra workspace delete`
     TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * This class implements a script to cleanup workspaces owned by test users. Tests are not supposed
@@ -29,8 +28,8 @@ import java.util.UUID;
  * defined, so it's easier to loop through them here.
  */
 public class CleanupTestUserWorkspaces {
-  private static List<UUID> deletedWorkspaces = new ArrayList<>();
-  private static List<UUID> failedWorkspaces = new ArrayList<>();
+  private static List<String> deletedWorkspaces = new ArrayList<>();
+  private static List<String> failedWorkspaces = new ArrayList<>();
 
   /**
    * List all workspaces the test user has access to and try to delete each one that the test user

--- a/src/test/java/harness/utils/WorkspaceUtils.java
+++ b/src/test/java/harness/utils/WorkspaceUtils.java
@@ -1,10 +1,12 @@
 package harness.utils;
 
+import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import harness.CRLJanitor;
 import harness.TestCommand;
 import harness.TestUser;
+import java.util.UUID;
 
 /** Utilities for working with workspaces in CLI tests. */
 public class WorkspaceUtils {
@@ -22,7 +24,7 @@ public class WorkspaceUtils {
     // `terra workspace create --format=json`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(UFWorkspace.class, "workspace", "create");
-    CRLJanitor.registerWorkspaceForCleanup(workspace, workspaceCreator);
+    CRLJanitor.registerWorkspaceForCleanup(getUuidFromCurrentWorkspace(), workspaceCreator);
     return workspace;
   }
 
@@ -43,7 +45,15 @@ public class WorkspaceUtils {
             "create",
             "--name=" + name,
             "--description=" + description);
-    CRLJanitor.registerWorkspaceForCleanup(workspace, workspaceCreator);
+    CRLJanitor.registerWorkspaceForCleanup(getUuidFromCurrentWorkspace(), workspaceCreator);
     return workspace;
+  }
+
+  /**
+   * UFWorkspace doesn't have UUID because user only sees userFacingId. Get UUID from context.json
+   * instead. This assumes there is a current workspace.
+   */
+  private static UUID getUuidFromCurrentWorkspace() {
+    return Context.requireWorkspace().getUuid();
   }
 }

--- a/src/test/java/unit/AuthStatus.java
+++ b/src/test/java/unit/AuthStatus.java
@@ -59,7 +59,7 @@ public class AuthStatus extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra auth status --format=json`
     UFAuthStatus authStatus =

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -18,7 +18,6 @@ import harness.baseclasses.SingleWorkspaceUnit;
 import harness.utils.ExternalBQDatasets;
 import java.io.IOException;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
@@ -36,7 +35,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id --format=json`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "listDescribeReflectCreate";
@@ -87,7 +86,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id --format=json`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "createDatasetWithoutSpecifyingDatasetId";
@@ -130,7 +129,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id --format=json`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "listReflectsDelete";
@@ -154,7 +153,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id --format=json`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "resolve";
@@ -199,7 +198,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "checkAccess";
@@ -227,7 +226,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id --format=json`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId --access=$access
     // --cloning=$cloning --description=$description --location=$location --format=json`
@@ -297,7 +296,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId
     // --description=$description`
@@ -363,7 +362,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create bq-dataset --name=$name --dataset-id=$datasetId
     // --description=$description`
@@ -414,9 +413,10 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and expect one resource with this name. Filters on
    * the specified workspace id; Uses the current workspace if null.
    */
-  static UFBqDataset listOneDatasetResourceWithName(String resourceName, UUID workspaceId)
-      throws JsonProcessingException {
-    List<UFBqDataset> matchedResources = listDatasetResourcesWithName(resourceName, workspaceId);
+  static UFBqDataset listOneDatasetResourceWithName(
+      String resourceName, String workspaceUserFacingId) throws JsonProcessingException {
+    List<UFBqDataset> matchedResources =
+        listDatasetResourcesWithName(resourceName, workspaceUserFacingId);
 
     assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
     return matchedResources.get(0);
@@ -434,11 +434,11 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name and workspace (uses the current workspace if null).
    */
-  static List<UFBqDataset> listDatasetResourcesWithName(String resourceName, UUID workspaceId)
-      throws JsonProcessingException {
+  static List<UFBqDataset> listDatasetResourcesWithName(
+      String resourceName, String workspaceUserFacingId) throws JsonProcessingException {
     // `terra resources list --type=BQ_DATASET --format=json`
     List<UFBqDataset> listedResources =
-        workspaceId == null
+        workspaceUserFacingId == null
             ? TestCommand.runAndParseCommandExpectSuccess(
                 new TypeReference<>() {}, "resource", "list", "--type=BQ_DATASET")
             : TestCommand.runAndParseCommandExpectSuccess(
@@ -446,7 +446,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
                 "resource",
                 "list",
                 "--type=BQ_DATASET",
-                "--workspace=" + workspaceId);
+                "--workspace=" + workspaceUserFacingId);
 
     // find the matching dataset in the list
     return listedResources.stream()

--- a/src/test/java/unit/BqDatasetLifetime.java
+++ b/src/test/java/unit/BqDatasetLifetime.java
@@ -34,7 +34,7 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
   }
 
   @Test

--- a/src/test/java/unit/BqDatasetNumTables.java
+++ b/src/test/java/unit/BqDatasetNumTables.java
@@ -60,7 +60,7 @@ public class BqDatasetNumTables extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId`
     String name = "numTablesForControlled";
@@ -102,7 +102,7 @@ public class BqDatasetNumTables extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId`
@@ -129,7 +129,7 @@ public class BqDatasetNumTables extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId`

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -62,7 +62,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --format=json`
@@ -126,7 +126,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --format=json`
@@ -153,7 +153,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --format=json`
@@ -204,7 +204,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --format=json`
@@ -230,7 +230,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --cloning=$cloning
@@ -291,7 +291,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId  --description=$description`
@@ -371,7 +371,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String controlledDataset = "controlledDataset";

--- a/src/test/java/unit/BqTableReferenced.java
+++ b/src/test/java/unit/BqTableReferenced.java
@@ -84,7 +84,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --table-id=$dataTableId --format=json`
@@ -159,7 +159,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --table-id=$dataTableId --format=json`
@@ -188,7 +188,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --table-id=$dataTableId --format=json`
@@ -249,7 +249,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --table-id=$dataTableId --format=json`
@@ -277,7 +277,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId --cloning=$cloning
@@ -345,7 +345,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId  --description=$description`
@@ -432,7 +432,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String controlledDataset = "controlledDataset";
@@ -520,7 +520,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-table --name=$name --project-id=$projectId
     // --dataset-id=$datasetId`

--- a/src/test/java/unit/BqTableReferencedUpdate.java
+++ b/src/test/java/unit/BqTableReferencedUpdate.java
@@ -50,7 +50,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
         sharedExternalTable);
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     // `terra workspace add-user --email=$email --role=WRITER`
     TestCommand.runCommandExpectSuccess(
         "workspace", "add-user", "--email=" + shareeUser.email, "--role=WRITER");
@@ -77,7 +77,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
   void updateTableReferenceWithNoAccess() throws IOException {
     workspaceCreator.login();
 
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId`
     String name = "updateTableReferenceWithNoAccess";
@@ -92,7 +92,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
 
     shareeUser.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     String newName = "updateTableReferenceWithNoAccess_NEW";
     TestCommand.runCommandExpectExitCode(
@@ -101,7 +101,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
     // Clean up.
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");
   }
 
@@ -111,7 +111,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
   void updateTableReferenceWithPartialAccess() throws IOException {
     workspaceCreator.login();
 
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId
     // --dataset-id=$datasetId`
@@ -127,7 +127,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
 
     shareeUser.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     String newName = "updateTableReferenceWithPartialAccess_NEW";
     UFBqTable updateTable =
@@ -158,7 +158,7 @@ public class BqTableReferencedUpdate extends SingleWorkspaceUnit {
   void addTableReferenceWithPartialAccess() throws IOException {
     shareeUser.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     String succeedName = "addTableReferenceWithPartialAccess_withAccess";
     // `terra resource add-ref bq-dataset --name=$name --project-id=$projectId

--- a/src/test/java/unit/ClientExceptionHandling.java
+++ b/src/test/java/unit/ClientExceptionHandling.java
@@ -61,7 +61,7 @@ public class ClientExceptionHandling extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id --format=json`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "listDescribeReflectCreate";

--- a/src/test/java/unit/Config.java
+++ b/src/test/java/unit/Config.java
@@ -35,7 +35,7 @@ public class Config extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // set the docker image id to an invalid string
     TestCommand.runCommandExpectSuccess("config", "set", "image", "--image=badimageid");
@@ -71,7 +71,7 @@ public class Config extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // create 2 resources
 
@@ -148,17 +148,17 @@ public class Config extends SingleWorkspaceUnit {
     assertEquals(workspace2.id, config.workspaceId, "workspace create affects config list");
 
     // `terra workspace set --id=$id1`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra config get workspace`
     getValue =
         TestCommand.runAndParseCommandExpectSuccess(
             UFWorkspace.class, "config", "get", "workspace");
-    assertEquals(getWorkspaceId(), getValue.id, "workspace set affects config get");
+    assertEquals(getUserFacingId(), getValue.id, "workspace set affects config get");
 
     // `terra config list`
     config = TestCommand.runAndParseCommandExpectSuccess(UFConfig.class, "config", "list");
-    assertEquals(getWorkspaceId(), config.workspaceId, "workspace set affects config list");
+    assertEquals(getUserFacingId(), config.workspaceId, "workspace set affects config list");
 
     // `terra config set workspace --id=$id2`
     TestCommand.runCommandExpectSuccess("config", "set", "workspace", "--id=" + workspace2.id);

--- a/src/test/java/unit/DeletePrompt.java
+++ b/src/test/java/unit/DeletePrompt.java
@@ -30,7 +30,7 @@ public class DeletePrompt extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
   }
 
   @Override

--- a/src/test/java/unit/FineGrainedAccessGcsObjectReference.java
+++ b/src/test/java/unit/FineGrainedAccessGcsObjectReference.java
@@ -96,7 +96,7 @@ public class FineGrainedAccessGcsObjectReference extends SingleWorkspaceUnit {
   void addObjectReferenceWithBucketLevelAccess() throws IOException {
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
     String name = "addObjectReferenceWithAccess";
@@ -146,7 +146,7 @@ public class FineGrainedAccessGcsObjectReference extends SingleWorkspaceUnit {
   void updateObjectReferenceWithBucketLevelAccess() throws IOException {
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
     String name = "updateObjectReferenceWithBucketLevelAccess";
@@ -348,7 +348,7 @@ public class FineGrainedAccessGcsObjectReference extends SingleWorkspaceUnit {
   void describeObjectReferenceWhenUserHasBucketLevelAccess() throws IOException {
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
     String name = "describeObjectReferenceWithAccess";

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -33,7 +33,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "listDescribeReflectCreate";
@@ -76,7 +76,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "listDescribeReflectCreate";
@@ -115,7 +115,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "listReflectsDelete";
@@ -137,7 +137,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "resolve";
@@ -171,7 +171,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "checkAccess";
@@ -197,7 +197,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create gcs-bucket --name=$name --bucket-name=$bucketName --access=$access
     // --cloning=$cloning --description=$description --location=$location --storage=$storage
@@ -272,7 +272,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create gcs-bucket --name=$name --description=$description
     // --bucket-name=$bucketName`
@@ -350,7 +350,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources create gcs-bucket --name=$name --description=$description
     // --bucket-name=$bucketName`
@@ -414,9 +414,9 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and expect one resource with this name. Filters on
    * the specified workspace id; Uses the current workspace if null.
    */
-  static UFGcsBucket listOneBucketResourceWithName(String resourceName, UUID workspaceId)
+  static UFGcsBucket listOneBucketResourceWithName(String resourceName, String userFacingId)
       throws JsonProcessingException {
-    List<UFGcsBucket> matchedResources = listBucketResourcesWithName(resourceName, workspaceId);
+    List<UFGcsBucket> matchedResources = listBucketResourcesWithName(resourceName, userFacingId);
 
     assertEquals(1, matchedResources.size(), "found exactly one resource with this name");
     return matchedResources.get(0);
@@ -435,11 +435,11 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
    * Helper method to call `terra resources list` and filter the results on the specified resource
    * name and workspace (uses the current workspace if null).
    */
-  static List<UFGcsBucket> listBucketResourcesWithName(String resourceName, UUID workspaceId)
-      throws JsonProcessingException {
+  static List<UFGcsBucket> listBucketResourcesWithName(
+      String resourceName, String workspaceUserFacingId) throws JsonProcessingException {
     // `terra resources list --type=GCS_BUCKET --format=json`
     List<UFGcsBucket> listedResources =
-        workspaceId == null
+        workspaceUserFacingId == null
             ? TestCommand.runAndParseCommandExpectSuccess(
                 new TypeReference<>() {}, "resource", "list", "--type=GCS_BUCKET")
             : TestCommand.runAndParseCommandExpectSuccess(
@@ -447,7 +447,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
                 "resource",
                 "list",
                 "--type=GCS_BUCKET",
-                "--workspace=" + workspaceId);
+                "--workspace=" + workspaceUserFacingId);
 
     // find the matching bucket in the list
     return listedResources.stream()

--- a/src/test/java/unit/GcsBucketLifecycle.java
+++ b/src/test/java/unit/GcsBucketLifecycle.java
@@ -63,7 +63,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
   }
 
   @Test

--- a/src/test/java/unit/GcsBucketNumObjects.java
+++ b/src/test/java/unit/GcsBucketNumObjects.java
@@ -74,7 +74,7 @@ public class GcsBucketNumObjects extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "numObjectsForControlled";
@@ -111,7 +111,7 @@ public class GcsBucketNumObjects extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "numObjectsForReferenced";
@@ -134,7 +134,7 @@ public class GcsBucketNumObjects extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "numObjectsForReferencedWithNoAccess";

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -47,7 +47,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     ExternalGCSBuckets.grantReadAccess(
         externalPrivateBucket, Identity.group(Auth.getProxyGroupEmail()));
 
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     shareeUser = TestUser.chooseTestUserWhoIsNot(workspaceCreator);
     TestCommand.runCommandExpectSuccess(
         "workspace", "add-user", "--email=" + shareeUser.email, "--role=WRITER");
@@ -72,7 +72,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "listDescribeReflectAdd";
@@ -127,7 +127,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "listReflectsDelete";
@@ -152,7 +152,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "resolve";
@@ -191,7 +191,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-bucket --name=$name --bucket-name=$bucketName`
     String name = "checkAccess";
@@ -215,7 +215,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref gcs-bucket --name=$name --bucket-name=$bucketName --cloning=$cloning
     // --description=$description --format=json`
@@ -266,7 +266,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref gcs-bucket --name=$name --description=$description
     // --bucket-name=$bucketName`
@@ -342,7 +342,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref gcs-bucket --name=$name --description=$description
     // --bucket-name=$bucketName`
@@ -399,7 +399,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     String name = "updateGcsBucketWithPartialAccess";
     TestCommand.runCommandExpectSuccess(
@@ -411,7 +411,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
 
     shareeUser.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     String newName = "updateGcsBucketWithPartialAccess_NEW";
     UFGcsBucket updateBucket =

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -95,7 +95,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
@@ -159,7 +159,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
@@ -263,7 +263,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
@@ -305,7 +305,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
@@ -333,7 +333,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName`
@@ -360,7 +360,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName --cloning=$cloning --description=$description --format=json`
@@ -422,7 +422,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref gcs-object --name=$name --bucket-name=$bucketName
     // --object-name=$objectName --description=$description`
@@ -523,7 +523,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref gcs-object --name=$name --description=$description
     // --bucket-name=$bucketName --object-name=$objectName`

--- a/src/test/java/unit/GitRepoReferenced.java
+++ b/src/test/java/unit/GitRepoReferenced.java
@@ -31,7 +31,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref git-repo --name=$name --repo-url=$repoUrl
     String name = "listDescribeReflectAdd";
@@ -81,7 +81,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref git-repo --name=$name --repo-url=$repoUrl
     String name = "resolve";
@@ -109,7 +109,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref git-repo --name=$name --repo-url=$repoUrl
     String name = "listReflectsDelete";
@@ -135,7 +135,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref git-repo --name=$name --repo-url=$repoUrl
     // --cloning=$cloning --description=$description --format=json`
@@ -184,7 +184,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource add-ref git-repo --name=$name --repo-url=$repoUrl --description=$description`
     String name = "updateIndividualProperties";
@@ -260,7 +260,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resources add-ref git-repo --name=$name --description=$description
     // --repo-url=$gitUrl

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -48,7 +48,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra app execute echo \$GOOGLE_CLOUD_PROJECT`
     TestCommand.Result cmd =
@@ -67,7 +67,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "resourceEnvVars";
@@ -96,7 +96,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     // `terra workspace set --id=$id`
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + getWorkspaceId());
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra gcloud config get-value project`
     TestCommand.Result cmd = TestCommand.runCommand("gcloud", "config", "get-value", "project");
@@ -134,7 +134,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "resourceName";
@@ -164,7 +164,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
     String name = "bqShow";
@@ -196,7 +196,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra nextflow -version`
     TestCommand.Result cmd = TestCommand.runCommand("nextflow", "-version");
@@ -211,7 +211,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
   void gitCloneAll() throws IOException {
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     TestCommand.runCommandExpectSuccess(
         "resource",
         "add-ref",
@@ -249,7 +249,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
   void gitCloneResource() throws IOException {
     workspaceCreator.login();
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
     TestCommand.runCommandExpectSuccess(
         "resource",
         "add-ref",
@@ -272,7 +272,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra gcloud -version`
     // this is a malformed command, should be --version
@@ -298,7 +298,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra config set app-launch LOCAL_PROCESS`
     TestCommand.runCommandExpectSuccess("config", "set", "app-launch", "LOCAL_PROCESS");

--- a/src/test/java/unit/Server.java
+++ b/src/test/java/unit/Server.java
@@ -137,7 +137,7 @@ public class Server extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra server set --name=broad-dev-cli-testing --quiet`
     TestCommand.runCommandExpectSuccess("server", "set", "--name=broad-dev-cli-testing", "--quiet");
@@ -164,7 +164,7 @@ public class Server extends SingleWorkspaceUnit {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getWorkspaceId());
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra server set --name=broad-dev-cli-testing --quiet`
     ByteArrayInputStream stdIn = new ByteArrayInputStream("NO".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -321,7 +321,7 @@ public class Workspace extends ClearContextUnit {
    * id. Use a high limit to ensure that leaked workspaces in the list don't cause the one we care
    * about to page out.
    */
-  static List<UFWorkspaceLight> listWorkspacesWithId(UUID workspaceId)
+  static List<UFWorkspaceLight> listWorkspacesWithId(String userFacingId)
       throws JsonProcessingException {
     // `terra workspace list --format=json --limit=500`
     List<UFWorkspaceLight> listWorkspaces =
@@ -329,7 +329,7 @@ public class Workspace extends ClearContextUnit {
             new TypeReference<>() {}, "workspace", "list", "--limit=500");
 
     return listWorkspaces.stream()
-        .filter(workspace -> workspace.id.equals(workspaceId))
+        .filter(workspace -> workspace.id.equals(userFacingId))
         .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
CLI commits are "released to prod" soon after they're merged. This PR uses `WorkspaceService.workspaceByUserFacingId`. **So I will wait for https://github.com/DataBiosphere/terra-workspace-manager/pull/636 to be in production (Broad and Verily) without any chance of rollback, before merging this PR.**

Before this PR, cli `ID` was `uuid`:
```
~/terra-cli (mc/ufid-create-update): terra workspace describe
ID: 66676d27-82e4-4f59-8f56-4202266c3258
Name:
Description:
Google project: terra-wsm-t-windy-truffle-3019
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-windy-truffle-3019
# Resources: 0
```

After this PR, `ID` is `userFacingId`:
```
~/terra-cli (mc/ufid-create-update): terra workspace describe
ID: user-facing-id
Name:
Description:
Google project: terra-wsm-t-windy-truffle-3019
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-windy-truffle-3019
# Resources: 0
```

This PR updates all CLI output, not just `terra workspace describe`.

Manual testing:
```
~/terra-cli (mc/ufid-create-update): terra workspace create --name="yo 1"
Workspace successfully created.
ID: a-0a942dea-f4be-4e3a-ba8c-c779d6c920d6
Name: yo 1
Description:
Google project: terra-wsm-t-silky-grape-2
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-silky-grape-2
# Resources: 0
~/terra-cli (mc/ufid-create-update): terra workspace create --name="yo 2"
Workspace successfully created.
ID: a-e601d42b-71e2-4d7f-a601-08599396e308
Name: yo 2
Description:
Google project: terra-wsm-t-sleek-walnut-9935
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sleek-walnut-9935
# Resources: 0
~/terra-cli (mc/ufid-create-update): terra workspace list
   ID                                    NAME                            GOOGLE PROJECT                  DESCRIPTION
   a-0a942dea-f4be-4e3a-ba8c-c779d6c...  yo 1                            terra-wsm-t-silky-grape-2       (unset)
 ✓ a-e601d42b-71e2-4d7f-a601-0859939...  yo 2                            terra-wsm-t-sleek-walnut-9935   (unset)
~/terra-cli (mc/ufid-create-update): terra workspace list --format=json

[ {
  "id" : "a-0a942dea-f4be-4e3a-ba8c-c779d6c920d6",
  "name" : "yo 1",
  "description" : "",
  "googleProjectId" : "terra-wsm-t-silky-grape-2",
  "serverName" : "broad-dev-local-wsm",
  "userEmail" : "melchang@google.com"
}, {
  "id" : "a-e601d42b-71e2-4d7f-a601-08599396e308",
  "name" : "yo 2",
  "description" : "",
  "googleProjectId" : "terra-wsm-t-sleek-walnut-9935",
  "serverName" : "broad-dev-local-wsm",
  "userEmail" : "melchang@google.com"
} ]
~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra config get workspace

a-e601d42b-71e2-4d7f-a601-08599396e308
~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra workspace describe

ID: a-e601d42b-71e2-4d7f-a601-08599396e308
Name: yo 2
Description:
Google project: terra-wsm-t-sleek-walnut-9935
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sleek-walnut-9935
# Resources: 0
~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra resource list

NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION

~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra resource create gcs-bucket --name=yo_2

Successfully added controlled GCS bucket.
Name:         yo_2
Description:
Type:         GCS_BUCKET
Stewardship:  CONTROLLED
Cloning:      COPY_RESOURCE
Access scope: SHARED_ACCESS
Managed by:   USER
GCS bucket name: terra-0be639d0-b70b-4f50-8398-3ba6ae7940f9-bucket
Location: US-CENTRAL1
# Objects: 0
~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra resource list
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION
yo_2                            GCS_BUCKET            CONTROLLED            (unset)
~/terra-cli (mc/ufid-create-update): terra resource list --workspace=a-e601d42b-71e2-4d7f-a601-08599396e308
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION
yo_2                            GCS_BUCKET            CONTROLLED            (unset)
~/terra-cli (mc/ufid-create-update): terra resource create gcs-bucket --name=yo_1 --workspace=a-0a942dea-f4be-4e3a-ba8c-c779d6c920d6
Successfully added controlled GCS bucket.
Name:         yo_1
Description:
Type:         GCS_BUCKET
Stewardship:  CONTROLLED
Cloning:      COPY_RESOURCE
Access scope: SHARED_ACCESS
Managed by:   USER
GCS bucket name: terra-2d120658-75bf-4b90-b6c8-1ac3a48da311-bucket
Location: US-CENTRAL1
# Objects: 0
~/terra-cli (mc/ufid-create-update): terra resource list --workspace=a-0a942dea-f4be-4e3a-ba8c-c779d6c920d6
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION
yo_1                            GCS_BUCKET            CONTROLLED            (unset)
~/terra-cli (mc/ufid-create-update): terra workspace update --name="yoyo 2"
Workspace successfully updated.
ID: a-e601d42b-71e2-4d7f-a601-08599396e308
Name: yoyo 2
Description:
Google project: terra-wsm-t-sleek-walnut-9935
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sleek-walnut-9935
# Resources: 0
~/terra-cli (mc/ufid-create-update): terra workspace describe
ID: a-e601d42b-71e2-4d7f-a601-08599396e308
Name: yoyo 2
Description:
Google project: terra-wsm-t-sleek-walnut-9935
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sleek-walnut-9935
# Resources: 0
~/terra-cli (mc/ufid-create-update): terra workspace list
   ID                                    NAME                            GOOGLE PROJECT                  DESCRIPTION
   a-0a942dea-f4be-4e3a-ba8c-c779d6c...  yo 1                            terra-wsm-t-silky-grape-2       (unset)
 ✓ a-e601d42b-71e2-4d7f-a601-0859939...  yoyo 2                          terra-wsm-t-sleek-walnut-9935   (unset)
~/terra-cli (mc/ufid-create-update): terra workspace clone
# Ignore error, this is due to PF-1623
Resource not found: yo_2
~/terra-cli (mc/ufid-create-update):
~/terra-cli (mc/ufid-create-update): terra workspace list
   ID                                    NAME                            GOOGLE PROJECT                  DESCRIPTION
   a-02f63a7b-1f5f-4772-8f2b-b79f940...  (unset)                         terra-wsm-t-lucent-acorn-9463   (unset)
   a-0a942dea-f4be-4e3a-ba8c-c779d6c...  yo 1                            terra-wsm-t-silky-grape-2       (unset)
 ✓ a-e601d42b-71e2-4d7f-a601-0859939...  yoyo 2                          terra-wsm-t-sleek-walnut-9935   (unset)
~/terra-cli (mc/ufid-create-update): terra workspace delete --quiet
ID: a-e601d42b-71e2-4d7f-a601-08599396e308
Name: yoyo 2
Description:
Google project: terra-wsm-t-sleek-walnut-9935
Cloud console: https://console.cloud.google.com/home/dashboard?project=terra-wsm-t-sleek-walnut-9935
# Resources: 0
Workspace successfully deleted.
~/terra-cli (mc/ufid-create-update): terra workspace list
   ID                                    NAME                            GOOGLE PROJECT                  DESCRIPTION
   a-02f63a7b-1f5f-4772-8f2b-b79f940...  (unset)                         terra-wsm-t-lucent-acorn-9463   (unset)
   a-0a942dea-f4be-4e3a-ba8c-c779d6c...  yo 1                            terra-wsm-t-silky-grape-2       (unset)
```

Ignore failing test `WorkspaceSetDeferLogin`. It will be deleted in PF-1622.

Next PRs:
- Allow setting ufId with create, update, clone
- Require ufId on create, clone

FYI @ginaygoogle 
