### PR TITLE
[PF-1665] Poll destination workspace for clone workspace job ID

### DIFF
--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -427,7 +427,8 @@ public class WorkspaceManagerService {
                 HttpUtils.pollWithRetries(
                     () ->
                         workspaceApi.getCloneWorkspaceResult(
-                            workspaceId, initialResult.getJobReport().getId()),
+                            initialResult.getWorkspace().getDestinationWorkspaceId(),
+                            initialResult.getJobReport().getId()),
                     (result) -> isDone(result.getJobReport()),
                     WorkspaceManagerService::isRetryable,
                     CLONE_WORKSPACE_MAXIMUM_RETRIES,


### PR DESCRIPTION
In https://github.com/DataBiosphere/terra-workspace-manager/pull/710 WSM began validating that job IDs were inside the appropriate workspace for all calls getting job results. One quirk this uncovered was that for `cloneWorkspace` jobs, the job lives inside the destination workspace, not the source workspace. This is different behavior from cloneResource endpoints, which live inside the source workspace. The CLI has been calling this endpoint incorrectly the whole time, we just didn't notice because we did not check which workspace jobs lived in.

(This fixes the CloneWorkspace test which began failing with the WSM change. I'm still not exactly sure how the last night's tests passed after I merged the change yesterday afternoon)