### PR TITLE
For cloud context creation, retry for 3 mins instead of 2 mins

### DIFF
--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -128,11 +128,6 @@ import org.slf4j.LoggerFactory;
 public class WorkspaceManagerService {
 
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceManagerService.class);
-  private static final int CLONE_WORKSPACE_MAXIMUM_RETRIES = 360;
-  private static final Duration CLONE_WORKSPACE_RETRY_INTERVAL = Duration.ofSeconds(10);
-  // the maximum number of retries and time to sleep for creating a new workspace
-  private static final int CREATE_WORKSPACE_MAXIMUM_RETRIES = 120;
-  private static final Duration CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY = Duration.ofSeconds(1);
   // maximum number of resources to fetch per call to the enumerate endpoint
   private static final int MAX_RESOURCES_PER_ENUMERATE_REQUEST = 100;
   // the Terra environment where the WSM service lives
@@ -464,8 +459,9 @@ public class WorkspaceManagerService {
                   () -> workspaceApi.getCreateCloudContextResult(workspaceId, jobId.toString()),
                   (result) -> isDone(result.getJobReport()),
                   WorkspaceManagerService::isRetryable,
-                  CREATE_WORKSPACE_MAXIMUM_RETRIES,
-                  CREATE_WORKSPACE_DURATION_SLEEP_FOR_RETRY);
+                  // I've observed a flight taking 2 mins 28 sec. So retry for 3 mins.
+                  /*maxCalls=*/ 36,
+                  /*sleepDuration=*/ 5);
           logger.debug("create workspace context result: {}", createContextResult);
           StatusEnum status = createContextResult.getJobReport().getStatus();
           if (StatusEnum.FAILED == status) {
@@ -656,8 +652,9 @@ public class WorkspaceManagerService {
                             initialResult.getJobReport().getId()),
                     (result) -> isDone(result.getJobReport()),
                     WorkspaceManagerService::isRetryable,
-                    CLONE_WORKSPACE_MAXIMUM_RETRIES,
-                    CLONE_WORKSPACE_RETRY_INTERVAL),
+                    // Retry for 5 minutes
+                    /*maxCalls=*/ 60,
+                    /*sleepDuration=*/ Duration.ofSeconds(5)),
             "Error in cloning workspace.");
     logger.debug("clone workspace polling result: {}", cloneWorkspaceResult);
     throwIfJobNotCompleted(

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -461,7 +461,7 @@ public class WorkspaceManagerService {
                   WorkspaceManagerService::isRetryable,
                   // I've observed a flight taking 2 mins 28 sec. So retry for 3 mins.
                   /*maxCalls=*/ 36,
-                  /*sleepDuration=*/ 5);
+                  /*sleepDuration=*/ Duration.ofSeconds(5));
           logger.debug("create workspace context result: {}", createContextResult);
           StatusEnum status = createContextResult.getJobReport().getStatus();
           if (StatusEnum.FAILED == status) {


### PR DESCRIPTION
We retry for 2 mins. For one of the flakes last night, cloud context creation took 2 mins 28 sec. So increase to 3 mins.

Also:

- Move constants inline, so I don't have to scroll to top of file to see values
- We were retrying clone workspace for 1 hr, which seems excessive. Changed to 5 min