### PR TITLE
PF-1554: set java jdk to 17 for lint and static test

### DIFF
--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -18,6 +18,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 17
     - name: Run linter
       id: run_linter
       run: |


### PR DESCRIPTION
Guang noticed that the lint check fails with her PR that uses a new java api in the PR https://github.com/DataBiosphere/terra-cli/pull/322.