### PR TITLE
[PF-1742] Add DATA_SOURCE resource

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@
     * [Terra and cloud services](#terra-and-cloud-services)
     * [Servers](#servers)
     * [Workspace IDs](#workspace-ids)
+    * [Adding a new resource type](#adding-a-new-resource-type)
 6. [Command style guide](#command-style-guide)
     * [Options instead of parameters](#options-instead-of-parameters)
     * [Always specify a description](#always-specify-a-description)
@@ -475,6 +476,10 @@ In WSM db, `workspace` table has 2 ID columns: `workspace_id` and `user_facing_i
 For simplicity, user only sees `user_facing_id`; for example in `terra workspace describe.`
 
 `uuid` does appear in `context.json` (and `.terra/logs/terra.log`). We need `uuid` because WSM APIs take `uuid`, not `userFacingId`. 
+
+#### Adding a new resource type
+
+See https://github.com/DataBiosphere/terra-cli/pull/276
 
 ### Command style guide
 Below are guidelines for adding or modifying commands. The goal is to have a consistent presentation across commands.

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
         // terra libraries
         crlPlatform = "0.2.0"
         samClient = "0.1-ffb0a89-SNAP"
-        workspaceManagerClient = "0.254.272-SNAPSHOT"
+        workspaceManagerClient = "0.254.283-SNAPSHOT"
         externalCredsClient = "0.82.0-SNAPSHOT"
         dataRepoClient = "1.0.155-SNAPSHOT"
         janitor = "0.113.5-SNAPSHOT"

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -2,6 +2,7 @@ package bio.terra.cli.businessobject;
 
 import bio.terra.cli.businessobject.resource.BqDataset;
 import bio.terra.cli.businessobject.resource.BqTable;
+import bio.terra.cli.businessobject.resource.DataSource;
 import bio.terra.cli.businessobject.resource.GcpNotebook;
 import bio.terra.cli.businessobject.resource.GcsBucket;
 import bio.terra.cli.businessobject.resource.GcsObject;
@@ -60,7 +61,9 @@ public abstract class Resource {
     BQ_DATASET,
     BQ_TABLE,
     AI_NOTEBOOK,
-    GIT_REPO;
+    GIT_REPO,
+    // Corresponds to WSM type TERRA_WORKSPACE
+    DATA_SOURCE;
   }
 
   /** Deserialize an instance of the disk format to the internal object. */
@@ -118,6 +121,8 @@ public abstract class Resource {
         return new GcpNotebook(wsmObject);
       case GIT_REPO:
         return new GitRepo(wsmObject);
+      case TERRA_WORKSPACE:
+        return new DataSource(wsmObject);
       default:
         throw new IllegalArgumentException("Unexpected resource type: " + wsmResourceType);
     }

--- a/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
@@ -1,0 +1,84 @@
+package bio.terra.cli.businessobject.resource;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Resource;
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.serialization.persisted.resource.PDDataSource;
+import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
+import bio.terra.cli.service.WorkspaceManagerService;
+import bio.terra.workspace.model.ResourceDescription;
+import bio.terra.workspace.model.TerraWorkspaceResource;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Internal representation of a data source referenced resource. Instances of this class are part of
+ * the current context or state.
+ */
+public class DataSource extends Resource {
+  private static final Logger logger = LoggerFactory.getLogger(DataSource.class);
+
+  private UUID dataSourceWorkspaceUuid;
+
+  /** Deserialize an instance of the disk format to the internal object. */
+  public DataSource(PDDataSource configFromDisk) {
+    super(configFromDisk);
+    this.dataSourceWorkspaceUuid = configFromDisk.dataSourceWorkspaceUuid;
+  }
+
+  /** Deserialize an instance of the WSM client library object to the internal object. */
+  public DataSource(ResourceDescription wsmObject) {
+    super(wsmObject.getMetadata());
+    this.resourceType = Type.DATA_SOURCE;
+    this.dataSourceWorkspaceUuid =
+        wsmObject.getResourceAttributes().getTerraWorkspace().getReferencedWorkspaceId();
+  }
+
+  /** Deserialize an instance of the WSM client library create object to the internal object. */
+  public DataSource(TerraWorkspaceResource wsmObject) {
+    super(wsmObject.getMetadata());
+    this.resourceType = Type.DATA_SOURCE;
+    this.dataSourceWorkspaceUuid = wsmObject.getAttributes().getReferencedWorkspaceId();
+  }
+
+  /**
+   * Serialize the internal representation of the resource to the format for command input/output.
+   */
+  public UFDataSource serializeToCommand() {
+    return new UFDataSource(this);
+  }
+
+  /** Serialize the internal representation of the resource to the format for writing to disk. */
+  public PDDataSource serializeToDisk() {
+    return new PDDataSource(this);
+  }
+
+  @Override
+  protected void deleteReferenced() {
+    WorkspaceManagerService.fromContext()
+        .deleteReferencedTerraWorkspace(Context.requireWorkspace().getUuid(), id);
+  }
+
+  @Override
+  protected void deleteControlled() {
+    logger.warn("Controlled data source resource is not supported");
+    throw new UnsupportedOperationException("Controlled data source resource is not supported");
+  }
+
+  /** Resolve data source. */
+  public String resolve() {
+    return "";
+  }
+
+  public Workspace getDataSourceWorkspace() {
+    return Workspace.get(dataSourceWorkspaceUuid);
+  }
+
+  // ====================================================
+  // Property getters.
+
+  public UUID getDataSourceWorkspaceUuid() {
+    return dataSourceWorkspaceUuid;
+  }
+}

--- a/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
@@ -19,7 +19,10 @@ import org.slf4j.LoggerFactory;
 public class DataSource extends Resource {
   private static final Logger logger = LoggerFactory.getLogger(DataSource.class);
 
-  private UUID dataSourceWorkspaceUuid;
+  public static final String SHORT_DESCRIPTION_KEY = "terra-short-description";
+  public static final String VERSION_KEY = "terra-version";
+
+  private final UUID dataSourceWorkspaceUuid;
 
   /** Deserialize an instance of the disk format to the internal object. */
   public DataSource(PDDataSource configFromDisk) {

--- a/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/DataSource.java
@@ -19,8 +19,8 @@ import org.slf4j.LoggerFactory;
 public class DataSource extends Resource {
   private static final Logger logger = LoggerFactory.getLogger(DataSource.class);
 
-  public static final String SHORT_DESCRIPTION_KEY = "terra-short-description";
-  public static final String VERSION_KEY = "terra-version";
+  public static final String SHORT_DESCRIPTION_KEY = "terra-workspace-short-description";
+  public static final String VERSION_KEY = "terra-workspace-version";
 
   private final UUID dataSourceWorkspaceUuid;
 
@@ -70,6 +70,7 @@ public class DataSource extends Resource {
   }
 
   /** Resolve data source. */
+  // TODO(PF-1743, PF-1744): Implement
   public String resolve() {
     return "";
   }

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
@@ -2,10 +2,10 @@ package bio.terra.cli.serialization.persisted;
 
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.workspace.model.Properties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -23,7 +23,7 @@ public class PDWorkspace {
   public final String name;
   public final String description;
   public final String googleProjectId;
-  public final Properties properties;
+  public final Map<String, String> properties;
   public final String serverName;
   public final String userEmail;
   public final List<PDResource> resources;
@@ -63,7 +63,7 @@ public class PDWorkspace {
     private String name;
     private String description;
     private String googleProjectId;
-    private Properties properties;
+    private Map<String, String> properties;
     private String serverName;
     private String userEmail;
     private List<PDResource> resources;
@@ -93,7 +93,7 @@ public class PDWorkspace {
       return this;
     }
 
-    public Builder properties(Properties properties) {
+    public Builder properties(Map<String, String> properties) {
       this.properties = properties;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/persisted/resource/PDDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/resource/PDDataSource.java
@@ -1,0 +1,54 @@
+package bio.terra.cli.serialization.persisted.resource;
+
+import bio.terra.cli.businessobject.resource.DataSource;
+import bio.terra.cli.serialization.persisted.PDResource;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.util.UUID;
+
+/**
+ * External representation of a reference to a data source.
+ *
+ * <p>This is a POJO class intended for serialization. This JSON format is not user-facing.
+ *
+ * <p>See the {@link DataSource} class for a data source's internal representation.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@JsonDeserialize(builder = PDDataSource.Builder.class)
+public class PDDataSource extends PDResource {
+  public final UUID dataSourceWorkspaceUuid;
+
+  public PDDataSource(DataSource internalObj) {
+    super(internalObj);
+    this.dataSourceWorkspaceUuid = internalObj.getDataSourceWorkspaceUuid();
+  }
+
+  private PDDataSource(PDDataSource.Builder builder) {
+    super(builder);
+    this.dataSourceWorkspaceUuid = builder.dataSourceWorkspaceUuid;
+  }
+
+  @Override
+  public DataSource deserializeToInternal() {
+    return new DataSource(this);
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class Builder extends PDResource.Builder {
+    private UUID dataSourceWorkspaceUuid;
+
+    public PDDataSource.Builder dataSourceWorkspaceUuid(UUID dataSourceWorkspaceUuid) {
+      this.dataSourceWorkspaceUuid = dataSourceWorkspaceUuid;
+      return this;
+    }
+
+    /** Call the private constructor. */
+    public PDDataSource build() {
+      return new PDDataSource(this);
+    }
+
+    /** Default constructor for Jackson. */
+    public Builder() {}
+  }
+}

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFResource.java
@@ -3,6 +3,7 @@ package bio.terra.cli.serialization.userfacing;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.cli.serialization.userfacing.resource.UFBqTable;
+import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
 import bio.terra.cli.serialization.userfacing.resource.UFGcpNotebook;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsObject;
@@ -40,6 +41,7 @@ import java.util.UUID;
   @Type(value = UFGcsBucket.class, name = "GCS_BUCKET"),
   @Type(value = UFGcsObject.class, name = "GCS_OBJECT"),
   @Type(value = UFGitRepo.class, name = "GIT_REPO"),
+  @Type(value = UFDataSource.class, name = "DATA_SOURCE"),
 })
 @JsonDeserialize(builder = UFResource.Builder.class)
 public abstract class UFResource {

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
@@ -2,10 +2,10 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.UserIO;
-import bio.terra.workspace.model.Properties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
+import java.util.Map;
 
 /**
  * External representation of a workspace for command input/output.
@@ -56,7 +56,7 @@ public class UFWorkspace extends UFWorkspaceLight {
     private String googleProjectId;
     private String serverName;
     private String userEmail;
-    private Properties properties;
+    private Map<String, String> properties;
     private long numResources;
 
     public Builder id(String id) {
@@ -79,7 +79,7 @@ public class UFWorkspace extends UFWorkspaceLight {
       return this;
     }
 
-    public Builder properties(Properties properties) {
+    public Builder properties(Map<String, String> properties) {
       this.properties = properties;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -2,10 +2,9 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.UserIO;
-import bio.terra.workspace.model.Properties;
-import bio.terra.workspace.model.Property;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
+import java.util.Map;
 
 public class UFWorkspaceLight {
   // "id" instead of "userFacingId" because user sees this with "terra workspace describe
@@ -14,7 +13,7 @@ public class UFWorkspaceLight {
   public String name;
   public String description;
   public String googleProjectId;
-  public Properties properties;
+  public Map<String, String> properties;
   public String serverName;
   public String userEmail;
 
@@ -66,9 +65,7 @@ public class UFWorkspaceLight {
     OUT.println("Description:       " + description);
     OUT.println("Google project:    " + googleProjectId);
     OUT.println("Properties:");
-    for (Property property : properties) {
-      OUT.println("  " + property.getKey() + ": " + property.getValue());
-    }
+    properties.forEach((key, value) -> OUT.println("  " + key + ": " + value));
     OUT.println(
         "Cloud console:     https://console.cloud.google.com/home/dashboard?project="
             + googleProjectId);
@@ -82,7 +79,7 @@ public class UFWorkspaceLight {
     private String name;
     private String description;
     private String googleProjectId;
-    private Properties properties;
+    private Map<String, String> properties;
     private String serverName;
     private String userEmail;
 
@@ -106,7 +103,7 @@ public class UFWorkspaceLight {
       return this;
     }
 
-    public UFWorkspaceLight.Builder properties(Properties properties) {
+    public UFWorkspaceLight.Builder properties(Map<String, String> properties) {
       this.properties = properties;
       return this;
     }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
@@ -24,7 +24,6 @@ public class UFDataSource extends UFResource {
   public final String title;
   public String shortDescription;
   public String version;
-  public final String description;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFDataSource(DataSource internalObj) {
@@ -35,7 +34,6 @@ public class UFDataSource extends UFResource {
     this.title = workspace.getName();
     this.shortDescription = workspace.getProperty(DataSource.SHORT_DESCRIPTION_KEY).orElse("");
     this.version = workspace.getProperty(DataSource.VERSION_KEY).orElse("");
-    this.description = workspace.getDescription();
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -45,7 +43,6 @@ public class UFDataSource extends UFResource {
     this.title = builder.title;
     this.shortDescription = builder.shortDescription;
     this.version = builder.version;
-    this.description = builder.description;
   }
 
   /** Print out this object in text format. */
@@ -60,7 +57,6 @@ public class UFDataSource extends UFResource {
     OUT.println(prefix + "Title:\t\t\t" + title);
     OUT.println(prefix + "Short description:\t" + shortDescription);
     OUT.println(prefix + "Version:\t\t" + version);
-    OUT.println(prefix + "Description:\t\t" + description);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -69,7 +65,6 @@ public class UFDataSource extends UFResource {
     private String title;
     private String shortDescription;
     private String version;
-    private String description;
 
     public Builder dataSourceWorkspaceUuid(UUID dataSourceWorkspaceUuid) {
       this.dataSourceWorkspaceUuid = dataSourceWorkspaceUuid;
@@ -88,11 +83,6 @@ public class UFDataSource extends UFResource {
 
     public Builder version(String version) {
       this.version = version;
-      return this;
-    }
-
-    public Builder description(String description) {
-      this.description = description;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
@@ -22,9 +22,9 @@ public class UFDataSource extends UFResource {
   // Fields from PF-1703
   // TODO(PF-1724): After PF-1738 is done, add Created On and Last Updated
   public final String title;
-  // public final String shortDescription;    Do after #269 is merged
+  public String shortDescription;
+  public String version;
   public final String description;
-  // public final String version;             Do after #269 is merged
 
   /** Serialize an instance of the internal class to the command format. */
   public UFDataSource(DataSource internalObj) {
@@ -33,6 +33,8 @@ public class UFDataSource extends UFResource {
 
     Workspace workspace = internalObj.getDataSourceWorkspace();
     this.title = workspace.getName();
+    this.shortDescription = workspace.getProperty(DataSource.SHORT_DESCRIPTION_KEY).orElse("");
+    this.version = workspace.getProperty(DataSource.VERSION_KEY).orElse("");
     this.description = workspace.getDescription();
   }
 
@@ -41,6 +43,8 @@ public class UFDataSource extends UFResource {
     super(builder);
     this.dataSourceWorkspaceUuid = builder.dataSourceWorkspaceUuid;
     this.title = builder.title;
+    this.shortDescription = builder.shortDescription;
+    this.version = builder.version;
     this.description = builder.description;
   }
 
@@ -51,17 +55,20 @@ public class UFDataSource extends UFResource {
     // - We don't want to print reference name; we want data source workspace name.
     // - Printing stewardship doesn't make sense for data sources.
     // - Etc
-
-    // Print the fields in PF-1703.
+    // Instead, print fields in PF-1703.
     PrintStream OUT = UserIO.getOut();
-    OUT.println(prefix + "Title:\t\t" + title);
-    OUT.println(prefix + "Description:\t" + description);
+    OUT.println(prefix + "Title:\t\t\t" + title);
+    OUT.println(prefix + "Short description:\t" + shortDescription);
+    OUT.println(prefix + "Version:\t\t" + version);
+    OUT.println(prefix + "Description:\t\t" + description);
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder extends UFResource.Builder {
     private UUID dataSourceWorkspaceUuid;
     private String title;
+    private String shortDescription;
+    private String version;
     private String description;
 
     public Builder dataSourceWorkspaceUuid(UUID dataSourceWorkspaceUuid) {
@@ -71,6 +78,16 @@ public class UFDataSource extends UFResource {
 
     public Builder title(String title) {
       this.title = title;
+      return this;
+    }
+
+    public Builder shortDescription(String shortDescription) {
+      this.shortDescription = shortDescription;
+      return this;
+    }
+
+    public Builder version(String version) {
+      this.version = version;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
@@ -1,0 +1,90 @@
+package bio.terra.cli.serialization.userfacing.resource;
+
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.businessobject.resource.DataSource;
+import bio.terra.cli.serialization.userfacing.UFResource;
+import bio.terra.cli.utils.UserIO;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.io.PrintStream;
+import java.util.UUID;
+
+/**
+ * External representation of a data source for command input/output.
+ *
+ * <p>This is a POJO class intended for serialization. This JSON format is user-facing.
+ *
+ * <p>See the {@link DataSource} class for internal representation.
+ */
+@JsonDeserialize(builder = UFDataSource.Builder.class)
+public class UFDataSource extends UFResource {
+  public final UUID dataSourceWorkspaceUuid;
+  // Fields from PF-1703
+  // TODO(PF-1724): After PF-1738 is done, add Created On and Last Updated
+  public final String title;
+  // public final String shortDescription;    Do after #269 is merged
+  public final String description;
+  // public final String version;             Do after #269 is merged
+
+  /** Serialize an instance of the internal class to the command format. */
+  public UFDataSource(DataSource internalObj) {
+    super(internalObj);
+    this.dataSourceWorkspaceUuid = internalObj.getDataSourceWorkspaceUuid();
+
+    Workspace workspace = internalObj.getDataSourceWorkspace();
+    this.title = workspace.getName();
+    this.description = workspace.getDescription();
+  }
+
+  /** Constructor for Jackson deserialization during testing. */
+  private UFDataSource(Builder builder) {
+    super(builder);
+    this.dataSourceWorkspaceUuid = builder.dataSourceWorkspaceUuid;
+    this.title = builder.title;
+    this.description = builder.description;
+  }
+
+  /** Print out this object in text format. */
+  @Override
+  public void print(String prefix) {
+    // Don't call super.print().
+    // - We don't want to print reference name; we want data source workspace name.
+    // - Printing stewardship doesn't make sense for data sources.
+    // - Etc
+
+    // Print the fields in PF-1703.
+    PrintStream OUT = UserIO.getOut();
+    OUT.println(prefix + "Title:\t\t" + title);
+    OUT.println(prefix + "Description:\t" + description);
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class Builder extends UFResource.Builder {
+    private UUID dataSourceWorkspaceUuid;
+    private String title;
+    private String description;
+
+    public Builder dataSourceWorkspaceUuid(UUID dataSourceWorkspaceUuid) {
+      this.dataSourceWorkspaceUuid = dataSourceWorkspaceUuid;
+      return this;
+    }
+
+    public Builder title(String title) {
+      this.title = title;
+      return this;
+    }
+
+    public Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    /** Call the private constructor. */
+    public UFDataSource build() {
+      return new UFDataSource(this);
+    }
+
+    /** Default constructor for Jackson. */
+    public Builder() {}
+  }
+}

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFGcpNotebook.java
@@ -63,7 +63,7 @@ public class UFGcpNotebook extends UFResource {
     PrintStream OUT = UserIO.getOut();
     OUT.println(prefix + "GCP project id:                " + projectId);
     OUT.println(prefix + "Location: " + (location == null ? "(undefined)" : location));
-    OUT.println(prefix + "Instance id:       " + instanceId);
+    OUT.println(prefix + "Instance id:   " + instanceId);
     OUT.println(prefix + "Instance name: " + (instanceName == null ? "(undefined)" : instanceName));
     OUT.println(prefix + "State:         " + (state == null ? "(undefined)" : state));
     OUT.println(prefix + "Metadata:");

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -2,6 +2,7 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
+import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.AddBqTableParams;
@@ -83,7 +84,6 @@ import bio.terra.workspace.model.JobControl;
 import bio.terra.workspace.model.JobReport;
 import bio.terra.workspace.model.JobReport.StatusEnum;
 import bio.terra.workspace.model.ManagedBy;
-import bio.terra.workspace.model.Properties;
 import bio.terra.workspace.model.ReferenceResourceCommonFields;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.ResourceList;
@@ -114,6 +114,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -223,7 +224,7 @@ public class WorkspaceManagerService {
       String userFacingId,
       @Nullable String name,
       @Nullable String description,
-      @Nullable Properties properties) {
+      @Nullable Map<String, String> properties) {
     return handleClientExceptions(
         () -> {
           // create the Terra workspace object
@@ -235,7 +236,7 @@ public class WorkspaceManagerService {
           workspaceRequestBody.setSpendProfile(Context.getServer().getWsmDefaultSpendProfile());
           workspaceRequestBody.setDisplayName(name);
           workspaceRequestBody.setDescription(description);
-          workspaceRequestBody.setProperties(properties);
+          workspaceRequestBody.setProperties(Workspace.stringMapToProperties(properties));
 
           // make the create workspace request
           WorkspaceApi workspaceApi = new WorkspaceApi(apiClient);

--- a/src/test/java/harness/utils/TestUtils.java
+++ b/src/test/java/harness/utils/TestUtils.java
@@ -1,0 +1,12 @@
+package harness.utils;
+
+import java.util.Random;
+
+public class TestUtils {
+  private static final Random RANDOM = new Random();
+
+  public static String appendRandomNumber(String string) {
+    // This might be used for BQ datasets, so can't have "-". (BQ dataset names can't have "-".)
+    return string + RANDOM.nextInt(10000);
+  }
+}

--- a/src/test/java/harness/utils/WorkspaceUtils.java
+++ b/src/test/java/harness/utils/WorkspaceUtils.java
@@ -41,7 +41,7 @@ public class WorkspaceUtils {
    *     the WSM workspaceDelete request.
    */
   public static UFWorkspace createWorkspace(
-      TestUser workspaceCreator, String name, String description, String property)
+      TestUser workspaceCreator, String name, String description, String properties)
       throws JsonProcessingException {
     // `terra workspace create --format=json --name=$name --description=$description`
     UFWorkspace workspace =
@@ -52,7 +52,7 @@ public class WorkspaceUtils {
             "--id=" + createUserFacingId(),
             "--name=" + name,
             "--description=" + description,
-            "--properties=" + property);
+            "--properties=" + properties);
     CRLJanitor.registerWorkspaceForCleanup(getUuidFromCurrentWorkspace(), workspaceCreator);
     return workspace;
   }

--- a/src/test/java/unit/DataSourceReferenced.java
+++ b/src/test/java/unit/DataSourceReferenced.java
@@ -25,7 +25,6 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
   private static final String thousandGenomesWorkspaceName = "1000 Genomes";
   private static final String thousandGenomesShortDescription = "short description";
   private static final String thousandGenomesVersion = "version";
-  private static final String thousandGenomesDescription = "description";
   private static final String thousandGenomesResourceName =
       TestUtils.appendRandomNumber("1000-genomes-ref");
   private UUID thousandGenomesUuid;
@@ -45,7 +44,7 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
             thousandGenomesVersion);
     UFWorkspace thousandGenomesWorkspace =
         WorkspaceUtils.createWorkspace(
-            workspaceCreator, thousandGenomesWorkspaceName, thousandGenomesDescription, properties);
+            workspaceCreator, thousandGenomesWorkspaceName, /*description=*/ "", properties);
 
     // Add 1000 Genomes data source to researcher workspace. We don't support add-ref for data
     // sources (see PF-1742), so call WSM directly.
@@ -106,6 +105,5 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
     assertEquals(thousandGenomesWorkspaceName, actual.title);
     assertEquals(thousandGenomesShortDescription, actual.shortDescription);
     assertEquals(thousandGenomesVersion, actual.version);
-    assertEquals(thousandGenomesDescription, actual.description);
   }
 }

--- a/src/test/java/unit/DataSourceReferenced.java
+++ b/src/test/java/unit/DataSourceReferenced.java
@@ -1,0 +1,94 @@
+package unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
+import bio.terra.cli.service.WorkspaceManagerService;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.MoreCollectors;
+import harness.TestCommand;
+import harness.baseclasses.SingleWorkspaceUnit;
+import harness.utils.TestUtils;
+import harness.utils.WorkspaceUtils;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/** Tests for the `terra resource` commands that handle data sources. */
+@Tag("unit")
+public class DataSourceReferenced extends SingleWorkspaceUnit {
+  private static final String thousandGenomesDataSourceWorkspaceName = "1000 Genomes";
+  private static final String thousandGenomesResourceName =
+      TestUtils.appendRandomNumber("1000-genomes-ref");
+  private UUID thousandGenomesUuid;
+
+  @BeforeAll
+  @Override
+  protected void setupOnce() throws Exception {
+    super.setupOnce();
+
+    // Set up 1000 Genomes data source workspace
+    UFWorkspace thousandGenomesWorkspace =
+        WorkspaceUtils.createWorkspace(
+            workspaceCreator, thousandGenomesDataSourceWorkspaceName, /*description=*/ "");
+
+    // Add 1000 Genomes data source to researcher workspace. This isn't supported by CLI, so call
+    // WSM directly.
+    UUID researcherWorkspaceUuid =
+        WorkspaceManagerService.fromContext().getWorkspaceByUserFacingId(getUserFacingId()).getId();
+    thousandGenomesUuid =
+        WorkspaceManagerService.fromContext()
+            .getWorkspaceByUserFacingId(thousandGenomesWorkspace.id)
+            .getId();
+    WorkspaceManagerService.fromContext()
+        .createReferencedTerraWorkspace(
+            researcherWorkspaceUuid, thousandGenomesUuid, thousandGenomesResourceName);
+    System.out.println("Created data source resource with name " + thousandGenomesResourceName);
+  }
+
+  @Test
+  void listDescribeDelete() throws IOException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
+
+    // `terra resource list --type=DATA_SOURCE`
+    List<UFDataSource> actualResources =
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "resource", "list", "--type=DATA_SOURCE");
+
+    // Assert resource list result
+    UFDataSource actualResource =
+        actualResources.stream()
+            .filter(resource -> resource.name.equals(thousandGenomesResourceName))
+            .collect(MoreCollectors.onlyElement());
+    // For some reason resourceType is null, so don't assert resourceType.
+    assertEquals(thousandGenomesUuid, actualResource.dataSourceWorkspaceUuid);
+    assertEquals(thousandGenomesDataSourceWorkspaceName, actualResource.title);
+
+    // `terra resource describe --name=$name`
+    actualResource =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFDataSource.class, "resource", "describe", "--name=" + thousandGenomesResourceName);
+
+    // Assert resource describe result
+    assertEquals(thousandGenomesUuid, actualResource.dataSourceWorkspaceUuid);
+    assertEquals(thousandGenomesDataSourceWorkspaceName, actualResource.title);
+
+    // `terra resource delete --name=$name`
+    TestCommand.runCommandExpectSuccess(
+        "resource", "delete", "--name=" + thousandGenomesResourceName, "--quiet");
+
+    // Assert resource was deleted
+    actualResources =
+        TestCommand.runAndParseCommandExpectSuccess(
+            new TypeReference<>() {}, "resource", "list", "--type=DATA_SOURCE");
+    actualResources.stream()
+        .noneMatch(resource -> resource.name.equals(thousandGenomesResourceName));
+  }
+}

--- a/src/test/java/unit/DataSourceReferenced.java
+++ b/src/test/java/unit/DataSourceReferenced.java
@@ -47,8 +47,8 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
         WorkspaceUtils.createWorkspace(
             workspaceCreator, thousandGenomesWorkspaceName, thousandGenomesDescription, properties);
 
-    // Add 1000 Genomes data source to researcher workspace. This isn't supported by CLI, so call
-    // WSM directly.
+    // Add 1000 Genomes data source to researcher workspace. We don't support add-ref for data
+    // sources (see PF-1742), so call WSM directly.
     UUID researcherWorkspaceUuid =
         WorkspaceManagerService.fromContext().getWorkspaceByUserFacingId(getUserFacingId()).getId();
     thousandGenomesUuid =

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cli.serialization.userfacing.UFStatus;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -124,16 +125,18 @@ public class Workspace extends ClearContextUnit {
 
     String name = "statusDescribeListReflectUpdate";
     String description = "status list reflect update";
-    String property = "key1=value1";
+    String key = "key";
+    String value = "value";
+    String property = key + "=" + value;
 
     UFWorkspace createdWorkspace =
         WorkspaceUtils.createWorkspace(testUser, name, description, property);
 
-    // check the created workspace name, description, properties are set
+    // check the created workspace name, description, property are set
     assertEquals(name, createdWorkspace.name);
     assertEquals(description, createdWorkspace.description);
-    assertEquals("key1", createdWorkspace.properties.get(0).getKey());
-    assertEquals("value1", createdWorkspace.properties.get(0).getValue());
+    assertTrue(createdWorkspace.properties.containsKey(key));
+    assertEquals(value, createdWorkspace.properties.get(key));
 
     // `terra workspace update --format=json --new-id=$newId --new-name=$newName
     // --new-description=$newDescription`


### PR DESCRIPTION
For `terra resource describe`, just print title/short description/version/description. Next PR will print data source resource details (eg GCS bucket).

I changed businessobject `Workspace` to store properties as `Map<String,String>` instead of `Properties`. Reason: I wanted to be able to easily get a property's value (see `Workspace.getProperty()`). For example, I wanted to look up a data source's version, which is stored in `terra-version` property.

```
~/terra-cli (mc/data-source-resource $): terra resource list
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION
1000-genomes-ref                DATA_SOURCE           REFERENCED            (unset)
hello_world                     AI_NOTEBOOK           CONTROLLED            (unset)
melchang_cli_preprod_tests_...  BQ_DATASET            CONTROLLED            (unset)
melchangbucketwithnounderscore  GCS_BUCKET            CONTROLLED            (unset)
resource-list-into-python-dict  AI_NOTEBOOK           CONTROLLED            (unset)
terra_cli_repo                  GIT_REPO              REFERENCED            (unset)
what-happens-if-bucket-does...  GCS_BUCKET            REFERENCED            (unset)
~/terra-cli (mc/data-source-resource $): terra resource list --format=json
[ {
  "id" : "3d084e8c-9af4-4b64-97a1-fbe138e00c7b",
  "name" : "1000-genomes-ref",
  "description" : "",
  "resourceType" : "DATA_SOURCE",
  "stewardshipType" : "REFERENCED",
  "cloningInstructions" : "COPY_NOTHING",
  "accessScope" : null,
  "managedBy" : null,
  "privateUserName" : null,
  "privateUserRoles" : null,
  "dataSourceWorkspaceUuid" : "abdf795a-0066-43a0-aaeb-dd0f1c40526b",
  "title" : "1000 Genomes Phase 3",
  "shortDescription" : "The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.",
  "version" : "Phase 3"
},
},
...
~/terra-cli (mc/data-source-resource $): terra resource describe --name=1000-genomes-ref
Title:			1000 Genomes Phase 3
Short description:	The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.
Version:		Phase 3
Description:
~/terra-cli (mc/data-source-resource $): terra resource describe --name=1000-genomes-ref --format=json
{
  "id" : "3d084e8c-9af4-4b64-97a1-fbe138e00c7b",
  "name" : "1000-genomes-ref",
  "description" : "",
  "resourceType" : "DATA_SOURCE",
  "stewardshipType" : "REFERENCED",
  "cloningInstructions" : "COPY_NOTHING",
  "accessScope" : null,
  "managedBy" : null,
  "privateUserName" : null,
  "privateUserRoles" : null,
  "dataSourceWorkspaceUuid" : "abdf795a-0066-43a0-aaeb-dd0f1c40526b",
  "title" : "1000 Genomes Phase 3",
  "shortDescription" : "The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.",
  "version" : "Phase 3"
}
~/terra-cli (mc/data-source-resource $): terra resource delete --name=1000-genomes-ref
Title:			1000 Genomes Phase 3
Short description:	The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.
Version:		Phase 3
Description:
Are you sure you want to delete (y/N)? y
Resource successfully deleted.
~/terra-cli (mc/data-source-resource $): terra resource list
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION
hello_world                     AI_NOTEBOOK           CONTROLLED            (unset)
melchang_cli_preprod_tests_...  BQ_DATASET            CONTROLLED            (unset)
melchangbucketwithnounderscore  GCS_BUCKET            CONTROLLED            (unset)
resource-list-into-python-dict  AI_NOTEBOOK           CONTROLLED            (unset)
terra_cli_repo                  GIT_REPO              REFERENCED            (unset)
what-happens-if-bucket-does...  GCS_BUCKET            REFERENCED            (unset)
```
`context.json`:
```
    "resources" : [ {
      "@class" : "bio.terra.cli.serialization.persisted.resource.PDDataSource",
      "id" : "62639f59-4cde-487a-b1ca-49b70d6a5d28",
      "name" : "1000-genomes",
      "description" : null,
      "resourceType" : "DATA_SOURCE",
      "stewardshipType" : "REFERENCED",
      "cloningInstructions" : "COPY_NOTHING",
      "accessScope" : null,
      "managedBy" : null,
      "privateUserName" : null,
      "privateUserRoles" : null,
      "dataSourceWorkspaceUuid" : "abdf795a-0066-43a0-aaeb-dd0f1c40526b"
    }
```