### PR TITLE
Update JNA to 5.11.0 for M1 Macs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'net.java.dev.jna:jna:5.11.0'
     ext {
         // command parsing
         picocli = '4.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ repositories {
 }
 
 dependencies {
+    // Needed for Mac M1
     implementation 'net.java.dev.jna:jna:5.11.0'
     ext {
         // command parsing


### PR DESCRIPTION
With older JNA, we hit an UnsatisfiedLinkError: 
Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: $HOME/Library/Caches/JNA/temp/jna10560848527279309035.tmp
