### PR TITLE
PF-1651: make all update parameters start with --new- (only workspace need here)

### DIFF
--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -21,13 +21,13 @@ public class Update extends BaseCommand {
 
   static class UpdateArgGroup {
     @CommandLine.Option(
-        names = "--name",
+        names = "--new-name",
         required = false,
         description = "Workspace name (not unique).")
     private String displayName;
 
     @CommandLine.Option(
-        names = "--description",
+        names = "--new-description",
         required = false,
         description = "Workspace description.")
     private String description;

--- a/src/test/java/unit/CloneWorkspace.java
+++ b/src/test/java/unit/CloneWorkspace.java
@@ -167,7 +167,7 @@ public class CloneWorkspace extends ClearContextUnit {
 
     // Update workspace name. This is for testing PF-1623.
     TestCommand.runAndParseCommandExpectSuccess(
-        UFWorkspace.class, "workspace", "update", "--name=update_Name");
+        UFWorkspace.class, "workspace", "update", "--new-name=update_Name");
 
     // Clone the workspace
     UFClonedWorkspace clonedWorkspace =

--- a/src/test/java/unit/CloneWorkspace.java
+++ b/src/test/java/unit/CloneWorkspace.java
@@ -167,7 +167,7 @@ public class CloneWorkspace extends ClearContextUnit {
 
     // Update workspace name. This is for testing PF-1623.
     TestCommand.runAndParseCommandExpectSuccess(
-        UFWorkspace.class, "workspace", "update", "--new-name=update_Name");
+        UFWorkspace.class, "workspace", "update", "--new-name=update_name");
 
     // Clone the workspace
     UFClonedWorkspace clonedWorkspace =

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -130,15 +130,15 @@ public class Workspace extends ClearContextUnit {
     assertNotNull(createdWorkspace.name, "create workspace name is defined");
     assertNotNull(createdWorkspace.description, "create workspace description is defined");
 
-    // `terra workspace update --format=json --name=$newName --description=$newDescription`
+    // `terra workspace update --format=json --new-name=$newName --new-description=$newDescription`
     String newName = "NEW_statusDescribeListReflectUpdate";
     String newDescription = "NEW status describe list reflect update";
     TestCommand.runCommandExpectSuccess(
         "workspace",
         "update",
         "--format=json",
-        "--name=" + newName,
-        "--description=" + newDescription);
+        "--new-name=" + newName,
+        "--new-description=" + newDescription);
 
     // `terra status --format=json`
     UFStatus status = TestCommand.runAndParseCommandExpectSuccess(UFStatus.class, "status");

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -381,8 +381,8 @@ public class WorkspaceOverride extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess(
         "workspace",
         "update",
-        "--name=" + newName,
-        "--description=" + newDescription,
+        "--new-name=" + newName,
+        "--new-description=" + newDescription,
         "--workspace=" + workspace3.id);
 
     // check that the workspace 3 description has been updated, and the workspace 1 has not

--- a/src/test/java/unit/WorkspaceOverride.java
+++ b/src/test/java/unit/WorkspaceOverride.java
@@ -435,8 +435,8 @@ public class WorkspaceOverride extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess(
         "workspace",
         "update",
-        "--name=" + newName,
-        "--description=" + newDescription,
+        "--new-name=" + newName,
+        "--new-description=" + newDescription,
         "--workspace=" + workspace3.id);
 
     // Check that current workspace status is updated, despite the --workspace flag.


### PR DESCRIPTION
Upon our cml. there are only `resource` and  `workspace` can be updated.
and resource (bq-dataset, bq-table, gcs-bucket, gcs-object, git-repo) are already added --new- in previous tickets.

So in this PR. I focus on add --new- only for `workspace` . it shows:
<img width="843" alt="Screen Shot 2022-05-20 at 3 09 12 PM" src="https://user-images.githubusercontent.com/100877272/169595856-42d7f346-4ecf-41ec-b948-7e063fb55261.png">

