### PR TITLE
Cleanup 500 users at a time

### DIFF
--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -33,7 +33,7 @@ public class CleanupTestUserWorkspaces {
 
   /**
    * List all workspaces the test user has access to and try to delete each one that the test user
-   * owns. Deletes up to 100 workspaces at a time.
+   * owns. Deletes up to 500 workspaces at a time.
    */
   private static void deleteWorkspaces(TestUser testUser, boolean isDryRun) throws IOException {
     System.out.println("Deleting workspaces for testuser " + testUser.email);
@@ -43,7 +43,7 @@ public class CleanupTestUserWorkspaces {
     // `terra workspace list`
     List<UFWorkspace> listWorkspaces =
         TestCommand.runAndParseCommandExpectSuccess(
-            new TypeReference<>() {}, "workspace", "list", "--limit=100");
+            new TypeReference<>() {}, "workspace", "list", "--limit=500");
 
     List<UFWorkspaceUser> listWorkspaceUsers;
     for (UFWorkspace workspace : listWorkspaces) {


### PR DESCRIPTION
I didn't realize this script only cleaned up a max of 500 users, that explains why we've had to re-run it more frequently than expected.