### PR TITLE
[PF-1660] Add a new server for wsmtest

### DIFF
--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -7,6 +7,7 @@
   "broad-dev-mmedlock.json",
   "broad-dev-wchamber.json",
   "broad-dev-zloery.json",
+  "broad-wsmtest.json",
   "verily.json",
   "verily-autopush.json",
   "verily-devel.json",

--- a/src/main/resources/servers/broad-wsmtest.json
+++ b/src/main/resources/servers/broad-wsmtest.json
@@ -1,0 +1,9 @@
+{
+  "name": "broad-wsmtest",
+  "description": "Broad WSM test server and Broad development environment for other services.",
+  "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",
+  "samUri": "https://sam.dsde-dev.broadinstitute.org",
+  "workspaceManagerUri": "https://workspace.wsmtest.integ.envs.broadinstitute.org",
+  "wsmDefaultSpendProfile": "wm-default-spend-profile",
+  "externalCredsUri": "https://externalcreds.dsde-dev.broadinstitute.org"
+}


### PR DESCRIPTION
To run post-startup script test in wsm nightly, we need to have the cli to be able to point to the wsmtest server. 