### PR TITLE
Increase polling time for deleting GCS bucket

### DIFF
--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -1440,7 +1440,9 @@ public class WorkspaceManagerService {
               HttpUtils.pollWithRetries(
                   () -> controlledGcpResourceApi.getDeleteBucketResult(workspaceId, asyncJobId),
                   (result) -> isDone(result.getJobReport()),
-                  WorkspaceManagerService::isRetryable);
+                  WorkspaceManagerService::isRetryable,
+                  /*maxCalls=*/ 12,
+                  /*sleepDuration=*/ Duration.ofSeconds(5));
           logger.debug("delete controlled gcs bucket result: {}", deleteResult);
 
           throwIfJobNotCompleted(deleteResult.getJobReport(), deleteResult.getErrorReport());


### PR DESCRIPTION
Flaky failure: https://github.com/verily-src/terra-tool-cli/runs/8211018493?check_suite_focus=true

GCS bucket deletiong flight took 43 seconds to complete. By default, we poll for 15 seconds. Increase polling time to 1 minute.