### PR TITLE
When installing, don't clobber terra-cli/ directory

### DIFF
--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -32,7 +32,8 @@ if [ ! -f "${archiveFileName}" ]; then
 fi
 
 echo "--  Unarchiving release"
-archiveDir=$PWD/terra-cli
+archiveDir=$PWD/terra-cli-install
+rm -rf "$archiveDir"
 mkdir -p "$archiveDir"
 tar -C "$archiveDir" --strip-components=1 -xf $archiveFileName
 if [ ! -f "$archiveDir/install.sh" ]; then


### PR DESCRIPTION
Repro

```
cd ~
git clone git@github.com:DataBiosphere/terra-cli.git
cd ~
curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash && export SUPPRESS_GCLOUD_CREDS_WARNING=true
```
Now the git repo `~/terra-cli` no longer exists. This PR should fix that.