### PR TITLE
[PF-1827] resolve return a json formatted string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ if (hasProperty('buildScan')) {
 }
 
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.208.0'
+version = '0.209.0'
 group = 'terra-cli'
 sourceCompatibility = JavaVersion.VERSION_11
 

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -67,11 +67,10 @@ public class Resolve extends BaseCommand {
   }
 
   private void printText(JSONObject object) {
-    Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
-    OUT.println(object.get(resource.getName()));
+    OUT.println(object.get(resourceNameOption.name));
   }
 
   private void printJson(JSONObject object) {
-    OUT.println(object.toString());
+    OUT.println(object);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -11,6 +11,7 @@ import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import org.json.JSONObject;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -60,6 +61,17 @@ public class Resolve extends BaseCommand {
       default:
         cloudId = resource.resolve();
     }
-    formatOption.printReturnValue(cloudId);
+    JSONObject object = new JSONObject();
+    object.put(resource.getName(), cloudId);
+    formatOption.printReturnValue(object, this::printText, this::printJson);
+  }
+
+  public void printText(JSONObject object) {
+    Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
+    OUT.println(object.get(resource.getName()));
+  }
+
+  public void printJson(JSONObject object) {
+    OUT.println(object.toString());
   }
 }

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -66,12 +66,12 @@ public class Resolve extends BaseCommand {
     formatOption.printReturnValue(object, this::printText, this::printJson);
   }
 
-  public void printText(JSONObject object) {
+  private void printText(JSONObject object) {
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
     OUT.println(object.get(resource.getName()));
   }
 
-  public void printJson(JSONObject object) {
+  private void printJson(JSONObject object) {
     OUT.println(object.toString());
   }
 }

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -112,6 +112,10 @@ public class TestCommand {
     return cmd.readObjectFromStdOut(objectType);
   }
 
+  /**
+   * Helper method to run a command, check its exit code is 0=success, and return the standard
+   * output. Adds `==format=json` to the argument list.
+   */
   public static String runAndGetStdoutExpectSuccess(String... args) {
     Result cmd = runCommand(addFormatJsonArg(args));
     assertEquals(0, cmd.exitCode, "exit code = success");

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -112,6 +112,12 @@ public class TestCommand {
     return cmd.readObjectFromStdOut(objectType);
   }
 
+  public static String runAndGetStdoutExpectSuccess(String... args) {
+    Result cmd = runCommand(addFormatJsonArg(args));
+    assertEquals(0, cmd.exitCode, "exit code = success");
+    return cmd.stdOut;
+  }
+
   /**
    * Helper method to run a command, check its exit code is 0=success, and read what's written to
    * standard out into a Java object. Adds `--format=json` to the argument list.

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.json.JSONObject;
 
 /**
  * Utility methods for executing commands and reading their outputs during testing. This class is
@@ -105,10 +106,21 @@ public class TestCommand {
    * Helper method to run a command, check its exit code is 0=success, and return {@link Result}.
    * Adds `==format=json` to the argument list.
    */
-  public static Result runAndGetResultExpectSuccess(String... args) {
+  private static Result runAndGetResultExpectSuccess(String... args) {
     Result cmd = runCommand(addFormatJsonArg(args));
     assertEquals(0, cmd.exitCode, "exit code = success");
     return cmd;
+  }
+
+  /**
+   * Helper method to run a command, check its exit code is 0=success, and return {@code
+   * Result.stdOut}. Adds `==format=json` to the argument list.
+   *
+   * <p>If the stdOut can be serialized to a Java class (e.g. UFGitRepo.class), use {@link
+   * TestCommand#runAndParseCommandExpectSuccess} instead.
+   */
+  public static JSONObject runAndGetJsonObjectExpectSuccess(String... args) {
+    return new JSONObject(runAndGetResultExpectSuccess(args).stdOut);
   }
 
   /**

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -102,24 +102,23 @@ public class TestCommand {
   }
 
   /**
+   * Helper method to run a command, check its exit code is 0=success, and return {@link Result}.
+   * Adds `==format=json` to the argument list.
+   */
+  public static Result runAndGetResultExpectSuccess(String... args) {
+    Result cmd = runCommand(addFormatJsonArg(args));
+    assertEquals(0, cmd.exitCode, "exit code = success");
+    return cmd;
+  }
+
+  /**
    * Helper method to run a command, check its exit code is 0=success, and read what's written to
    * standard out into a Java object. Adds `--format=json` to the argument list.
    */
   public static <T> T runAndParseCommandExpectSuccess(Class<T> objectType, String... args)
       throws JsonProcessingException {
-    Result cmd = runCommand(addFormatJsonArg(args));
-    assertEquals(0, cmd.exitCode, "exit code = success");
+    Result cmd = runAndGetResultExpectSuccess(args);
     return cmd.readObjectFromStdOut(objectType);
-  }
-
-  /**
-   * Helper method to run a command, check its exit code is 0=success, and return the standard
-   * output. Adds `==format=json` to the argument list.
-   */
-  public static String runAndGetStdoutExpectSuccess(String... args) {
-    Result cmd = runCommand(addFormatJsonArg(args));
-    assertEquals(0, cmd.exitCode, "exit code = success");
-    return cmd.stdOut;
   }
 
   /**
@@ -128,8 +127,7 @@ public class TestCommand {
    */
   public static <T> T runAndParseCommandExpectSuccess(TypeReference<T> objectType, String... args)
       throws JsonProcessingException {
-    Result cmd = runCommand(addFormatJsonArg(args));
-    assertEquals(0, cmd.exitCode, "exit code = success");
+    Result cmd = runAndGetResultExpectSuccess(args);
     return cmd.readObjectFromStdOut(objectType);
   }
 

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -165,7 +165,8 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         workspace.googleProjectId + "." + datasetId,
         resolved.get(name),
@@ -174,8 +175,9 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
+                .stdOut);
     assertEquals(
         workspace.googleProjectId,
         resolvedProjectIdOnly.get(name),
@@ -184,8 +186,9 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
+                .stdOut);
     assertEquals(
         datasetId,
         resolvedDatasetIdOnly.get(name),

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -162,30 +163,32 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         "resource", "create", "bq-dataset", "--name=" + name, "--dataset-id=" + datasetId);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         workspace.googleProjectId + "." + datasetId,
-        resolved,
+        resolved.get(name),
         "default resolve includes [project id].[dataset id]");
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
-    String resolvedProjectIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
+    JSONObject resolvedProjectIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
     assertEquals(
         workspace.googleProjectId,
-        resolvedProjectIdOnly,
+        resolvedProjectIdOnly.get(name),
         "resolve with option PROJECT_ID_ONLY only includes the project id");
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
-    String resolvedDatasetIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
+    JSONObject resolvedDatasetIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
     assertEquals(
         datasetId,
-        resolvedDatasetIdOnly,
+        resolvedDatasetIdOnly.get(name),
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
     // `terra resources delete --name=$name`

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -164,9 +164,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         workspace.googleProjectId + "." + datasetId,
         resolved.get(name),
@@ -174,10 +172,8 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
     assertEquals(
         workspace.googleProjectId,
         resolvedProjectIdOnly.get(name),
@@ -185,10 +181,8 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
     assertEquals(
         datasetId,
         resolvedDatasetIdOnly.get(name),

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -169,9 +169,7 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         ExternalBQDatasets.getDatasetFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId()),
@@ -180,10 +178,8 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
     assertEquals(
         externalDataset.getProjectId(),
         resolvedProjectIdOnly.get(name),
@@ -191,10 +187,8 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
     assertEquals(
         externalDataset.getDatasetId(),
         resolvedDatasetIdOnly.get(name),

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -170,7 +170,8 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         ExternalBQDatasets.getDatasetFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId()),
@@ -180,8 +181,9 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
+                .stdOut);
     assertEquals(
         externalDataset.getProjectId(),
         resolvedProjectIdOnly.get(name),
@@ -190,8 +192,9 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
+                .stdOut);
     assertEquals(
         externalDataset.getDatasetId(),
         resolvedDatasetIdOnly.get(name),

--- a/src/test/java/unit/BqDatasetReferenced.java
+++ b/src/test/java/unit/BqDatasetReferenced.java
@@ -17,6 +17,7 @@ import harness.utils.ExternalBQDatasets.IamMemberType;
 import java.io.IOException;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -167,31 +168,33 @@ public class BqDatasetReferenced extends SingleWorkspaceUnit {
         "--dataset-id=" + externalDataset.getDatasetId());
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         ExternalBQDatasets.getDatasetFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId()),
-        resolved,
+        resolved.get(name),
         "default resolve includes [project id].[dataset id]");
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
-    String resolvedProjectIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
+    JSONObject resolvedProjectIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
     assertEquals(
         externalDataset.getProjectId(),
-        resolvedProjectIdOnly,
+        resolvedProjectIdOnly.get(name),
         "resolve with option PROJECT_ID_ONLY only includes the project id");
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
-    String resolvedDatasetIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
+    JSONObject resolvedDatasetIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
     assertEquals(
         externalDataset.getDatasetId(),
-        resolvedDatasetIdOnly,
+        resolvedDatasetIdOnly.get(name),
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
     // `terra resource delete --name=$name`

--- a/src/test/java/unit/BqTableReferenced.java
+++ b/src/test/java/unit/BqTableReferenced.java
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -204,39 +205,42 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
         "--table-id=" + externalDataTableName);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         ExternalBQDatasets.getDataTableFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId(), externalDataTableName),
-        resolved,
+        resolved.get(name),
         "default resolve include full path");
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
-    String resolvedProjectIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
+    JSONObject resolvedProjectIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
     assertEquals(
         externalDataset.getProjectId(),
-        resolvedProjectIdOnly,
+        resolvedProjectIdOnly.get(name),
         "resolve with option PROJECT_ID_ONLY only includes the project id");
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
-    String resolvedDatasetIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
+    JSONObject resolvedDatasetIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
     assertEquals(
         externalDataset.getDatasetId(),
-        resolvedDatasetIdOnly,
+        resolvedDatasetIdOnly.get(name),
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
-    String resolveTableIdOnly =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY");
+    JSONObject resolveTableIdOnly =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY"));
     assertEquals(
         externalDataTableName,
-        resolveTableIdOnly,
+        resolveTableIdOnly.get(name),
         "resolve with option TABLE_ID_ONLY only includes the table id");
 
     // `terra resource delete --name=$name`

--- a/src/test/java/unit/BqTableReferenced.java
+++ b/src/test/java/unit/BqTableReferenced.java
@@ -207,7 +207,8 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         ExternalBQDatasets.getDataTableFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId(), externalDataTableName),
@@ -217,8 +218,9 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
+                .stdOut);
     assertEquals(
         externalDataset.getProjectId(),
         resolvedProjectIdOnly.get(name),
@@ -227,8 +229,9 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
+                .stdOut);
     assertEquals(
         externalDataset.getDatasetId(),
         resolvedDatasetIdOnly.get(name),
@@ -236,8 +239,9 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
 
     JSONObject resolveTableIdOnly =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY")
+                .stdOut);
     assertEquals(
         externalDataTableName,
         resolveTableIdOnly.get(name),

--- a/src/test/java/unit/BqTableReferenced.java
+++ b/src/test/java/unit/BqTableReferenced.java
@@ -206,9 +206,7 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         ExternalBQDatasets.getDataTableFullPath(
             externalDataset.getProjectId(), externalDataset.getDatasetId(), externalDataTableName),
@@ -217,10 +215,8 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=PROJECT_ID_ONLY --format=json`
     JSONObject resolvedProjectIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=PROJECT_ID_ONLY");
     assertEquals(
         externalDataset.getProjectId(),
         resolvedProjectIdOnly.get(name),
@@ -228,20 +224,16 @@ public class BqTableReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --bq-path=DATASET_ID_ONLY --format=json`
     JSONObject resolvedDatasetIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=DATASET_ID_ONLY");
     assertEquals(
         externalDataset.getDatasetId(),
         resolvedDatasetIdOnly.get(name),
         "resolve with option DATASET_ID_ONLY only includes the project id");
 
     JSONObject resolveTableIdOnly =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--bq-path=TABLE_ID_ONLY");
     assertEquals(
         externalDataTableName,
         resolveTableIdOnly.get(name),

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -116,9 +116,7 @@ public class GcpNotebookControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         createdNotebook.instanceName, resolved.get(name), "resolve returns the instance name");
 

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -114,10 +115,11 @@ public class GcpNotebookControlled extends SingleWorkspaceUnit {
             UFGcpNotebook.class, "resource", "create", "gcp-notebook", "--name=" + name);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
-    assertEquals(createdNotebook.instanceName, resolved, "resolve returns the instance name");
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+    assertEquals(
+        createdNotebook.instanceName, resolved.get(name), "resolve returns the instance name");
 
     // `terra resource check-access --name=$name`
     String stdErr =

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -117,7 +117,8 @@ public class GcpNotebookControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         createdNotebook.instanceName, resolved.get(name), "resolve returns the instance name");
 

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -149,7 +149,8 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         ExternalGCSBuckets.getGsPath(bucketName),
         resolved.get(name),
@@ -158,8 +159,9 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
     JSONObject resolvedExcludePrefix =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
+                .stdOut);
     assertEquals(
         bucketName,
         resolvedExcludePrefix.get(name),

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -148,9 +148,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         ExternalGCSBuckets.getGsPath(bucketName),
         resolved.get(name),
@@ -158,10 +156,8 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
     JSONObject resolvedExcludePrefix =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
     assertEquals(
         bucketName,
         resolvedExcludePrefix.get(name),

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -146,20 +147,23 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         "resource", "create", "gcs-bucket", "--name=" + name, "--bucket-name=" + bucketName);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         ExternalGCSBuckets.getGsPath(bucketName),
-        resolved,
+        resolved.get(name),
         "default resolve includes gs:// prefix");
 
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
-    String resolvedExcludePrefix =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
+    JSONObject resolvedExcludePrefix =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
     assertEquals(
-        bucketName, resolvedExcludePrefix, "exclude prefix resolve only includes bucket name");
+        bucketName,
+        resolvedExcludePrefix.get(name),
+        "exclude prefix resolve only includes bucket name");
 
     // `terra resources delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -167,7 +167,8 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalSharedBucket.getName()),
         resolved.get(name),
@@ -176,8 +177,9 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
     JSONObject resolvedExcludePrefix =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
+                .stdOut);
     assertEquals(
         externalSharedBucket.getName(),
         resolvedExcludePrefix.get(name),

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -17,6 +17,7 @@ import harness.utils.ExternalGCSBuckets;
 import java.io.IOException;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -164,21 +165,22 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
         "--bucket-name=" + externalSharedBucket.getName());
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalSharedBucket.getName()),
-        resolved,
+        resolved.get(name),
         "default resolve includes gs:// prefix");
 
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
-    String resolvedExcludePrefix =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
+    JSONObject resolvedExcludePrefix =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
     assertEquals(
         externalSharedBucket.getName(),
-        resolvedExcludePrefix,
+        resolvedExcludePrefix.get(name),
         "exclude prefix resolve only includes bucket name");
 
     // `terra resource delete --name=$name`

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -166,9 +166,7 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalSharedBucket.getName()),
         resolved.get(name),
@@ -176,10 +174,8 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --exclude-bucket-prefix --format=json`
     JSONObject resolvedExcludePrefix =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
     assertEquals(
         externalSharedBucket.getName(),
         resolvedExcludePrefix.get(name),

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -280,9 +280,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket.getName(), externalBucketBlobName),
         resolved.get(name),
@@ -290,10 +288,8 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json --exclude-bucket-prefix`
     JSONObject resolveExcludeBucketPrefix =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess(
-                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess(
+            "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
     assertEquals(
         externalBucket.getName() + "/" + externalBucketBlobName,
         resolveExcludeBucketPrefix.get(name),
@@ -499,9 +495,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     assertEquals(externalBucket.getName(), updatedBucketObject.bucketName);
 
     var resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + newName);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket.getName(), externalBucketBlobName2),
         resolved.get(newName),
@@ -519,9 +513,7 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     assertEquals(externalBucket2.getName(), updatedBucketObject.bucketName);
 
     var resolved2 =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + newName);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket2.getName(), externalBucketBlobName2),
         resolved2.get(newName),

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -498,12 +498,13 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     assertEquals(externalBucketBlobName2, updatedBucketObject.objectName);
     assertEquals(externalBucket.getName(), updatedBucketObject.bucketName);
 
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + newName);
+    var resolved =
+        new JSONObject(
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
+                .stdOut);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket.getName(), externalBucketBlobName2),
-        resolved,
+        resolved.get(newName),
         "resolve matches bucket object blob2 name");
 
     updatedBucketObject =
@@ -517,12 +518,13 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     assertEquals(externalBucketBlobName2, updatedBucketObject.objectName);
     assertEquals(externalBucket2.getName(), updatedBucketObject.bucketName);
 
-    String resolved2 =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + newName);
+    var resolved2 =
+        new JSONObject(
+            TestCommand.runAndParseCommandExpectSuccess(
+                String.class, "resource", "resolve", "--name=" + newName));
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket2.getName(), externalBucketBlobName2),
-        resolved2,
+        resolved2.get(newName),
         "resolve matches bucket2 bucket name");
   }
 

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -281,7 +281,8 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket.getName(), externalBucketBlobName),
         resolved.get(name),
@@ -290,8 +291,9 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json --exclude-bucket-prefix`
     JSONObject resolveExcludeBucketPrefix =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess(
-                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
+            TestCommand.runAndGetResultExpectSuccess(
+                    "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix")
+                .stdOut);
     assertEquals(
         externalBucket.getName() + "/" + externalBucketBlobName,
         resolveExcludeBucketPrefix.get(name),

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -520,8 +520,8 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
 
     var resolved2 =
         new JSONObject(
-            TestCommand.runAndParseCommandExpectSuccess(
-                String.class, "resource", "resolve", "--name=" + newName));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
+                .stdOut);
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket2.getName(), externalBucketBlobName2),
         resolved2.get(newName),

--- a/src/test/java/unit/GcsObjectReferenced.java
+++ b/src/test/java/unit/GcsObjectReferenced.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -278,21 +279,22 @@ public class GcsObjectReferenced extends SingleWorkspaceUnit {
         "--object-name=" + externalBucketBlobName);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
     assertEquals(
         ExternalGCSBuckets.getGsPath(externalBucket.getName(), externalBucketBlobName),
-        resolved,
+        resolved.get(name),
         "resolve matches bucket object name");
 
     // `terra resource resolve --name=$name --format=json --exclude-bucket-prefix`
-    String resolveExcludeBucketPrefix =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix");
+    JSONObject resolveExcludeBucketPrefix =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess(
+                "resource", "resolve", "--name=" + name, "--exclude-bucket-prefix"));
     assertEquals(
         externalBucket.getName() + "/" + externalBucketBlobName,
-        resolveExcludeBucketPrefix,
+        resolveExcludeBucketPrefix.get(name),
         "resolve matches bucket object name excluding the prefix");
 
     // `terra resource delete --name=$name`

--- a/src/test/java/unit/GitRepoReferenced.java
+++ b/src/test/java/unit/GitRepoReferenced.java
@@ -254,10 +254,11 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
             "--new-repo-url=" + GIT_REPO_HTTPS_URL);
     assertEquals(GIT_REPO_HTTPS_URL, updatedGitRepo.gitRepoUrl);
 
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + newName);
-    assertEquals(GIT_REPO_HTTPS_URL, resolved, "resolve matches https Git url");
+    var resolved =
+        new JSONObject(
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
+                .stdOut);
+    assertEquals(GIT_REPO_HTTPS_URL, resolved.get(newName), "resolve matches https Git url");
   }
 
   @Test

--- a/src/test/java/unit/GitRepoReferenced.java
+++ b/src/test/java/unit/GitRepoReferenced.java
@@ -96,9 +96,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + name);
     assertEquals(GIT_REPO_SSH_URL, resolved.get(name), "resolve matches git repo ssh url");
 
     // `terra resource delete --name=$name`
@@ -255,9 +253,7 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     assertEquals(GIT_REPO_HTTPS_URL, updatedGitRepo.gitRepoUrl);
 
     var resolved =
-        new JSONObject(
-            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + newName)
-                .stdOut);
+        TestCommand.runAndGetJsonObjectExpectSuccess("resource", "resolve", "--name=" + newName);
     assertEquals(GIT_REPO_HTTPS_URL, resolved.get(newName), "resolve matches https Git url");
   }
 

--- a/src/test/java/unit/GitRepoReferenced.java
+++ b/src/test/java/unit/GitRepoReferenced.java
@@ -97,7 +97,8 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
         new JSONObject(
-            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+            TestCommand.runAndGetResultExpectSuccess("resource", "resolve", "--name=" + name)
+                .stdOut);
     assertEquals(GIT_REPO_SSH_URL, resolved.get(name), "resolve matches git repo ssh url");
 
     // `terra resource delete --name=$name`

--- a/src/test/java/unit/GitRepoReferenced.java
+++ b/src/test/java/unit/GitRepoReferenced.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.hamcrest.CoreMatchers;
+import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -94,10 +95,10 @@ public class GitRepoReferenced extends SingleWorkspaceUnit {
         "--repo-url=" + GIT_REPO_SSH_URL);
 
     // `terra resource resolve --name=$name --format=json`
-    String resolved =
-        TestCommand.runAndParseCommandExpectSuccess(
-            String.class, "resource", "resolve", "--name=" + name);
-    assertEquals(GIT_REPO_SSH_URL, resolved, "resolve matches git repo ssh url");
+    JSONObject resolved =
+        new JSONObject(
+            TestCommand.runAndGetStdoutExpectSuccess("resource", "resolve", "--name=" + name));
+    assertEquals(GIT_REPO_SSH_URL, resolved.get(name), "resolve matches git repo ssh url");
 
     // `terra resource delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");


### PR DESCRIPTION
 terra resolve --name=foo_bucket --format=json
{"foo_bucket":"<project-id>/<bucket_name>"}

This command does not change by this PR: terra resolve --name=foo_bucket
project-id/bucket-name


in the following PR where i implement terra resolve --name=foo_datasource
it will be a JSONArray of JSONObjects
[
{"foo_bucket":"<project-id>/<bucket_name>"},
{"bar_dataset":"<path-to-dataset>"}
]