### PR TITLE
[PF-1757] Retry I/O errors from WSM and ECM clients

### DIFF
--- a/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
+++ b/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 
 public class ExternalCredentialsManagerService {
@@ -116,6 +117,12 @@ public class ExternalCredentialsManagerService {
    * @return true if the exception is retryable
    */
   private static boolean isRetryable(Exception ex) {
+    // Unlike Sam or WSM, the ECM client throws an entirely different exception for I/O errors,
+    // rather than pretending they have HTTP status code 0. Despite the name ResourceAccessException
+    // is thrown on low-level I/O errors and is unrelated to application layer access issues.
+    if (ex instanceof ResourceAccessException) {
+      return true;
+    }
     if (!(ex instanceof HttpStatusCodeException)) {
       return false;
     }

--- a/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
+++ b/src/main/java/bio/terra/cli/service/ExternalCredentialsManagerService.java
@@ -118,8 +118,9 @@ public class ExternalCredentialsManagerService {
    */
   private static boolean isRetryable(Exception ex) {
     // Unlike Sam or WSM, the ECM client throws an entirely different exception for I/O errors,
-    // rather than pretending they have HTTP status code 0. Despite the name ResourceAccessException
-    // is thrown on low-level I/O errors and is unrelated to application layer access issues.
+    // rather than pretending they have HTTP status code 0. Despite the name,
+    // ResourceAccessException is thrown on low-level I/O errors and is unrelated to application
+    // layer access issues.
     if (ex instanceof ResourceAccessException) {
       return true;
     }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -105,6 +105,9 @@ import bio.terra.workspace.model.WorkspaceStageModel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -1364,7 +1367,14 @@ public class WorkspaceManagerService {
     }
     logErrorMessage((ApiException) ex);
     int statusCode = ((ApiException) ex).getCode();
-    return statusCode == HttpStatus.SC_INTERNAL_SERVER_ERROR
+    // if a request to WSM times out, the client will wrap a SocketException in an ApiException,
+    // set the HTTP status code to 0, and rethrows it to the caller. Unfortunately this is a
+    // different exception than the SocketTimeoutException thrown by other client libraries.
+    final int TIMEOUT_STATUS_CODE = 0;
+    boolean isWsmTimeout = statusCode == TIMEOUT_STATUS_CODE && ex.getCause() instanceof SocketException;
+
+    return isWsmTimeout
+        || statusCode == HttpStatus.SC_INTERNAL_SERVER_ERROR
         || statusCode == HttpStatus.SC_BAD_GATEWAY
         || statusCode == HttpStatus.SC_SERVICE_UNAVAILABLE
         || statusCode == HttpStatus.SC_GATEWAY_TIMEOUT;

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -105,9 +105,7 @@ import bio.terra.workspace.model.WorkspaceStageModel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.auth.oauth2.AccessToken;
-import java.net.ConnectException;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -1371,7 +1369,8 @@ public class WorkspaceManagerService {
     // set the HTTP status code to 0, and rethrows it to the caller. Unfortunately this is a
     // different exception than the SocketTimeoutException thrown by other client libraries.
     final int TIMEOUT_STATUS_CODE = 0;
-    boolean isWsmTimeout = statusCode == TIMEOUT_STATUS_CODE && ex.getCause() instanceof SocketException;
+    boolean isWsmTimeout =
+        statusCode == TIMEOUT_STATUS_CODE && ex.getCause() instanceof SocketException;
 
     return isWsmTimeout
         || statusCode == HttpStatus.SC_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
We currently retry timeouts from Sam and GCP APIs, this change also adds retries for timeouts from WSM and ECM client libraries. Unfortunately each client library has its own patterns and exception classes, so the `isRetryable` methods can't be deduplicated very well.