### PR TITLE
Make `terra group list-users` table not so wide

### DIFF
--- a/src/main/java/bio/terra/cli/command/group/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/group/ListUsers.java
@@ -42,7 +42,7 @@ public class ListUsers extends BaseCommand {
 
   /** Column information for fields in `resource list` output */
   private enum UFGroupMemberColumns implements ColumnDefinition<UFGroupMember> {
-    EMAIL("EMAIL", g -> g.email, 40, LEFT),
+    EMAIL("EMAIL", g -> g.email, 50, LEFT),
     POLICIES("POLICIES", g -> g.policies.toString(), 15, LEFT);
 
     private final String columnLabel;

--- a/src/main/java/bio/terra/cli/command/group/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/group/ListUsers.java
@@ -42,7 +42,7 @@ public class ListUsers extends BaseCommand {
 
   /** Column information for fields in `resource list` output */
   private enum UFGroupMemberColumns implements ColumnDefinition<UFGroupMember> {
-    EMAIL("EMAIL", g -> g.email, 30, LEFT),
+    EMAIL("EMAIL", g -> g.email, 40, LEFT),
     POLICIES("POLICIES", g -> g.policies.toString(), 15, LEFT);
 
     private final String columnLabel;

--- a/src/main/java/bio/terra/cli/command/group/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/group/ListUsers.java
@@ -42,7 +42,7 @@ public class ListUsers extends BaseCommand {
 
   /** Column information for fields in `resource list` output */
   private enum UFGroupMemberColumns implements ColumnDefinition<UFGroupMember> {
-    EMAIL("EMAIL", g -> g.email, 85, LEFT),
+    EMAIL("EMAIL", g -> g.email, 30, LEFT),
     POLICIES("POLICIES", g -> g.policies.toString(), 15, LEFT);
 
     private final String columnLabel;


### PR DESCRIPTION
Before:

```
~/terra-cli (mc/group-list-users $): terra group list-users --name=developer-admins-devel
EMAIL                                                                                  POLICIES
XXXXX@google.com                                                                       [ADMIN]
XXXXXXXXXXX@google.com                                                                 [ADMIN]
XXXXX@google.com                                                                       [ADMIN]
```

After:
```
~/terra-cli (mc/group-list-users $): terra group list-users --name=developer-admins-devel
EMAIL                           POLICIES
XXXXX@google.com                [ADMIN]
XXXXXXXXXXX@google.com          [ADMIN]
XXXXX@google.com                [ADMIN]

```