### PR TITLE
[PF-1335] Add gradle test tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,10 @@ task runTestsWithTag(type: Test) {
             throw new GradleException("The testTag Gradle property is required (e.g. -PtestTag=unit, -PtestTag=integration)")
         }
 
+        // For Gradle Enterprise trial, we'd like to distinguish unit tests from
+        // integration tests in GE UI.
+        buildScan.tag testTag
+
         // tell junit to run tests with this tag: unit or integration
         useJUnitPlatform {
             includeTags testTag

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,8 @@
 dockerRepoPath = gcr.io/terra-cli-dev
 dockerImageName = terra-cli
 dockerImageTag = stable
+
+# Enabling configuration cache means enabling incremental build for Gradle
+# config (as opposed to application code). Eventually this will be enabled by
+# default, and this can be deleted.
+org.gradle.unsafe.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,3 @@
 dockerRepoPath = gcr.io/terra-cli-dev
 dockerImageName = terra-cli
 dockerImageTag = stable
-
-# Enabling configuration cache means enabling incremental build for Gradle
-# config (as opposed to application code). Eventually this will be enabled by
-# default, and this can be deleted.
-org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
For Gradle Enterprise trial, we'd like to see how much Test Distribution helps unit tests ([see here](https://gradle-enterprise-prod-helm-cluster.api.verily.com/scans/performance?search.timeZoneId=America/Los_Angeles)). We want a way to only look at unit tests in GE UI. (In GE UI, you can't search on system properties, only tags.)

@ghale