### PR TITLE
[PF-1721] Fix Metadata command option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ out/
 ### Nextflow
 .nextflow
 .nextflow.log
+
+### Jenv directory-local version setting
+.java-version

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -64,10 +64,10 @@ public class GcpNotebook extends BaseCommand {
   private String postStartupScript;
 
   @CommandLine.Option(
-      names = "-M, --metadata",
+      names = {"--metadata", "-M"},
       description =
           "Custom metadata to apply to this instance.\n"
-              + "specify multiple metadata in the format of --metadata=key1=value1 --Mkey2=value2.\n"
+              + "specify multiple metadata in the format of --metadata=key1=value1 -Mkey2=value2.\n"
               + "By default set Terra CLI server terra-cli-server=[CLI_SERVER_ID]\n"
               + "and the Terra workspace id (terra-workspace-id=[WORKSPACE_ID]).")
   private Map<String, String> metadata;

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -39,7 +39,12 @@ public class GcpNotebookControlled extends SingleWorkspaceUnit {
     String name = "listDescribeReflectCreateDelete";
     UFGcpNotebook createdNotebook =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFGcpNotebook.class, "resource", "create", "gcp-notebook", "--name=" + name);
+            UFGcpNotebook.class,
+            "resource",
+            "create",
+            "gcp-notebook",
+            "--name=" + name,
+            "--metadata=foo=bar");
 
     // check that the name and notebook name match
     assertEquals(name, createdNotebook.name, "create output matches name");


### PR DESCRIPTION
Metadata option declaration was using a single string with comma-separated values. We need to use an array of separate strings for this to work.

Added a small test to make sure command is accepted; we can only see the metadata created in the Cloud Console AFAIK.

Also a small .gitignore entry for jenv local file.