### PR TITLE
[PF-1513] Move test retry config inside runTestsWithTag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,23 @@ task runTestsWithTag(type: Test) {
     dependsOn runInstallForTesting // run the install-for-testing.sh script before any tests
 
     outputs.upToDateWhen { false } // force tests to always be re-run
+
+    retry {
+        // This is set automatically on Github Actions runners, and never set
+        // otherwise.
+        if (System.getenv().containsKey("CI")) {
+            // Max retries per test.
+            maxRetries = 1
+            // Max total test failures.
+            // This is an estimate based on current failure rates, but if more
+            // than 5 tests fail in a run it's likely a real source of failure
+            // and we should stop retrying.
+            maxFailures = 5
+        }
+        maxRetries = 1
+        maxFailures = 5
+        failOnPassedAfterRetry = true
+    }
 }
 
 // cleanup workspaces owned by test users.
@@ -362,22 +379,5 @@ task getDockerImageName {
 task getDockerImageTag {
     doLast {
         println("${project.properties['dockerImageTag']}")
-    }
-}
-
-test {
-    retry {
-        // This is set automatically on Github Actions runners, and never set
-        // otherwise.
-        if (System.getenv().containsKey("CI")) {
-            // Max retries per test.
-            maxRetries = 1
-            // Max total test failures.
-            // This is an estimate based on current failure rates, but if more
-            // than 5 tests fail in a run it's likely a real source of failure
-            // and we should stop retrying.
-            maxFailures = 5
-        }
-        failOnPassedAfterRetry = true
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -243,8 +243,6 @@ task runTestsWithTag(type: Test) {
             // and we should stop retrying.
             maxFailures = 5
         }
-        maxRetries = 1
-        maxFailures = 5
         failOnPassedAfterRetry = true
     }
 }


### PR DESCRIPTION
I thought we could have the `retry` block inside the `test` task since `runTestsWithTask` has type `Test`, but it looks like we never actually retried tests.

Tested this locally, the new configuration will actually retry tests as expected.