### PR TITLE
include build-scan as a plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     // use the wrong guava version, leading to runtime errors.
     // See also https://blog.gradle.org/guava
     id 'de.jjohannes.missing-metadata-guava' version '31.1.1'
+    id 'com.gradle.build-scan' version '3.11.1'
 }
 
 // TODO(PF-1981) - Move version to settings.gradle

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 plugins {
     id 'com.gradle.enterprise' version '3.11.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.8'
-    id "com.gradle.build-scan" version "3.11.1"
 }
 
 // Gradle Enterprise Trial Navigator Step 1

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.gradle.enterprise' version '3.11.1'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.8'
+    id "com.gradle.build-scan" version "3.11.1"
 }
 
 // Gradle Enterprise Trial Navigator Step 1


### PR DESCRIPTION
Gradle buildscan is getting socketNetowork timeout error.

https://docs.gradle.com/enterprise/gradle-plugin/ according to the official doc, the new version of gradle requires specifying build-scan as a plugin.