### PR TITLE
[PF-1513] Add gradle test retry plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -368,14 +368,12 @@ task getDockerImageTag {
 test {
     retry {
         // Max retries per test.
-        maxRetries = 2
+        maxRetries = 1
         // Max total test failures.
         // This is an estimate based on current failure rates, but if more than
         // 5 tests fail in a run it's likely a real source of failure and we
         // should stop retrying.
         maxFailures = 5
-        // TODO: until test flakiness is at a manageable level, accept flaky
-        //  tests as long as they pass once.
-        failOnPassedAfterRetry = false
+        failOnPassedAfterRetry = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -367,13 +367,17 @@ task getDockerImageTag {
 
 test {
     retry {
-        // Max retries per test.
-        maxRetries = 1
-        // Max total test failures.
-        // This is an estimate based on current failure rates, but if more than
-        // 5 tests fail in a run it's likely a real source of failure and we
-        // should stop retrying.
-        maxFailures = 5
+        // This is set automatically on Github Actions runners, and never set
+        // otherwise.
+        if (System.getenv().containsKey("CI")) {
+            // Max retries per test.
+            maxRetries = 1
+            // Max total test failures.
+            // This is an estimate based on current failure rates, but if more
+            // than 5 tests fail in a run it's likely a real source of failure
+            // and we should stop retrying.
+            maxFailures = 5
+        }
         failOnPassedAfterRetry = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     // use the wrong guava version, leading to runtime errors.
     // See also https://blog.gradle.org/guava
     id 'de.jjohannes.missing-metadata-guava' version '0.4'
+    id 'org.gradle.test-retry' version '1.4.0'
 }
 
 if (hasProperty('buildScan')) {
@@ -361,5 +362,20 @@ task getDockerImageName {
 task getDockerImageTag {
     doLast {
         println("${project.properties['dockerImageTag']}")
+    }
+}
+
+test {
+    retry {
+        // Max retries per test.
+        maxRetries = 2
+        // Max total test failures.
+        // This is an estimate based on current failure rates, but if more than
+        // 5 tests fail in a run it's likely a real source of failure and we
+        // should stop retrying.
+        maxFailures = 5
+        // TODO: until test flakiness is at a manageable level, accept flaky
+        //  tests as long as they pass once.
+        failOnPassedAfterRetry = false
     }
 }


### PR DESCRIPTION
Per gradle discussion, I'm adding this plugin to start tracking test flakes and automatically retry some. This plugin will retry failing tests up to twice, which should reduce the number of times we manually rerun tests on PRs.

This covers up test flakiness but doesn't fix it, if we want shorter PR/nightly tests we'll still need to actually fix the causes of failure. The flake data from this plugin should help, though.