### PR TITLE
[PF-1731] Replace Java setup action

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -21,9 +21,10 @@ jobs:
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
       - name: Set up AdoptOpenJDK 11
         id: setup_jdk
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         id: cache_gradle
         uses: actions/cache@v2

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -19,9 +19,10 @@ jobs:
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
       - name: Set up AdoptOpenJDK 11
         id: setup_jdk
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         id: cache_gradle
         uses: actions/cache@v2

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -41,9 +41,10 @@ jobs:
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
       - name: Set up AdoptOpenJDK 11
         id: setup_jdk
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: 'temurin'
       - name: Cache Gradle packages
         id: cache_gradle
         uses: actions/cache@v2


### PR DESCRIPTION
The `joschi/setup-jdk@v2` Github action is deprecated and the recommendation is to move to the official github setup-java action with the `temurin` distribution: see https://github.com/joschi/setup-jdk#-notice