### PR TITLE
Fix bumper action

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -18,7 +18,7 @@ jobs:
           ref: main
       - name: Bump tag and build version
         id: bump_tag
-        uses: databiosphere/github-actions/actions/bumper@v0.0.3
+        uses: databiosphere/github-actions/actions/bumper@v0.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           DEFAULT_BUMP: minor


### PR DESCRIPTION
Bumper action has been failing recently:

https://github.com/DataBiosphere/terra-cli/actions/workflows/release-on-pr-merge.yml

[This slack thread](https://broadinstitute.slack.com/archives/CADM7MZ35/p1650054683138679) says upgrading action should fix it.