### PR TITLE
[PF-1335] Gradle Enterprise Trial Navigator Step 1

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,18 @@
+plugins {
+    id "com.gradle.enterprise" version "3.10"
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.5'
+}
+
 rootProject.name = 'terra-cli'
+
+// Gradle Enterprise Trial Navigator Step 1
+gradleEnterprise {
+    server = "https://gradle-enterprise-prod-helm-cluster.api.verily.com"
+    buildScan {
+        publishAlways()
+        capture {
+            taskInputFiles = true
+        }
+        uploadInBackground = System.getenv("CI") == null
+    }
+}


### PR DESCRIPTION
This sends build scans to https://gradle-enterprise-prod-helm-cluster.api.verily.com/ instead of scans.gradle.com. Here are scans from both local run and GHA:

![image](https://user-images.githubusercontent.com/10929390/168145897-56eb95d3-182f-4914-b595-49e380fc7482.png)

@ghale