### PR TITLE
[PF-1998] Check that 'test worker' property is present before using.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -125,7 +125,10 @@ public class Context {
     // parallel without clobbering context across runners.
     String isTest = System.getProperty(CommandRunner.IS_TEST);
     if (isTest != null && isTest.equals("true")) {
-      contextPath = contextPath.resolve(System.getProperty("org.gradle.test.worker"));
+      String testWorker = System.getProperty("org.gradle.test.worker");
+      if (null != testWorker) {
+        contextPath = contextPath.resolve(testWorker);
+      }
     }
     // build.gradle test task makes contextDir. However, with test-runner specific directories,
     // this test is executed in a different place from where the test task mkdir was run. So need

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -126,7 +126,7 @@ public class Context {
     String isTest = System.getProperty(CommandRunner.IS_TEST);
     if (isTest != null && isTest.equals("true")) {
       String testWorker = System.getProperty("org.gradle.test.worker");
-      if (null != testWorker) {
+      if (testWorker != null) {
         contextPath = contextPath.resolve(testWorker);
       }
     }

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -125,6 +125,9 @@ public class Context {
     // parallel without clobbering context across runners.
     String isTest = System.getProperty(CommandRunner.IS_TEST);
     if (isTest != null && isTest.equals("true")) {
+      // cleanupTestUserWorkspaces uses CLI Test Harness to call commands outside of test context.
+      // In this case IS_TEST is true, but "org.gradle.test.worker" is not set, causing testWorker
+      // to be NULL.
       String testWorker = System.getProperty("org.gradle.test.worker");
       if (testWorker != null) {
         contextPath = contextPath.resolve(testWorker);


### PR DESCRIPTION
The `cleanupTestUserWorkspaces` uses the CLI Test Harness to call commands outside of a test context.  This leads to an NPE when a NULL String is passed to the `Path.resolve()` method.