### PR TITLE
[PF-1742] Show data source resources in `terra resource describe`

### DIFF
--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -64,11 +64,15 @@ public class UFWorkspaceLight {
     OUT.println("Name:              " + name);
     OUT.println("Description:       " + description);
     OUT.println("Google project:    " + googleProjectId);
-    OUT.println("Properties:");
-    properties.forEach((key, value) -> OUT.println("  " + key + ": " + value));
     OUT.println(
         "Cloud console:     https://console.cloud.google.com/home/dashboard?project="
             + googleProjectId);
+
+    if (properties == null) {
+      return;
+    }
+    OUT.println("Properties:");
+    properties.forEach((key, value) -> OUT.println("  " + key + ": " + value));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
@@ -10,7 +10,6 @@ import bio.terra.cli.utils.UserIO;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
-import java.util.UUID;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFDataSource.java
@@ -1,5 +1,8 @@
 package bio.terra.cli.serialization.userfacing.resource;
 
+import bio.terra.cli.app.utils.tables.ColumnDefinition;
+import bio.terra.cli.app.utils.tables.TablePrinter;
+import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.businessobject.resource.DataSource;
 import bio.terra.cli.serialization.userfacing.UFResource;
@@ -8,6 +11,10 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
 import java.util.UUID;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * External representation of a data source for command input/output.
@@ -24,6 +31,7 @@ public class UFDataSource extends UFResource {
   public final String title;
   public String shortDescription;
   public String version;
+  public final List<UFResource> resources;
 
   /** Serialize an instance of the internal class to the command format. */
   public UFDataSource(DataSource internalObj) {
@@ -34,6 +42,10 @@ public class UFDataSource extends UFResource {
     this.title = workspace.getName();
     this.shortDescription = workspace.getProperty(DataSource.SHORT_DESCRIPTION_KEY).orElse("");
     this.version = workspace.getProperty(DataSource.VERSION_KEY).orElse("");
+    this.resources =
+        workspace.getResources().stream()
+            .map(Resource::serializeToCommand)
+            .collect(Collectors.toList());
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -43,6 +55,7 @@ public class UFDataSource extends UFResource {
     this.title = builder.title;
     this.shortDescription = builder.shortDescription;
     this.version = builder.version;
+    this.resources = builder.resources;
   }
 
   /** Print out this object in text format. */
@@ -57,6 +70,54 @@ public class UFDataSource extends UFResource {
     OUT.println(prefix + "Title:\t\t\t" + title);
     OUT.println(prefix + "Short description:\t" + shortDescription);
     OUT.println(prefix + "Version:\t\t" + version);
+
+    OUT.println(prefix + "Resources:");
+    TablePrinter<UFResource> printer = UFResourceColumns::values;
+    OUT.println(printer.print(resources));
+  }
+
+  /** Column information for data source resources in data source `resource describe` output */
+  private enum UFResourceColumns implements ColumnDefinition<UFResource> {
+    BLANK_COLUMN("", r -> " ", 22, Alignment.LEFT),
+    NAME("NAME", r -> r.name, 30, Alignment.LEFT),
+    RESOURCE_TYPE("RESOURCE TYPE", r -> r.resourceType.toString(), 20, Alignment.LEFT),
+    DESCRIPTION("DESCRIPTION", r -> r.description, 40, Alignment.LEFT);
+
+    private final String columnLabel;
+    private final Function<UFResource, String> valueExtractor;
+    private final int width;
+    private final Alignment alignment;
+
+    UFResourceColumns(
+        String columnLabel,
+        Function<UFResource, String> valueExtractor,
+        int width,
+        Alignment alignment) {
+      this.columnLabel = columnLabel;
+      this.valueExtractor = valueExtractor;
+      this.width = width;
+      this.alignment = alignment;
+    }
+
+    @Override
+    public String getLabel() {
+      return columnLabel;
+    }
+
+    @Override
+    public Function<UFResource, String> getValueExtractor() {
+      return valueExtractor;
+    }
+
+    @Override
+    public int getWidth() {
+      return width;
+    }
+
+    @Override
+    public Alignment getAlignment() {
+      return alignment;
+    }
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
@@ -65,6 +126,7 @@ public class UFDataSource extends UFResource {
     private String title;
     private String shortDescription;
     private String version;
+    private List<UFResource> resources;
 
     public Builder dataSourceWorkspaceUuid(UUID dataSourceWorkspaceUuid) {
       this.dataSourceWorkspaceUuid = dataSourceWorkspaceUuid;
@@ -83,6 +145,11 @@ public class UFDataSource extends UFResource {
 
     public Builder version(String version) {
       this.version = version;
+      return this;
+    }
+
+    public Builder resources(List<UFResource> resources) {
+      this.resources = resources;
       return this;
     }
 

--- a/src/test/java/unit/DataSourceReferenced.java
+++ b/src/test/java/unit/DataSourceReferenced.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import bio.terra.cli.businessobject.resource.DataSource;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
+import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
+import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.cli.service.WorkspaceManagerService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.MoreCollectors;
@@ -25,8 +27,13 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
   private static final String thousandGenomesWorkspaceName = "1000 Genomes";
   private static final String thousandGenomesShortDescription = "short description";
   private static final String thousandGenomesVersion = "version";
+  private static final String thousandGenomesBucketName = "bucket-name";
+  private static final String thousandGenomesBucketResourceName =
+      TestUtils.appendRandomNumber("bucket_resource_name");
+
   private static final String thousandGenomesResourceName =
       TestUtils.appendRandomNumber("1000-genomes-ref");
+
   private UUID thousandGenomesUuid;
 
   @BeforeAll
@@ -42,9 +49,18 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
             thousandGenomesShortDescription,
             DataSource.VERSION_KEY,
             thousandGenomesVersion);
-    UFWorkspace thousandGenomesWorkspace =
+    String thousandGenomesUfId =
         WorkspaceUtils.createWorkspace(
-            workspaceCreator, thousandGenomesWorkspaceName, /*description=*/ "", properties);
+                workspaceCreator, thousandGenomesWorkspaceName, /*description=*/ "", properties)
+            .id;
+    TestCommand.runAndParseCommandExpectSuccess(
+        UFGcsBucket.class,
+        "resource",
+        "add-ref",
+        "gcs-bucket",
+        "--name=" + thousandGenomesBucketResourceName,
+        "--bucket-name=" + thousandGenomesBucketName,
+        "--workspace=" + thousandGenomesUfId);
 
     // Add 1000 Genomes data source to researcher workspace. We don't support add-ref for data
     // sources (see PF-1742), so call WSM directly.
@@ -52,7 +68,7 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
         WorkspaceManagerService.fromContext().getWorkspaceByUserFacingId(getUserFacingId()).getId();
     thousandGenomesUuid =
         WorkspaceManagerService.fromContext()
-            .getWorkspaceByUserFacingId(thousandGenomesWorkspace.id)
+            .getWorkspaceByUserFacingId(thousandGenomesUfId)
             .getId();
     WorkspaceManagerService.fromContext()
         .createReferencedTerraWorkspace(
@@ -105,5 +121,9 @@ public class DataSourceReferenced extends SingleWorkspaceUnit {
     assertEquals(thousandGenomesWorkspaceName, actual.title);
     assertEquals(thousandGenomesShortDescription, actual.shortDescription);
     assertEquals(thousandGenomesVersion, actual.version);
+
+    UFGcsBucket actualBucket = (UFGcsBucket) actual.resources.get(0);
+    assertEquals(thousandGenomesBucketResourceName, actualBucket.name);
+    assertEquals(thousandGenomesBucketName, actualBucket.bucketName);
   }
 }

--- a/src/test/java/unit/DataSourceReferenced.java
+++ b/src/test/java/unit/DataSourceReferenced.java
@@ -3,8 +3,6 @@ package unit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.cli.businessobject.resource.DataSource;
-import bio.terra.cli.serialization.userfacing.UFWorkspace;
-import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
 import bio.terra.cli.serialization.userfacing.resource.UFDataSource;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
 import bio.terra.cli.service.WorkspaceManagerService;


### PR DESCRIPTION
```
~/terra-cli (mc/data-source-resource $): terra resource describe --name=1000-genomes
Title:			1000 Genomes Phase 3
Short description:	The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.
Version:		Phase 3
Resources:
                        NAME                  RESOURCE TYPE         DESCRIPTION
                        gcs-folder            GCS_OBJECT            (unset)
                        pedigree              BQ_TABLE              (unset)
                        phase-3-variants      BQ_TABLE              (unset)
                        sample_info           BQ_TABLE              (unset)
~/terra-cli (mc/data-source-resource $): terra resource describe --name=1000-genomes --format=json
{
  "id" : "62639f59-4cde-487a-b1ca-49b70d6a5d28",
  "name" : "1000-genomes",
  "description" : null,
  "resourceType" : "DATA_SOURCE",
  "stewardshipType" : "REFERENCED",
  "cloningInstructions" : "COPY_NOTHING",
  "accessScope" : null,
  "managedBy" : null,
  "privateUserName" : null,
  "privateUserRoles" : null,
  "dataSourceWorkspaceUuid" : "abdf795a-0066-43a0-aaeb-dd0f1c40526b",
  "title" : "1000 Genomes Phase 3",
  "shortDescription" : "The genomes of more than a thousand anonymous participants from a number of different ethnic groups were analyzed and made publicly available.",
  "version" : "Phase 3",
  "resources" : [ {
    "id" : "b3f8a480-14f5-4583-89f8-7cb8841c4f15",
    "name" : "gcs-folder",
    "description" : null,
    "resourceType" : "GCS_OBJECT",
    "stewardshipType" : "REFERENCED",
    "cloningInstructions" : "COPY_REFERENCE",
    "accessScope" : null,
    "managedBy" : null,
    "privateUserName" : null,
    "privateUserRoles" : null,
    "bucketName" : "genomics-public-data",
    "contentType" : null,
    "objectName" : "1000-genomes-phase-3",
    "isDirectory" : null,
    "size" : null,
    "timeStorageClassUpdated" : null
  }, {
    "id" : "4488d1c8-e544-41d0-abb3-28f17c01cef7",
    "name" : "pedigree",
    "description" : null,
    "resourceType" : "BQ_TABLE",
    "stewardshipType" : "REFERENCED",
    "cloningInstructions" : "COPY_REFERENCE",
    "accessScope" : null,
    "managedBy" : null,
    "privateUserName" : null,
    "privateUserRoles" : null,
    "projectId" : "bigquery-public-data",
    "datasetId" : "human_genome_variants",
    "dataTableId" : "1000_genomes_pedigree",
    "tableDescription" : "Source:\nhttp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20130606_sample_info/20130606_g1k.ped\n\nDescription:\nhttp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/working/20130606_sample_info/README_20130606_sample_info\n\nFor more information see https://cloud.google.com/genomics/docs/public-datasets/1000-genomes",
    "numRows" : 3501
  }, {
...
  } ]
}
```