### PR TITLE
Don't clone duplicate git repos

### DIFF
--- a/src/main/java/bio/terra/cli/app/utils/LocalProcessLauncher.java
+++ b/src/main/java/bio/terra/cli/app/utils/LocalProcessLauncher.java
@@ -82,7 +82,7 @@ public class LocalProcessLauncher {
 
       String line;
       while ((line = bufferedReader.readLine()) != null) {
-        toStream.print(line);
+        toStream.println(line);
         toStream.flush();
       }
     } catch (IOException ioEx) {


### PR DESCRIPTION
`terra git clone --all` gives this error for my devel workspace:


> /tmp: terra git clone --all
>Setting the gcloud project to the workspace projectUpdated property [core/project].Cloning into 'terra-example-notebooks'...Restoring the original gcloud project configuration: terra-vdevel-buoyant-plum-9341Updated property [core/project].Setting the gcloud project to the workspace projectUpdated property [core/project].fatal: destination path 'terra-example-notebooks' already exists and is not an empty directory.Git clone for git@github.com:melissachang/terra-example-notebooks.git failed

This was because a git repo was being cloned twice.

- My workspace had a git repo
- My workspace had a data collection which had the same git repo

I also fixed the tool output in local mode; newlines are now property being written. Now:

```
~/terra-cli (main): rm -rf terra-example-notebooks/ && terra git clone --all
Setting the gcloud project to the workspace project
Updated property [core/project].
Cloning into 'terra-example-notebooks'...
Restoring the original gcloud project configuration: terra-vdevel-buoyant-plum-9341
Updated property [core/project].
```