### PR TITLE
[PF-2049] terra-cli: Remove paths ignore from Github workflows

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch: { }
   push:
     branches: [ main ]
+    paths-ignore: [ '**.md' ]
 
 jobs:
   bump-version-publish-release:

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch: { }
   push:
     branches: [ main ]
-    paths-ignore: [ '**.md' ]
 
 jobs:
   bump-version-publish-release:

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -3,10 +3,8 @@ on:
   workflow_dispatch: { }
   push:
     branches: [ main ]
-    paths-ignore: [ '**.md' ]
   pull_request:
     branches: [ '**' ]
-    paths-ignore: [ '**.md' ]
 
 jobs:
   lint-and-static-analysis:

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -3,7 +3,9 @@ on:
   workflow_dispatch: { }
   push:
     branches: [ main ]
+    paths-ignore: [ '**.md' ]
   pull_request:
+    # Branch settings require status checks before merging, so don't add paths-ignore.
     branches: [ '**' ]
 
 jobs:


### PR DESCRIPTION
Issue - If changeset only has .md files (readme.md for example) the PR check (github workflow) does not report the status as success  skipped, thus leading to a PR that can't be merged

As a workaround remove this config for now
Further work will be carried out in https://broadworkbench.atlassian.net/browse/PF-2048
