### PR TITLE
[PF-963] Fix cleanup test user action

### DIFF
--- a/src/test/java/harness/baseclasses/ClearContextUnit.java
+++ b/src/test/java/harness/baseclasses/ClearContextUnit.java
@@ -38,7 +38,7 @@ public class ClearContextUnit {
     // set the server to the one specified by the test
     // (see the Gradle test task for how this env var gets set from a Gradle property)
     TestCommand.runCommandExpectSuccess(
-        "server", "set", "--name", System.getenv("TERRA_SERVER"), "--quiet");
+        "server", "set", "--name=" + System.getenv("TERRA_SERVER"), "--quiet");
 
     // set the docker image id to the one specified by the test, or to the default if it's
     // unspecified

--- a/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
+++ b/src/test/java/harness/utils/CleanupTestUserWorkspaces.java
@@ -103,7 +103,7 @@ public class CleanupTestUserWorkspaces {
     if (server == null || server.isEmpty()) {
       throw new UserActionableException("Specify the server to cleanup.");
     }
-    TestCommand.runCommandExpectSuccess("server", "set", "--name", server, "--quiet");
+    TestCommand.runCommandExpectSuccess("server", "set", "--name=" + server, "--quiet");
 
     boolean isDryRun = Boolean.parseBoolean(System.getProperty("DRY_RUN"));
 


### PR DESCRIPTION
The cleanup user action is broken in the Verily deployment - for some reason this command usage doesn't work as expected. This is the only command where an argument with a value is provided without a `=` character, though I don't understand why this is an issue in Verily but not the Broad deployment.