### PR TITLE
[PF-1842] Fix nightly test action logs

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -67,34 +67,34 @@ jobs:
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
           ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit
-      - name: Run integration tests against source code
-        id: run_integration_tests_against_source_code
-        if: always()
-        run: |
-          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-          mkdir -p ~/logs-integration-source
-          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
-      - name: Run integration tests against release
-        id: run_integration_tests_against_release
-        if: always()
-        run: |
-          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-          mkdir -p ~/logs-integration-release
-          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
+#      - name: Run integration tests against source code
+#        id: run_integration_tests_against_source_code
+#        if: always()
+#        run: |
+#          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
+#          mkdir -p ~/logs-integration-source
+#          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
+#      - name: Run integration tests against release
+#        id: run_integration_tests_against_release
+#        if: always()
+#        run: |
+#          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
+#          mkdir -p ~/logs-integration-release
+#          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
       - name: Compile logs and context files for all test runs
         id: compile_logs_and_context_files
         if: always()
         run: |
-          declare -a arr=("integration-source" "integration-release")
-          for i in "${arr[@]}"
-          do
-            echo "Compiling logs and context files for test run: $i"
-            mkdir -p ~/to-archive/$i
-            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
-            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
-          done
+#          declare -a arr=("integration-source" "integration-release")
+#          for i in "${arr[@]}"
+#          do
+#            echo "Compiling logs and context files for test run: $i"
+#            mkdir -p ~/to-archive/$i
+#            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
+#            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
+#          done
           # Unit tests write to worker-specific directories, extract those here
-          mkdir -p ~/to-archive/logs-unit
+          mkdir -p ~/to-archive/unit
           for N in `ls ~/logs-unit`
           do
             mkdir -p ~/to-archive/unit/$N/logs

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -85,13 +85,21 @@ jobs:
         id: compile_logs_and_context_files
         if: always()
         run: |
-          declare -a arr=("unit" "integration-source" "integration-release")
+          declare -a arr=("integration-source" "integration-release")
           for i in "${arr[@]}"
           do
             echo "Compiling logs and context files for test run: $i"
             mkdir -p ~/to-archive/$i
             cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
             cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
+          done
+          # Unit tests write to worker-specific directories, extract those here
+          mkdir -p ~/to-archive/logs-unit
+          for N in `ls ~/logs-unit`
+          do
+            mkdir -p ~/to-archive/unit/$N/logs
+            cp -R ~/logs-unit/$N/.terra/logs/ ~/to-archive/unit/$N/logs/
+            cp -R ~/logs-unit/$N/.terra/context.json ~/to-archive/unit/$N/context.json
           done
       - name: Archive logs and context file for all test runs
         id: archive_logs_and_context

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -67,32 +67,32 @@ jobs:
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
           ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit
-#      - name: Run integration tests against source code
-#        id: run_integration_tests_against_source_code
-#        if: always()
-#        run: |
-#          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-#          mkdir -p ~/logs-integration-source
-#          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
-#      - name: Run integration tests against release
-#        id: run_integration_tests_against_release
-#        if: always()
-#        run: |
-#          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-#          mkdir -p ~/logs-integration-release
-#          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
+      #      - name: Run integration tests against source code
+      #        id: run_integration_tests_against_source_code
+      #        if: always()
+      #        run: |
+      #          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
+      #          mkdir -p ~/logs-integration-source
+      #          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
+      #      - name: Run integration tests against release
+      #        id: run_integration_tests_against_release
+      #        if: always()
+      #        run: |
+      #          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
+      #          mkdir -p ~/logs-integration-release
+      #          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
       - name: Compile logs and context files for all test runs
         id: compile_logs_and_context_files
         if: always()
         run: |
-#          declare -a arr=("integration-source" "integration-release")
-#          for i in "${arr[@]}"
-#          do
-#            echo "Compiling logs and context files for test run: $i"
-#            mkdir -p ~/to-archive/$i
-#            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
-#            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
-#          done
+          #          declare -a arr=("integration-source" "integration-release")
+          #          for i in "${arr[@]}"
+          #          do
+          #            echo "Compiling logs and context files for test run: $i"
+          #            mkdir -p ~/to-archive/$i
+          #            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
+          #            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
+          #          done
           # Unit tests write to worker-specific directories, extract those here
           mkdir -p ~/to-archive/unit
           for N in `ls ~/logs-unit`

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -67,37 +67,37 @@ jobs:
           echo "Running unit tests for server: ${{ matrix.testServer }}"
           mkdir -p ~/logs-unit
           ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit
-      #      - name: Run integration tests against source code
-      #        id: run_integration_tests_against_source_code
-      #        if: always()
-      #        run: |
-      #          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
-      #          mkdir -p ~/logs-integration-source
-      #          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
-      #      - name: Run integration tests against release
-      #        id: run_integration_tests_against_release
-      #        if: always()
-      #        run: |
-      #          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
-      #          mkdir -p ~/logs-integration-release
-      #          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
+      - name: Run integration tests against source code
+        id: run_integration_tests_against_source_code
+        if: always()
+        run: |
+          echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
+          mkdir -p ~/logs-integration-source
+          ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
+      - name: Run integration tests against release
+        id: run_integration_tests_against_release
+        if: always()
+        run: |
+          echo "Running integration tests against release for server: ${{ matrix.testServer }}"
+          mkdir -p ~/logs-integration-release
+          ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
       - name: Compile logs and context files for all test runs
         id: compile_logs_and_context_files
         if: always()
         run: |
-          #          declare -a arr=("integration-source" "integration-release")
-          #          for i in "${arr[@]}"
-          #          do
-          #            echo "Compiling logs and context files for test run: $i"
-          #            mkdir -p ~/to-archive/$i
-          #            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
-          #            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
-          #          done
+          declare -a arr=("integration-source" "integration-release")
+          for i in "${arr[@]}"
+          do
+            echo "Compiling logs and context files for test run: $i"
+            mkdir -p ~/to-archive/$i
+            cp -R ~/logs-$i/.terra/logs/ ~/to-archive/$i/logs/
+            cp -R ~/logs-$i/.terra/context.json ~/to-archive/$i/context.json
+          done
           # Unit tests write to worker-specific directories, extract those here
           mkdir -p ~/to-archive/unit
           for N in `ls ~/logs-unit`
           do
-            mkdir -p ~/to-archive/unit/$N/logs
+            mkdir -p ~/to-archive/unit/$N
             cp -R ~/logs-unit/$N/.terra/logs/ ~/to-archive/unit/$N/logs/
             cp -R ~/logs-unit/$N/.terra/context.json ~/to-archive/unit/$N/context.json
           done

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -119,25 +119,23 @@ public class Context {
    */
   public static Path getContextDir() {
     // default to the user's home directory
-    String contextDir = System.getProperty("user.home");
+    Path contextPath = Paths.get(System.getProperty("user.home"));
     // if the override environment variable is set, use it instead
     String overrideDirName = System.getenv(CONTEXT_DIR_OVERRIDE_NAME);
     if (overrideDirName != null && !overrideDirName.isBlank()) {
-      contextDir = overrideDirName;
+      contextPath = Paths.get(overrideDirName);
     }
     // If this is a test, append the current runner's ID. This lets us run multiple tests in
     // parallel without clobbering context across runners.
     String isTest = System.getProperty(CommandRunner.IS_TEST);
     if (isTest != null && isTest.equals("true")) {
-      contextDir += System.getProperty("org.gradle.test.worker");
+      contextPath.resolve(System.getProperty("org.gradle.test.worker"));
     }
-
-    Path contextPath = Paths.get(contextDir).toAbsolutePath();
     // build.gradle test task makes contextDir. However, with test-runner specific directories,
     // this test is executed in a different place from where the test task mkdir was run. So need
     // to create directory for if Test Distribution is being used.
-    if (!contextPath.toFile().exists()) {
-      contextPath.toFile().mkdir();
+    if (!contextPath.toAbsolutePath().toFile().exists()) {
+      contextPath.toAbsolutePath().toFile().mkdir();
     }
 
     return contextPath.resolve(CONTEXT_DIRNAME).toAbsolutePath();

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -129,7 +129,7 @@ public class Context {
     // parallel without clobbering context across runners.
     String isTest = System.getProperty(CommandRunner.IS_TEST);
     if (isTest != null && isTest.equals("true")) {
-      contextPath.resolve(System.getProperty("org.gradle.test.worker"));
+      contextPath = contextPath.resolve(System.getProperty("org.gradle.test.worker"));
     }
     // build.gradle test task makes contextDir. However, with test-runner specific directories,
     // this test is executed in a different place from where the test task mkdir was run. So need


### PR DESCRIPTION
#282 began storing unit test logs in a different place, which broke the nightly test workflow's log uploading step. Additionally, it mis-handled the `CONTEXT_DIR_OVERRIDE_NAME` by combining filepaths via string concatenation, which caused problems depending on whether the provided value had a trailing `/`. Sorry about that!

Working nightly run from this branch: https://github.com/DataBiosphere/terra-cli/actions/runs/2721117397