### PR TITLE
PF-1569: Add Option to use ID Tokens for AuthN in Terra API Calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,10 @@ dependencies {
         jackson = '2.12.3'
 
         // GCP
-        googleOauth2 = '0.22.0'
-        googleClient = '1.31.1'
+        googleOauth2 = '1.6.0'
+        googleClient = '1.33.3'
         bigQuery = '1.116.6'
-        cloudStorage = '1.117.0'
+        cloudStorage = '2.7.2'
         // Only used for testing
         pubsub = '1.116.4'
 
@@ -94,6 +94,7 @@ dependencies {
 
     implementation "com.google.oauth-client:google-oauth-client-jetty:${googleClient}"
     implementation "com.google.oauth-client:google-oauth-client-java6:${googleClient}"
+    implementation "com.google.auth:google-auth-library-credentials:${googleOauth2}"
     implementation "com.google.auth:google-auth-library-oauth2-http:${googleOauth2}"
     implementation "com.google.cloud:google-cloud-bigquery:${bigQuery}"
     implementation "com.google.cloud:google-cloud-storage:${cloudStorage}"
@@ -119,8 +120,8 @@ dependencies {
     implementation "bio.terra:externalcreds-client-resttemplate:${externalCredsClient}"
     testImplementation "bio.terra:terra-resource-janitor-client:${janitor}"
 
-    compile "io.swagger.core.v3:swagger-annotations:${swaggerAnnotations}"
-    compile "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
+    implementation "io.swagger.core.v3:swagger-annotations:${swaggerAnnotations}"
+    implementation "org.glassfish.jersey.inject:jersey-hk2:${jersey}"
 
     testImplementation platform("org.junit:junit-bom:${junit}")
     testImplementation "org.junit.jupiter:junit-jupiter"

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -101,7 +101,7 @@ public class AppDefaultCredentialUtils {
    * ADC must be properly scoped; passing improperly scoped credentials will result in a {@code
    * SystemException}. Any other failure to obtain the token will result in an {@code IoException}.
    */
-  private static IdToken getIdTokenFromADC(GoogleCredentials applicationDefaultCredentials)
+  private static IdToken getIdTokenFromAdc(GoogleCredentials applicationDefaultCredentials)
       throws IOException {
     if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
       throw new SystemException(
@@ -123,12 +123,12 @@ public class AppDefaultCredentialUtils {
     return idTokenCredentials.getIdToken();
   }
 
-  public static TerraCredentials getExistingADC(List<String> scopes) throws IOException {
+  public static TerraCredentials getExistingAdc(List<String> scopes) throws IOException {
     GoogleCredentials applicationDefaultCredentials =
         AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(scopes);
 
     return new TerraCredentials(
         applicationDefaultCredentials,
-        AppDefaultCredentialUtils.getIdTokenFromADC(applicationDefaultCredentials));
+        AppDefaultCredentialUtils.getIdTokenFromAdc(applicationDefaultCredentials));
   }
 }

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -3,7 +3,7 @@ package bio.terra.cli.app.utils;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import bio.terra.cli.service.GoogleOauth;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdToken;
@@ -97,11 +97,10 @@ public class AppDefaultCredentialUtils {
 
   /**
    * Get an ID token from an Application Default Credential and Client Secrets. Note that the passed
-   * ADC must be properly scoped, passing improperly scoped credentials will result in a {@code
+   * ADC must be properly scoped; passing improperly scoped credentials will result in a {@code
    * SystemException}. Any other failure to obtain the token will result in an {@code IoException}.
    */
-  public static IdToken getIdTokenFromApplicationDefaultCredentials(
-      GoogleCredentials applicationDefaultCredentials, GoogleClientSecrets clientSecrets)
+  public static IdToken getIdTokenFromADC(GoogleCredentials applicationDefaultCredentials)
       throws IOException {
     if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
       throw new SystemException(
@@ -114,7 +113,7 @@ public class AppDefaultCredentialUtils {
     IdTokenCredentials idTokenCredentials =
         IdTokenCredentials.newBuilder()
             .setIdTokenProvider((IdTokenProvider) applicationDefaultCredentials)
-            .setTargetAudience(clientSecrets.getDetails().getClientId())
+            .setTargetAudience(GoogleOauth.getClientSecrets().getDetails().getClientId())
             .setOptions(List.of(IdTokenProvider.Option.FORMAT_FULL))
             .build();
 

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -99,7 +99,7 @@ public class AppDefaultCredentialUtils {
   /**
    * Get an ID token from an Application Default Credential and Client Secrets. Note that the passed
    * ADC must be properly scoped; passing improperly scoped credentials will result in a {@code
-   * SystemException}. Any other failure to obtain the token will result in an {@code IoException}.
+   * SystemException}. Any other failure to obtain the token will result in an {@code IOException}.
    */
   private static IdToken getIdTokenFromAdc(GoogleCredentials applicationDefaultCredentials)
       throws IOException {

--- a/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/AppDefaultCredentialUtils.java
@@ -4,6 +4,7 @@ import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.GoogleOauth;
+import bio.terra.cli.service.utils.TerraCredentials;
 import com.google.auth.oauth2.ComputeEngineCredentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdToken;
@@ -85,7 +86,7 @@ public class AppDefaultCredentialUtils {
   }
 
   /** Get the application default credentials. Throw an exception if they are not defined. */
-  public static GoogleCredentials getApplicationDefaultCredentials() {
+  private static GoogleCredentials getApplicationDefaultCredentials() {
     try {
       return GoogleCredentials.getApplicationDefault();
     } catch (IOException ioEx) {
@@ -100,7 +101,7 @@ public class AppDefaultCredentialUtils {
    * ADC must be properly scoped; passing improperly scoped credentials will result in a {@code
    * SystemException}. Any other failure to obtain the token will result in an {@code IoException}.
    */
-  public static IdToken getIdTokenFromADC(GoogleCredentials applicationDefaultCredentials)
+  private static IdToken getIdTokenFromADC(GoogleCredentials applicationDefaultCredentials)
       throws IOException {
     if (!(applicationDefaultCredentials instanceof IdTokenProvider)) {
       throw new SystemException(
@@ -120,5 +121,14 @@ public class AppDefaultCredentialUtils {
     // Must call refresh() to obtain the token.
     idTokenCredentials.refresh();
     return idTokenCredentials.getIdToken();
+  }
+
+  public static TerraCredentials getExistingADC(List<String> scopes) throws IOException {
+    GoogleCredentials applicationDefaultCredentials =
+        AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(scopes);
+
+    return new TerraCredentials(
+        applicationDefaultCredentials,
+        AppDefaultCredentialUtils.getIdTokenFromADC(applicationDefaultCredentials));
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -42,6 +42,7 @@ public class Server {
   private final String wsmDefaultSpendProfile;
   private final String dataRepoUri;
   private final String externalCredsUri;
+  private final boolean idTokenAuthentication;
 
   private static final String DEFAULT_SERVER_FILENAME = "broad-dev-cli-testing.json";
   @VisibleForTesting public static final String RESOURCE_DIRECTORY = "servers";
@@ -57,6 +58,7 @@ public class Server {
     this.wsmDefaultSpendProfile = configFromDisk.wsmDefaultSpendProfile;
     this.dataRepoUri = configFromDisk.dataRepoUri;
     this.externalCredsUri = configFromDisk.externalCredsUri;
+    this.idTokenAuthentication = configFromDisk.idTokenAuthentication;
   }
 
   /** Return an instance of this class with default values. */
@@ -200,5 +202,9 @@ public class Server {
 
   public String getExternalCredsUri() {
     return externalCredsUri;
+  }
+
+  public boolean getIdTokenAuthentication() {
+    return idTokenAuthentication;
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -42,7 +42,9 @@ public class Server {
   private final String wsmDefaultSpendProfile;
   private final String dataRepoUri;
   private final String externalCredsUri;
-  private final boolean idTokenAuthentication;
+  
+  // Terra services in the service instance are configured to accept JWT ID tokens for authentication.
+  private final boolean supportsIdToken;
 
   private static final String DEFAULT_SERVER_FILENAME = "broad-dev-cli-testing.json";
   @VisibleForTesting public static final String RESOURCE_DIRECTORY = "servers";
@@ -58,7 +60,7 @@ public class Server {
     this.wsmDefaultSpendProfile = configFromDisk.wsmDefaultSpendProfile;
     this.dataRepoUri = configFromDisk.dataRepoUri;
     this.externalCredsUri = configFromDisk.externalCredsUri;
-    this.idTokenAuthentication = configFromDisk.idTokenAuthentication;
+    this.supportsIdToken = configFromDisk.supportsIdToken;
   }
 
   /** Return an instance of this class with default values. */
@@ -204,7 +206,7 @@ public class Server {
     return externalCredsUri;
   }
 
-  public boolean getIdTokenAuthentication() {
-    return idTokenAuthentication;
+  public boolean getSupportsIdToken() {
+    return supportsIdToken;
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/Server.java
+++ b/src/main/java/bio/terra/cli/businessobject/Server.java
@@ -42,8 +42,9 @@ public class Server {
   private final String wsmDefaultSpendProfile;
   private final String dataRepoUri;
   private final String externalCredsUri;
-  
-  // Terra services in the service instance are configured to accept JWT ID tokens for authentication.
+
+  // Terra services in the service instance are configured to accept JWT ID tokens for
+  // authentication.
   private final boolean supportsIdToken;
 
   private static final String DEFAULT_SERVER_FILENAME = "broad-dev-cli-testing.json";

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -164,14 +164,7 @@ public class User {
   private void loadAppDefaultCredentials() {
 
     try {
-      GoogleCredentials applicationDefaultCredentials =
-          AppDefaultCredentialUtils.getApplicationDefaultCredentials().createScoped(PET_SA_SCOPES);
-
-      terraCredentials =
-          new TerraCredentials(
-              applicationDefaultCredentials,
-              AppDefaultCredentialUtils.getIdTokenFromADC(applicationDefaultCredentials));
-
+      terraCredentials = AppDefaultCredentialUtils.getExistingADC(PET_SA_SCOPES);
     } catch (IOException ioException) {
       throw new SystemException(
           "Could not obtain ID Token from Application Default Credentials.", ioException);

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -341,7 +341,7 @@ public class User {
    * configured Server instance.
    */
   public AccessToken getTerraToken() {
-    return Context.getServer().getIdTokenAuthentication() ? getUserIdToken() : getUserAccessToken();
+    return Context.getServer().getSupportsIdToken() ? getUserIdToken() : getUserAccessToken();
   }
 
   /** Get the access token for the pet SA credentials. */

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -336,6 +336,14 @@ public class User {
     return GoogleOauth.getIdToken(terraCredentials);
   }
 
+  /**
+   * Get the token to use for authentication when calling a Terra service API against the currently
+   * configured Server instance.
+   */
+  public AccessToken getTerraToken() {
+    return Context.getServer().getIdTokenAuthentication() ? getUserIdToken() : getUserAccessToken();
+  }
+
   /** Get the access token for the pet SA credentials. */
   public AccessToken getPetSaAccessToken() {
     String googleProjectId = Context.requireWorkspace().getGoogleProjectId();

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -164,7 +164,7 @@ public class User {
   private void loadAppDefaultCredentials() {
 
     try {
-      terraCredentials = AppDefaultCredentialUtils.getExistingADC(PET_SA_SCOPES);
+      terraCredentials = AppDefaultCredentialUtils.getExistingAdc(PET_SA_SCOPES);
     } catch (IOException ioException) {
       throw new SystemException(
           "Could not obtain ID Token from Application Default Credentials.", ioException);

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
@@ -21,6 +21,7 @@ public class PDServer {
   public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
   public final String externalCredsUri;
+  public boolean idTokenAuthentication;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDServer(Server internalObj) {
@@ -32,6 +33,7 @@ public class PDServer {
     this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
     this.externalCredsUri = internalObj.getExternalCredsUri();
+    this.idTokenAuthentication = internalObj.getIdTokenAuthentication();
   }
 
   private PDServer(PDServer.Builder builder) {
@@ -43,6 +45,7 @@ public class PDServer {
     this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
     this.externalCredsUri = builder.externalCredsUri;
+    this.idTokenAuthentication = builder.idTokenAuthentication;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -55,6 +58,7 @@ public class PDServer {
     private String wsmDefaultSpendProfile;
     private String dataRepoUri;
     private String externalCredsUri;
+    private boolean idTokenAuthentication;
 
     public Builder name(String name) {
       this.name = name;
@@ -93,6 +97,11 @@ public class PDServer {
 
     public Builder externalCredsUri(String externalCredsUri) {
       this.externalCredsUri = externalCredsUri;
+      return this;
+    }
+
+    public Builder idTokenAuthentication(boolean idTokenAuthentication) {
+      this.idTokenAuthentication = idTokenAuthentication;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDServer.java
@@ -21,7 +21,7 @@ public class PDServer {
   public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
   public final String externalCredsUri;
-  public boolean idTokenAuthentication;
+  public final boolean supportsIdToken;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDServer(Server internalObj) {
@@ -33,7 +33,7 @@ public class PDServer {
     this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
     this.externalCredsUri = internalObj.getExternalCredsUri();
-    this.idTokenAuthentication = internalObj.getIdTokenAuthentication();
+    this.supportsIdToken = internalObj.getSupportsIdToken();
   }
 
   private PDServer(PDServer.Builder builder) {
@@ -45,7 +45,7 @@ public class PDServer {
     this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
     this.externalCredsUri = builder.externalCredsUri;
-    this.idTokenAuthentication = builder.idTokenAuthentication;
+    this.supportsIdToken = builder.supportsIdToken;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -58,7 +58,7 @@ public class PDServer {
     private String wsmDefaultSpendProfile;
     private String dataRepoUri;
     private String externalCredsUri;
-    private boolean idTokenAuthentication;
+    private boolean supportsIdToken;
 
     public Builder name(String name) {
       this.name = name;
@@ -100,8 +100,8 @@ public class PDServer {
       return this;
     }
 
-    public Builder idTokenAuthentication(boolean idTokenAuthentication) {
-      this.idTokenAuthentication = idTokenAuthentication;
+    public Builder supportsIdToken(boolean supportsIdToken) {
+      this.supportsIdToken = supportsIdToken;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
@@ -22,7 +22,7 @@ public class UFServer {
   public final String workspaceManagerUri;
   public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
-  public final boolean idTokenAuthentication;
+  public final boolean supportsIdToken;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFServer(Server internalObj) {
@@ -33,7 +33,7 @@ public class UFServer {
     this.workspaceManagerUri = internalObj.getWorkspaceManagerUri();
     this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
-    this.idTokenAuthentication = internalObj.getIdTokenAuthentication();
+    this.supportsIdToken = internalObj.getSupportsIdToken();
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -45,7 +45,7 @@ public class UFServer {
     this.workspaceManagerUri = builder.workspaceManagerUri;
     this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
-    this.idTokenAuthentication = builder.idTokenAuthentication;
+    this.supportsIdToken = builder.supportsIdToken;
   }
 
   /** Print out this object in text format. */
@@ -63,7 +63,7 @@ public class UFServer {
     private String workspaceManagerUri;
     private String wsmDefaultSpendProfile;
     private String dataRepoUri;
-    private boolean idTokenAuthentication;
+    private boolean supportsIdToken;
 
     public Builder name(String name) {
       this.name = name;
@@ -100,8 +100,8 @@ public class UFServer {
       return this;
     }
 
-    public Builder idTokenAuthentication(boolean idTokenAuthentication) {
-      this.idTokenAuthentication = idTokenAuthentication;
+    public Builder supportsIdToken(boolean supportsIdToken) {
+      this.supportsIdToken = supportsIdToken;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFServer.java
@@ -22,6 +22,7 @@ public class UFServer {
   public final String workspaceManagerUri;
   public final String wsmDefaultSpendProfile;
   public final String dataRepoUri;
+  public final boolean idTokenAuthentication;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFServer(Server internalObj) {
@@ -32,6 +33,7 @@ public class UFServer {
     this.workspaceManagerUri = internalObj.getWorkspaceManagerUri();
     this.wsmDefaultSpendProfile = internalObj.getWsmDefaultSpendProfile();
     this.dataRepoUri = internalObj.getDataRepoUri();
+    this.idTokenAuthentication = internalObj.getIdTokenAuthentication();
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -43,6 +45,7 @@ public class UFServer {
     this.workspaceManagerUri = builder.workspaceManagerUri;
     this.wsmDefaultSpendProfile = builder.wsmDefaultSpendProfile;
     this.dataRepoUri = builder.dataRepoUri;
+    this.idTokenAuthentication = builder.idTokenAuthentication;
   }
 
   /** Print out this object in text format. */
@@ -60,6 +63,7 @@ public class UFServer {
     private String workspaceManagerUri;
     private String wsmDefaultSpendProfile;
     private String dataRepoUri;
+    private boolean idTokenAuthentication;
 
     public Builder name(String name) {
       this.name = name;
@@ -93,6 +97,11 @@ public class UFServer {
 
     public Builder dataRepoUri(String dataRepoUri) {
       this.dataRepoUri = dataRepoUri;
+      return this;
+    }
+
+    public Builder idTokenAuthentication(boolean idTokenAuthentication) {
+      this.idTokenAuthentication = idTokenAuthentication;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/service/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/DataRepoService.java
@@ -8,7 +8,6 @@ import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.RepositoryConfigurationModel;
 import bio.terra.datarepo.model.RepositoryStatusModel;
-import com.google.auth.oauth2.AccessToken;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,13 +35,7 @@ public class DataRepoService {
     this.apiClient = new ApiClient();
 
     this.apiClient.setBasePath(server.getDataRepoUri());
-    if (user != null) {
-      // fetch the user access token
-      // this method call will attempt to refresh the token if it's already expired
-      AccessToken token =
-          server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
-      this.apiClient.setAccessToken(token.getTokenValue());
-    }
+    if (user != null) this.apiClient.setAccessToken(user.getTerraToken().getTokenValue());
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/DataRepoService.java
@@ -35,7 +35,9 @@ public class DataRepoService {
     this.apiClient = new ApiClient();
 
     this.apiClient.setBasePath(server.getDataRepoUri());
-    if (user != null) this.apiClient.setAccessToken(user.getTerraToken().getTokenValue());
+    if (user != null) {
+      this.apiClient.setAccessToken(user.getTerraToken().getTokenValue());
+    }
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/DataRepoService.java
@@ -8,6 +8,7 @@ import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
 import bio.terra.datarepo.model.RepositoryConfigurationModel;
 import bio.terra.datarepo.model.RepositoryStatusModel;
+import com.google.auth.oauth2.AccessToken;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,9 @@ public class DataRepoService {
     if (user != null) {
       // fetch the user access token
       // this method call will attempt to refresh the token if it's already expired
-      this.apiClient.setAccessToken(user.getUserAccessToken().getTokenValue());
+      AccessToken token =
+          server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
+      this.apiClient.setAccessToken(token.getTokenValue());
     }
   }
 

--- a/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
+++ b/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
@@ -2,6 +2,7 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
+import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.service.utils.HttpUtils;
 import bio.terra.externalcreds.api.SshKeyPairApi;
@@ -40,8 +41,11 @@ public class ExternalCredentialsManagerService {
   }
 
   public static ExternalCredentialsManagerService fromContext() {
-    return new ExternalCredentialsManagerService(
-        Context.requireUser().getUserAccessToken(), Context.getServer());
+    Server server = Context.getServer();
+    User user = Context.requireUser();
+    AccessToken token =
+        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
+    return new ExternalCredentialsManagerService(token, server);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
+++ b/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
@@ -2,7 +2,6 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
-import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.service.utils.HttpUtils;
 import bio.terra.externalcreds.api.SshKeyPairApi;
@@ -41,11 +40,8 @@ public class ExternalCredentialsManagerService {
   }
 
   public static ExternalCredentialsManagerService fromContext() {
-    Server server = Context.getServer();
-    User user = Context.requireUser();
-    AccessToken token =
-        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
-    return new ExternalCredentialsManagerService(token, server);
+    return new ExternalCredentialsManagerService(
+        Context.requireUser().getTerraToken(), Context.getServer());
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/service/GoogleOauth.java
@@ -1,6 +1,5 @@
 package bio.terra.cli.service;
 
-import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.utils.HttpUtils;
@@ -40,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +65,7 @@ public final class GoogleOauth {
   /** Load the client secrets file to pass to oauth API's. */
   private static GoogleClientSecrets readClientSecrets() {
     try (InputStream inputStream =
-        User.class.getClassLoader().getResourceAsStream(CLIENT_SECRET_FILENAME)) {
+        GoogleOauth.class.getClassLoader().getResourceAsStream(CLIENT_SECRET_FILENAME)) {
 
       GoogleClientSecrets clientSecrets =
           GoogleClientSecrets.load(
@@ -75,7 +75,7 @@ public final class GoogleOauth {
       return clientSecrets;
     } catch (IOException ioException) {
       throw new SystemException(
-          String.format("Could not open client secret file '%s'.", CLIENT_SECRET_FILENAME),
+          String.format("Failure reading client secrets from file: '%s'.", CLIENT_SECRET_FILENAME),
           ioException);
     }
   }
@@ -189,12 +189,13 @@ public final class GoogleOauth {
   }
 
   /**
-   * Get the existing credential for the given user.
+   * Get the existing stored credential for the given user if it exists.
    *
    * @param scopes list of scopes requested of the user
    * @param dataStoreDir directory where the local credential store is persisted
-   * @return credentials object for the user
+   * @return credentials object for the user, or null if a valid stored credential does not exist
    */
+  @Nullable
   public static TerraCredentials getExistingUserCredential(List<String> scopes, File dataStoreDir)
       throws IOException, GeneralSecurityException {
 
@@ -436,7 +437,7 @@ public final class GoogleOauth {
       // retry their command, as next run should get new creds and succeed.
       logger.error(
           "ID token expiration ({}) before current time ({}).", idToken.getExpirationTime(), now);
-      throw new UserActionableException("ID Token expired, please try your call again.");
+      throw new UserActionableException("ID Token expired, please try your command again.");
     }
     return idToken;
   }

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -66,7 +66,10 @@ public class SamService {
 
   /** Factory method for class that talks to SAM. Pulls the current server from the context. */
   public static SamService forUser(User user) {
-    return new SamService(user.getUserAccessToken(), Context.getServer());
+    Server server = Context.getServer();
+    AccessToken token =
+        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
+    return new SamService(token, Context.getServer());
   }
 
   /** Factory method for class that talks to SAM. Pulls the current server from the context. */

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -66,10 +66,7 @@ public class SamService {
 
   /** Factory method for class that talks to SAM. Pulls the current server from the context. */
   public static SamService forUser(User user) {
-    Server server = Context.getServer();
-    AccessToken token =
-        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
-    return new SamService(token, Context.getServer());
+    return new SamService(user.getTerraToken(), Context.getServer());
   }
 
   /** Factory method for class that talks to SAM. Pulls the current server from the context. */

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -2,6 +2,7 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
+import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
@@ -153,8 +154,11 @@ public class WorkspaceManagerService {
    * Factory method for class that talks to WSM. Pulls the current server and user from the context.
    */
   public static WorkspaceManagerService fromContext() {
-    return new WorkspaceManagerService(
-        Context.requireUser().getUserAccessToken(), Context.getServer());
+    Server server = Context.getServer();
+    User user = Context.requireUser();
+    AccessToken token =
+        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
+    return new WorkspaceManagerService(token, server);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -2,7 +2,6 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
-import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
@@ -154,11 +153,7 @@ public class WorkspaceManagerService {
    * Factory method for class that talks to WSM. Pulls the current server and user from the context.
    */
   public static WorkspaceManagerService fromContext() {
-    Server server = Context.getServer();
-    User user = Context.requireUser();
-    AccessToken token =
-        server.getIdTokenAuthentication() ? user.getUserIdToken() : user.getUserAccessToken();
-    return new WorkspaceManagerService(token, server);
+    return new WorkspaceManagerService(Context.requireUser().getTerraToken(), Context.getServer());
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/utils/TerraCredentials.java
+++ b/src/main/java/bio/terra/cli/service/utils/TerraCredentials.java
@@ -4,8 +4,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.IdToken;
 
 /**
- * Wrapper class to hold a user's credential to use when calling Terra API. Consists of a
- * GoogleCredential object containing access and refresh tokens and an IdToken object containing a
+ * Wrapper class to hold a user's credential to use when making Terra service API calls. Consists of
+ * a GoogleCredential object containing access and refresh tokens and an IdToken object containing a
  * JWT ID token.
  */
 public class TerraCredentials {

--- a/src/main/java/bio/terra/cli/service/utils/TerraCredentials.java
+++ b/src/main/java/bio/terra/cli/service/utils/TerraCredentials.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.service.utils;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdToken;
+
+/**
+ * Wrapper class to hold a user's credential to use when calling Terra API. Consists of a
+ * GoogleCredential object containing access and refresh tokens and an IdToken object containing a
+ * JWT ID token.
+ */
+public class TerraCredentials {
+  private final GoogleCredentials googleCredentials;
+  private final IdToken idToken;
+
+  public TerraCredentials(GoogleCredentials googleCredentials, IdToken idToken) {
+    if (googleCredentials == null || idToken == null) {
+      throw new NullPointerException("GoogleCredential and IdToken must both be non-null.");
+    }
+    this.googleCredentials = googleCredentials;
+    this.idToken = idToken;
+  }
+
+  public GoogleCredentials getGoogleCredentials() {
+    return googleCredentials;
+  }
+
+  public IdToken getIdToken() {
+    return idToken;
+  }
+}

--- a/src/main/resources/servers/verily-autopush.json
+++ b/src/main/resources/servers/verily-autopush.json
@@ -7,5 +7,5 @@
   "workspaceManagerUri": "https://terra-autopush-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
   "externalCredsUri": "https://terra-autopush-ecm.api.verily.com",
-  "idTokenAuthentication" : true
+  "supportsIdToken" : true
 }

--- a/src/main/resources/servers/verily-autopush.json
+++ b/src/main/resources/servers/verily-autopush.json
@@ -6,5 +6,6 @@
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-autopush-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
-  "externalCredsUri": "https://terra-autopush-ecm.api.verily.com"
+  "externalCredsUri": "https://terra-autopush-ecm.api.verily.com",
+  "idTokenAuthentication" : true
 }

--- a/src/main/resources/servers/verily-devel.json
+++ b/src/main/resources/servers/verily-devel.json
@@ -7,5 +7,5 @@
   "workspaceManagerUri": "https://terra-devel-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
   "externalCredsUri": "https://terra-devel-ecm.api.verily.com",
-  "idTokenAuthentication" : true
+  "supportsIdToken" : true
 }

--- a/src/main/resources/servers/verily-devel.json
+++ b/src/main/resources/servers/verily-devel.json
@@ -6,5 +6,6 @@
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-devel-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
-  "externalCredsUri": "https://terra-devel-ecm.api.verily.com"
+  "externalCredsUri": "https://terra-devel-ecm.api.verily.com",
+  "idTokenAuthentication" : true
 }

--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -7,5 +7,5 @@
   "workspaceManagerUri": "https://terra-preprod-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
   "externalCredsUri": "https://terra-preprod-ecm.api.verily.com",
-  "idTokenAuthentication" : true
+  "supportsIdToken" : true
 }

--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -6,5 +6,6 @@
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-preprod-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
-  "externalCredsUri": "https://terra-preprod-ecm.api.verily.com"
+  "externalCredsUri": "https://terra-preprod-ecm.api.verily.com",
+  "idTokenAuthentication" : true
 }

--- a/src/main/resources/servers/verily-staging.json
+++ b/src/main/resources/servers/verily-staging.json
@@ -7,5 +7,5 @@
   "workspaceManagerUri": "https://terra-staging-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
   "externalCredsUri": "https://terra-staging-ecm.api.verily.com",
-  "idTokenAuthentication" : true
+  "supportsIdToken" : true
 }

--- a/src/main/resources/servers/verily-staging.json
+++ b/src/main/resources/servers/verily-staging.json
@@ -6,5 +6,6 @@
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-staging-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
-  "externalCredsUri": "https://terra-staging-ecm.api.verily.com"
+  "externalCredsUri": "https://terra-staging-ecm.api.verily.com",
+  "idTokenAuthentication" : true
 }

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -6,5 +6,6 @@
   "samInviteRequiresAdmin": true,
   "workspaceManagerUri": "https://terra-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
-  "externalCredsUri": "https://terra-ecm.api.verily.com"
+  "externalCredsUri": "https://terra-ecm.api.verily.com",
+  "idTokenAuthentication" : true
 }

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -7,5 +7,5 @@
   "workspaceManagerUri": "https://terra-wsm.api.verily.com",
   "wsmDefaultSpendProfile": "wm-default-spend-profile",
   "externalCredsUri": "https://terra-ecm.api.verily.com",
-  "idTokenAuthentication" : true
+  "supportsIdToken" : true
 }

--- a/src/test/java/harness/TestUser.java
+++ b/src/test/java/harness/TestUser.java
@@ -86,8 +86,7 @@ public class TestUser {
     // get domain-wide delegated credentials for this user. use the same scopes that are requested
     // of CLI users when they login.
     GoogleCredentials googleCredentials = getCredentials(User.USER_SCOPES);
-    IdToken idToken = getIdToken(googleCredentials);
-    writeTerraOAuthCredentialFile(googleCredentials, idToken);
+    writeTerraOAuthCredentialFile(googleCredentials, getIdToken(googleCredentials));
 
     // We're not using pet SA key file (for security reasons), so auth is more complicated.
     writeAdcCredentialFiles();
@@ -180,11 +179,9 @@ public class TestUser {
               + ")");
     }
 
-    List<String> scopesWithCloudPlatform = new ArrayList<>(User.USER_SCOPES);
-    scopesWithCloudPlatform.add(CLOUD_PLATFORM_SCOPE);
     GoogleCredentials serviceAccountCredential =
         ServiceAccountCredentials.fromStream(new FileInputStream(jsonKey.toFile()))
-            .createScoped(scopesWithCloudPlatform);
+            .createScoped(scopes);
 
     // use the test-user SA to get a domain-wide delegated credential for the test user
     GoogleCredentials delegatedUserCredential = serviceAccountCredential.createDelegated(email);

--- a/src/test/java/unit/AuthLoginLogout.java
+++ b/src/test/java/unit/AuthLoginLogout.java
@@ -1,6 +1,7 @@
 package unit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.text.IsEmptyString.emptyOrNullString;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -40,7 +41,7 @@ public class AuthLoginLogout extends ClearContextUnit {
 
     // check that the credential exists in the store on disk
     DataStore<StoredCredential> credentialStore = TestUser.getCredentialStore();
-    assertEquals(2, credentialStore.keySet().size(), "credential store contains two entries");
+    assertThat("credential store contains two entries", credentialStore.keySet(), hasSize(2));
     assertTrue(
         credentialStore.containsKey(GoogleOauth.CREDENTIAL_STORE_KEY),
         "credential store contains hard-coded user key");

--- a/src/test/java/unit/AuthLoginLogout.java
+++ b/src/test/java/unit/AuthLoginLogout.java
@@ -13,6 +13,7 @@ import bio.terra.cli.service.GoogleOauth;
 import bio.terra.cli.service.SamService;
 import com.google.api.client.auth.oauth2.StoredCredential;
 import com.google.api.client.util.store.DataStore;
+import com.google.auth.oauth2.IdToken;
 import harness.TestCommand;
 import harness.TestUser;
 import harness.baseclasses.ClearContextUnit;
@@ -38,13 +39,25 @@ public class AuthLoginLogout extends ClearContextUnit {
     testUser.login();
 
     // check that the credential exists in the store on disk
-    DataStore<StoredCredential> dataStore = TestUser.getCredentialStore();
-    assertEquals(1, dataStore.keySet().size(), "credential store only contains one entry");
+    DataStore<StoredCredential> credentialStore = TestUser.getCredentialStore();
+    assertEquals(2, credentialStore.keySet().size(), "credential store contains two entries");
     assertTrue(
-        dataStore.containsKey(GoogleOauth.CREDENTIAL_STORE_KEY),
-        "credential store contains hard-coded single user key");
-    StoredCredential storedCredential = dataStore.get(GoogleOauth.CREDENTIAL_STORE_KEY);
+        credentialStore.containsKey(GoogleOauth.CREDENTIAL_STORE_KEY),
+        "credential store contains hard-coded user key");
+    assertTrue(
+        credentialStore.containsKey(GoogleOauth.ID_TOKEN_STORE_KEY),
+        "credential store contains  id token");
+    StoredCredential storedCredential = credentialStore.get(GoogleOauth.CREDENTIAL_STORE_KEY);
     assertThat(storedCredential.getAccessToken(), CoreMatchers.not(emptyOrNullString()));
+
+    DataStore<IdToken> idTokenStore = TestUser.getCredentialStore();
+    assertEquals(
+        idTokenStore.keySet(),
+        credentialStore.keySet(),
+        "credentialStore and idTokenStore are different views of same underlying datastore");
+    assertThat(
+        idTokenStore.get(GoogleOauth.ID_TOKEN_STORE_KEY).getTokenValue(),
+        CoreMatchers.not(emptyOrNullString()));
 
     // check that the current user in the global context = the test user
     Optional<User> currentUser = Context.getUser();

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -132,7 +132,7 @@ public class Workspace extends ClearContextUnit {
 
     // `terra workspace update --format=json --new-id=$newId --new-name=$newName
     // --new-description=$newDescription`
-    String newId = "newid";
+    String newId = "new-" + createdWorkspace.id;
     String newName = "NEW_statusDescribeListReflectUpdate";
     String newDescription = "NEW status describe list reflect update";
     TestCommand.runCommandExpectSuccess(


### PR DESCRIPTION
This PR adds the ability to optionally authenticate to Terra using JWT ID Tokens instead of opaque Access Tokens, configured at the `Server` level.

This PR also configures Verily `Server` definitions to enable ID Token authentication when calling Terra there.