### PR TITLE
googleGuest wifi will cause could not login

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ listed in the command usage.
 #### Troubleshooting
 - Wipe the global context directory. `rm -R $HOME/.terra`.
 - Re-run the setup script. `source tools/local-dev.sh`.
+- Do not use GoogleGuest wifi in the google office.
 
 
 ### Publish a release


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/100877272/167701083-aea07854-ff32-4e5a-a00d-b5fc8b7675d2.png)
The log file shows the [error] network can’t reachable. Because used WIFI from googleGuest. 
Change to Google-A or others will be solved. 

Just add one line in CONTRIBUTING.md after talked with Jay.