### PR TITLE
fix the autoname bucket name bug

### DIFF
--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -134,7 +134,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName`
-    String name = "listDescribeReflectCreate";
+    String name = "GcsBucketWithoutSpecifyingBucketName";
     UFGcsBucket createdBucket =
         TestCommand.runAndParseCommandExpectSuccess(
             UFGcsBucket.class, "resource", "create", "gcs-bucket", "--name=" + name);
@@ -143,7 +143,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
     assertEquals(name, createdBucket.name, "create output matches name");
     String bucketName = createdBucket.bucketName;
     assertNotNull(bucketName, "a random bucket name is generated");
-    assertTrue(bucketName.contains("bucket"));
+    assertTrue(bucketName.contains(name.toLowerCase()));
 
     // check that the bucket is in the list
     UFGcsBucket matchedResource = listOneBucketResourceWithName(name);


### PR DESCRIPTION
This ticket solves 2 issues after the PF-1750 auto-generation cloud-native id.
Both changes in the unit test GcsBucketControlled.java. 
-  the generated bucket name is not contain "bucket". It contains the originalName.toLowerCase(). (the original name does not have any character, so only to lower case is enough)
- we do not allow the same bucket name in the same workspace. I changed the bucket name is unique. (feel a little confused each unit test, the resource will be delete in the end, it could not have same bucket name, maybe rerun the whole unit test can solve, I still change the name unique in order to be clear with each unit test with their individual specified bucket name.)