### PR TITLE
Fix tool commands in local process mode

### DIFF
--- a/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
@@ -56,7 +56,8 @@ public class LocalProcessCommandRunner extends CommandRunner {
    */
   protected int runToolCommandImpl(String command, Map<String, String> envVars)
       throws PassthroughException {
-    if (System.getProperty(CommandRunner.IS_TEST).equals("true")) {
+    String isTestSystemProperty = System.getProperty(CommandRunner.IS_TEST);
+    if (isTestSystemProperty != null && isTestSystemProperty.equals("true")) {
       // For unit tests, set CLOUDSDK_AUTH_ACCESS_TOKEN. This is how to programmatically
       // authenticate as test user, without SA key file
       // (https://cloud.google.com/sdk/docs/authorizing).

--- a/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
@@ -56,8 +56,7 @@ public class LocalProcessCommandRunner extends CommandRunner {
    */
   protected int runToolCommandImpl(String command, Map<String, String> envVars)
       throws PassthroughException {
-    String isTestSystemProperty = System.getProperty(CommandRunner.IS_TEST);
-    if (isTestSystemProperty != null && isTestSystemProperty.equals("true")) {
+    if ("true".equals(System.getProperty(CommandRunner.IS_TEST))) {
       // For unit tests, set CLOUDSDK_AUTH_ACCESS_TOKEN. This is how to programmatically
       // authenticate as test user, without SA key file
       // (https://cloud.google.com/sdk/docs/authorizing).


### PR DESCRIPTION
In notebook post-startup script, `terra git clone --all` failed with:

```
2022-07-21 19:24:23.529 UTC [main] ERROR bio.terra.cli.command.Main - An unexpected error occurred in java.lang.NullPointerException: null
java.lang.NullPointerException: null
        at bio.terra.cli.app.LocalProcessCommandRunner.runToolCommandImpl(LocalProcessCommandRunner.java:59)
        at bio.terra.cli.app.CommandRunner.runToolCommand(CommandRunner.java:83)
        at bio.terra.cli.app.CommandRunner.runToolCommand(CommandRunner.java:50)
        at bio.terra.cli.command.app.passthrough.Git.cloneGitRepoResource(Git.java:76)
        at bio.terra.cli.command.app.passthrough.Git.lambda$executeImpl$1(Git.java:51)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:497)
        at bio.terra.cli.command.app.passthrough.Git.executeImpl(Git.java:51)
        at bio.terra.cli.command.app.passthrough.ToolCommand.execute(ToolCommand.java:46)
        at bio.terra.cli.command.shared.BaseCommand.call(BaseCommand.java:63)
        at bio.terra.cli.command.shared.BaseCommand.call(BaseCommand.java:26)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at bio.terra.cli.command.Main.runCommand(Main.java:99)
        at bio.terra.cli.command.Main.main(Main.java:118)
```

Before #282, we checked if system property was null:

```
if (System.getProperty(CommandRunner.IS_TEST) != null) {
```

After #282

```
if (System.getProperty(CommandRunner.IS_TEST).equals("true")) {
```

`System.getProperty(CommandRunner.IS_TEST)` returns null because property isn't set. Fix by adding null check.