### PR TITLE
[PF-1743] For `terra resolve` data collection, print table

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -132,7 +132,7 @@ public class Resolve extends BaseCommand {
 
   private enum ResolveColumns implements ColumnDefinition<Pair<String, String>> {
     NAME("NAME", Pair::getLeft, 40, Alignment.LEFT),
-    CLOUD_ID("CLOUD ID", Pair::getRight, 90, Alignment.LEFT);
+    CLOUD_ID("PATH", Pair::getRight, 90, Alignment.LEFT);
 
     private final String columnLabel;
     private final Function<Pair<String, String>, String> valueExtractor;

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -107,6 +107,7 @@ public class Resolve extends BaseCommand {
     if (resourceNamesToCloudIds.length() == 1) {
       String resourceName = (String) resourceNamesToCloudIds.keySet().iterator().next();
       OUT.println(resourceNamesToCloudIds.get(resourceName));
+      return;
     }
 
     // These are the resources for a data collection. Print table of resource name and cloud ID.


### PR DESCRIPTION
Before:

```
~/terra-workspace-manager (mc/pandas_gbq): terra resolve --name=1000-genomes
pedigree: bigquery-public-data.human_genome_variants.1000_genomes_pedigree
gcs-folder: gs://genomics-public-data/1000-genomes-phase-3
phase-3-variants: bigquery-public-data.human_genome_variants.1000_genomes_phase_3_variants_20150220
melissachang-terra-example-notebooks: git@github.com:melissachang/terra-example-notebooks.git
sample_info: bigquery-public-data.human_genome_variants.1000_genomes_sample_info
```

After:
```
~/terra-cli (mc/resolve): terra resolve --name=1000-genomes
NAME                                      PATH
pedigree                                  bigquery-public-data.human_genome_variants.1000_genomes_pedigree
gcs-folder                                gs://genomics-public-data/1000-genomes-phase-3
phase-3-variants                          bigquery-public-data.human_genome_variants.1000_genomes_phase_3_variants_20150220
melissachang-terra-example-notebooks      git@github.com:melissachang/terra-example-notebooks.git
sample_info                               bigquery-public-data.human_genome_variants.1000_genomes_sample_info
```