### PR TITLE
[PF-1614] fix crash on M1 chip

### DIFF
--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 ## This script sets up the environment for local development.
 ## Dependencies: docker, chmod
 ## Usage: source tools/local-dev.sh
@@ -33,7 +32,3 @@ chmod a+x tools/*
 
 # pull credentials needed for development
 ./tools/render-config.sh
-
-# restore the bash setting to exit on a failing command
-# (this script is typically called with `source`, and so we don't want to modify the calling shell)
-set +e

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -12,7 +12,7 @@ if [ $(basename $PWD) != 'terra-cli' ]; then
 fi
 
 VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
-DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:consul-0.20.0
+DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
 CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
 TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
 TEST_USERS_VAULT_PATH=secret/dsde/terra/cli-test/test-users


### PR DESCRIPTION
We were using a very old version of the `dsde-toolbox`; new one has fix for this issue. [Slack convo](https://broadinstitute.slack.com/archives/CADM7MZ35/p1651596362136939). Also got rid of `set -e`, which kills terminal sessions (and can even close windows) in the event of a crash.