### PR TITLE
[PF-1750] Alllow dashes in resource name

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -154,7 +154,7 @@ public abstract class CommandRunner {
   }
 
   // Note: `foo-bar` and `foo_bar` will have the same env variable. PF-1907 will fix this.
-  private static final String convertToEnvironmentVariable(String string) {
+  public static final String convertToEnvironmentVariable(String string) {
     return "TERRA_" + string.replace("-", "_");
   }
 

--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -123,7 +123,8 @@ public abstract class CommandRunner {
         .forEach(
             resource -> {
               if (Resource.Type.DATA_COLLECTION != resource.getResourceType()) {
-                terraReferences.put("TERRA_" + resource.getName(), resource.resolve());
+                String envVariable = convertToEnvironmentVariable(resource.getName());
+                terraReferences.put(envVariable, resource.resolve());
               } else {
                 Workspace dataCollectionWorkspace = null;
                 try {
@@ -139,14 +140,22 @@ public abstract class CommandRunner {
                           // This should NEVER happen but check here to prevent endless resolve.
                           r -> Resource.Type.DATA_COLLECTION != r.getResourceType())
                       .forEach(
-                          r ->
-                              terraReferences.put(
-                                  "TERRA_" + resource.getName() + "_" + r.getName(), r.resolve()));
+                          r -> {
+                            String envVariable =
+                                convertToEnvironmentVariable(
+                                    resource.getName() + "_" + r.getName());
+                            terraReferences.put(envVariable, r.resolve());
+                          });
                 }
               }
             });
 
     return terraReferences;
+  }
+
+  // Note: `foo-bar` and `foo_bar` will have the same env variable. PF-1907 will fix this.
+  private static final String convertToEnvironmentVariable(String string) {
+    return "TERRA_" + string.replace("-", "_");
   }
 
   /**

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -23,6 +23,7 @@ import bio.terra.workspace.model.ResourceMetadata;
 import bio.terra.workspace.model.StewardshipType;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Internal representation of a workspace resource. This abstract class contains properties common
@@ -30,6 +31,10 @@ import java.util.regex.Pattern;
  * sub-classes are part of the current context or state.
  */
 public abstract class Resource {
+  // Copied from WSM
+  private static final Pattern RESOURCE_NAME_VALIDATION_PATTERN =
+      Pattern.compile("^[a-zA-Z0-9][-_a-zA-Z0-9]{0,1023}$");
+
   // all resources
   protected UUID id;
   protected String name;
@@ -135,21 +140,10 @@ public abstract class Resource {
   /** Serialize the internal representation of the resource to the format for writing to disk. */
   public abstract PDResource serializeToDisk();
 
-  /**
-   * Check if the name only contains alphanumeric and underscore characters.
-   *
-   * <p>When launching an app, either in a Docker container or a local process, we pass a map of all
-   * the resources in the workspace to their resolved cloud identifiers (e.g. TERRA_MYBUCKET ->
-   * gs://mybucket). This is the reason for this restriction at resource creation time.
-   *
-   * @param name string to check
-   * @throws UserActionableException if the string is not a valid environment variable name
-   */
-  protected static void validateEnvironmentVariableName(String name) {
-    if (Pattern.compile("[^a-zA-Z0-9_]").matcher(name).find()) {
+  protected static void validateResourceName(String name) {
+    if (StringUtils.isEmpty(name) || !RESOURCE_NAME_VALIDATION_PATTERN.matcher(name).matches())
       throw new UserActionableException(
-          "Resource name can contain only alphanumeric and underscore characters.");
-    }
+          "Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.");
   }
 
   /** Update the properties of this resource object that are common to all resource types. */

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
@@ -76,7 +76,7 @@ public class BqDataset extends Resource {
    * @return the resource that was added
    */
   public static BqDataset addReferenced(CreateBqDatasetParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     GcpBigQueryDatasetResource addedResource =
         WorkspaceManagerService.fromContext()
@@ -94,7 +94,7 @@ public class BqDataset extends Resource {
    * @return the resource that was created
    */
   public static BqDataset createControlled(CreateBqDatasetParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     // call WSM to create the resource
     GcpBigQueryDatasetResource createdResource =
@@ -110,7 +110,7 @@ public class BqDataset extends Resource {
   /** Update a BigQuery dataset referenced resource in the workspace. */
   public void updateReferenced(UpdateReferencedBqDatasetParams updateParams) {
     if (updateParams.resourceParams.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceParams.name);
+      validateResourceName(updateParams.resourceParams.name);
     }
     if (updateParams.projectId != null) {
       this.projectId = updateParams.projectId;
@@ -129,7 +129,7 @@ public class BqDataset extends Resource {
   /** Update a BigQuery dataset controlled resource in the workspace. */
   public void updateControlled(UpdateControlledBqDatasetParams updateParams) {
     if (updateParams.resourceFields.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceFields.name);
+      validateResourceName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
         .updateControlledBigQueryDataset(Context.requireWorkspace().getUuid(), id, updateParams);

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
@@ -70,7 +70,7 @@ public class BqTable extends Resource {
    * @return the resource that was added
    */
   public static BqTable addReferenced(AddBqTableParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     GcpBigQueryDataTableResource addedResource =
         WorkspaceManagerService.fromContext()
@@ -85,7 +85,7 @@ public class BqTable extends Resource {
   /** Update a BigQuery data table referenced resource in the workspace. */
   public void updateReferenced(UpdateReferencedBqTableParams updateParams) {
     if (updateParams.resourceParams.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceParams.name);
+      validateResourceName(updateParams.resourceParams.name);
     }
     if (updateParams.projectId != null) {
       this.projectId = updateParams.projectId;

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
@@ -77,7 +77,7 @@ public class GcpNotebook extends Resource {
    * @return the resource that was created
    */
   public static GcpNotebook createControlled(CreateGcpNotebookParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     // call WSM to create the resource
     GcpAiNotebookInstanceResource createdResource =
@@ -93,7 +93,7 @@ public class GcpNotebook extends Resource {
 
   public void updateControlled(UpdateControlledGcpNotebookParams updateParams) {
     if (updateParams.resourceFields.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceFields.name);
+      validateResourceName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
         .updateControlledGcpNotebook(Context.requireWorkspace().getUuid(), id, updateParams);

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
@@ -67,7 +67,7 @@ public class GcsBucket extends Resource {
    * @return the resource that was added
    */
   public static GcsBucket addReferenced(CreateGcsBucketParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     GcpGcsBucketResource addedResource =
         WorkspaceManagerService.fromContext()
@@ -85,7 +85,7 @@ public class GcsBucket extends Resource {
    * @return the resource that was created
    */
   public static GcsBucket createControlled(CreateGcsBucketParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     // call WSM to create the resource
     GcpGcsBucketResource createdResource =
@@ -101,7 +101,7 @@ public class GcsBucket extends Resource {
   /** Update a GCS bucket referenced resource in the workspace. */
   public void updateReferenced(UpdateReferencedGcsBucketParams updateParams) {
     if (updateParams.resourceParams.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceParams.name);
+      validateResourceName(updateParams.resourceParams.name);
     }
     if (updateParams.bucketName != null) {
       this.bucketName = updateParams.bucketName;
@@ -117,7 +117,7 @@ public class GcsBucket extends Resource {
   /** Update a GCS bucket controlled resource in the workspace. */
   public void updateControlled(UpdateControlledGcsBucketParams updateParams) {
     if (updateParams.resourceFields.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceFields.name);
+      validateResourceName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
         .updateControlledGcsBucket(Context.requireWorkspace().getUuid(), id, updateParams);

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
@@ -66,7 +66,7 @@ public class GcsObject extends Resource {
    * @return the resource that was added
    */
   public static GcsObject addReferenced(AddGcsObjectParams createParams) {
-    validateEnvironmentVariableName(createParams.resourceFields.name);
+    validateResourceName(createParams.resourceFields.name);
 
     GcpGcsObjectResource addedResource =
         WorkspaceManagerService.fromContext()
@@ -82,7 +82,7 @@ public class GcsObject extends Resource {
   public void updateReferenced(UpdateReferencedGcsObjectParams updateParams) {
     UpdateResourceParams resourceParams = updateParams.resourceFields;
     if (resourceParams.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceFields.name);
+      validateResourceName(updateParams.resourceFields.name);
     }
     WorkspaceManagerService.fromContext()
         .updateReferencedGcsObject(Context.requireWorkspace().getUuid(), id, updateParams);

--- a/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
@@ -59,7 +59,7 @@ public class GitRepo extends Resource {
    * @return the resource that was added
    */
   public static GitRepo addReferenced(AddGitRepoParams addGitRepoParams) {
-    validateEnvironmentVariableName(addGitRepoParams.resourceFields.name);
+    validateResourceName(addGitRepoParams.resourceFields.name);
 
     // call WSM to add the reference.
     GitRepoResource addedResource =
@@ -74,7 +74,7 @@ public class GitRepo extends Resource {
   /** Update a Git repo referenced resource in the workspace. */
   public void updateReferenced(UpdateReferencedGitRepoParams updateParams) {
     if (updateParams.resourceFields.name != null) {
-      validateEnvironmentVariableName(updateParams.resourceFields.name);
+      validateResourceName(updateParams.resourceFields.name);
     }
     if (updateParams.gitRepoUrl != null) {
       this.gitRepoUrl = updateParams.gitRepoUrl;

--- a/src/test/java/unit/DataCollectionReferenced.java
+++ b/src/test/java/unit/DataCollectionReferenced.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import bio.terra.cli.app.CommandRunner;
 import bio.terra.cli.businessobject.resource.DataCollection;
 import bio.terra.cli.serialization.userfacing.resource.UFDataCollection;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
@@ -242,21 +243,23 @@ public class DataCollectionReferenced extends SingleWorkspaceUnit {
   }
 
   private void assertDataCollectionResourcesEnv(String stdOut) {
+    String expectedBucketEnvVariable =
+        CommandRunner.convertToEnvironmentVariable(DATA_COLLECTION_RESOURCE_NAME)
+            + "_"
+            + DATA_COLLECTION_BUCKET_RESOURCE_NAME
+            + "="
+            + ExternalGCSBuckets.getGsPath(DATA_COLLECTION_BUCKET_NAME);
     assertTrue(
-        stdOut.contains(
-            "TERRA_"
-                + DATA_COLLECTION_RESOURCE_NAME
-                + "_"
-                + DATA_COLLECTION_BUCKET_RESOURCE_NAME
-                + "="
-                + ExternalGCSBuckets.getGsPath(DATA_COLLECTION_BUCKET_NAME)));
+        stdOut.contains(expectedBucketEnvVariable),
+        "Did not get expected bucket environment variable: " + expectedBucketEnvVariable);
+    String expectedGitRepoEnvVariable =
+        CommandRunner.convertToEnvironmentVariable(DATA_COLLECTION_RESOURCE_NAME)
+            + "_"
+            + DATA_COLLECTION_GIT_RESOURCE_NAME
+            + "="
+            + GIT_REPO_URL;
     assertTrue(
-        stdOut.contains(
-            "TERRA_"
-                + DATA_COLLECTION_RESOURCE_NAME
-                + "_"
-                + DATA_COLLECTION_GIT_RESOURCE_NAME
-                + "="
-                + GIT_REPO_URL));
+        stdOut.contains(expectedGitRepoEnvVariable),
+        "Did not get expected git repo environment variable: " + expectedGitRepoEnvVariable);
   }
 }

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -119,7 +119,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
     // `terra app execute echo \$TERRA_$name`
     TestCommand.Result cmd =
-        TestCommand.runCommand("app", "execute", "echo", "$TERRA_resource__Env__Vars");
+        TestCommand.runCommand("app", "execute", "echo", "$TERRA_resource_Env_Vars");
 
     // check that TERRA_$name = resolved bucket name
     assertThat(


### PR DESCRIPTION
WSM allows dashes:

https://cs.github.com/DataBiosphere/terra-workspace-manager/blob/4eabe67ee705645c85cb9f522e739fb8b8a77228/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java?q=resource_name#L103

CLI currently doesn't. Change CLI to match WSM.

Before:

```
~/terra-cli (mc/allow-dash): terra resource create gcp-notebook --post-startup-script=gs://melchangbucketwithnounderscore/post-startup.sh --name="resource-name-dash"
Invalid resource name specified. Name must be 1 to 1024 alphanumeric characters, underscores, and dashes and must not start with a dash or underscore.
```

After:

```
~/terra-cli (mc/allow-dash): terra resource create gcp-notebook --post-startup-script=gs://melchangbucketwithnounderscore/post-startup.sh --name="resource-name-dash"
Successfully added controlled GCP Notebook instance.
```

Also fix bug when resource name has dashes. Environment variables don't allow dashes.

Before:
- TERRA_ env variable wouldn't work because it has dash

After:
- TERRA_ env variable works, no longer has dash