### PR TITLE
Add example group usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,8 @@ not `mygroup@mydomain.com`:
 > terra group list-users --name=mygroup
 ```
 
+Adding a member to a Terra group implicitly adds their pet service accounts. For example, say `terra-user` is added to `mygroup@mydomain.com`. When `mygroup` is granted access to a resource, `terra-user` is able to access that resource from any of their Terra workspaces.
+
 #### gsutil
 
 You can run `terra gsutil` or `terra gcloud alpha storage`


### PR DESCRIPTION
I had always assumed Terra groups worked this way, but didn't see any documentation in the CLI to confirm/deny. Fortunately we were able to test and confirmed that it does indeed work this way.

Created this because tests weren't running in #323