### PR TITLE
[PF-2101] Check java version in CLI download-install.sh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 
 // TODO(PF-1981) - Move version to settings.gradle
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.258.0'
+version = '0.259.0'
 group = 'terra-cli'
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 
 // TODO(PF-1981) - Move version to settings.gradle
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.259.0'
+version = '0.260.0'
 group = 'terra-cli'
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -27,9 +27,6 @@ task runTestsWithTag(type: Test) {
         if (testTag == null) {
             throw new GradleException("The testTag Gradle property is required (e.g. -PtestTag=unit, -PtestTag=integration)")
         }
-        // For Gradle Enterprise trial, we'd like to distinguish unit tests from
-        // integration tests in GE UI.
-        buildScan.tag testTag
         // tell junit to run tests with this tag: unit or integration
         useJUnitPlatform {
             includeTags testTag

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,19 +1,2 @@
-plugins {
-    id 'com.gradle.enterprise' version '3.11.1'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.8'
-}
-
-// Gradle Enterprise Trial Navigator Step 1
-gradleEnterprise {
-    server = "https://gradle-enterprise-prod-helm-cluster.api.verily.com"
-    buildScan {
-        publishAlways()
-        capture {
-            taskInputFiles = true
-        }
-        uploadInBackground = System.getenv("CI") == null
-    }
-}
-
 enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
 rootProject.name = 'terra-cli'

--- a/src/main/java/bio/terra/cli/businessobject/Context.java
+++ b/src/main/java/bio/terra/cli/businessobject/Context.java
@@ -135,7 +135,7 @@ public class Context {
     }
     // build.gradle test task makes contextDir. However, with test-runner specific directories,
     // this test is executed in a different place from where the test task mkdir was run. So need
-    // to create directory for if Test Distribution is being used.
+    // to create directory for if tests are running in parallel.
     if (!contextPath.toAbsolutePath().toFile().exists()) {
       contextPath.toAbsolutePath().toFile().mkdir();
     }

--- a/src/main/java/bio/terra/cli/command/shared/options/CloningInstructionsForUpdate.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/CloningInstructionsForUpdate.java
@@ -15,9 +15,9 @@ public class CloningInstructionsForUpdate {
   @CommandLine.Option(
       names = "--new-cloning",
       // For what is allowed, see:
-      // https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java#L448
+      // https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/main/java/bio/terra/workspace/service/resource/ResourceValidationUtils.java#L478
       description =
-          "Instructions for handling when cloning the workspace: COPY_NOTHING, COPY_DEFINITION, or COPY_RESOURCE for controlled resources; COPY_NOTHING or COPY_REFERENCE for referenced resources.")
+          "Instructions for handling when cloning the workspace: COPY_NOTHING, COPY_DEFINITION, COPY_RESOURCE, COPY_REFERENCE for controlled resources; COPY_NOTHING or COPY_REFERENCE for referenced resources.")
   private CloningInstructionsEnum cloning;
 
   public CloningInstructionsEnum getCloning() {

--- a/src/main/resources/configs/generate-cromwell-config.sh
+++ b/src/main/resources/configs/generate-cromwell-config.sh
@@ -6,7 +6,7 @@ echo "CROMWELL_CONFIG_PATH" : $1
 echo "GOOGLE_PROJECT": $2
 echo "PET_SA_EMAIL": $3
 echo "IMPORTANT: In cromwell.conf, change {WORKSPACE_BUCKET} to a bucket in your workspace."
-if [ ! -f "$1" ]; then
+if [[ ! -f "$1" ]]; then
   cat <<EOF | tee "$1"
 
 google {

--- a/src/test/resources/testscripts/CreateWorkspace.sh
+++ b/src/test/resources/testscripts/CreateWorkspace.sh
@@ -6,7 +6,7 @@ terra status
 terra auth status
 
 isLoggedIn=$(terra auth status --format=json | jq .loggedIn)
-if [[ "true" = "$isLoggedIn" ]]; then
+if [[ "true" == "$isLoggedIn" ]]; then
   currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Creating a new workspace."
   terra workspace create --id=my-workspace-$RANDOM

--- a/src/test/resources/testscripts/CreateWorkspace.sh
+++ b/src/test/resources/testscripts/CreateWorkspace.sh
@@ -6,8 +6,7 @@ terra status
 terra auth status
 
 isLoggedIn=$(terra auth status --format=json | jq .loggedIn)
-if [[ "true" = "$isLoggedIn" ]]
-then
+if [[ "true" = "$isLoggedIn" ]]; then
   currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Creating a new workspace."
   terra workspace create --id=my-workspace-$RANDOM

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -6,8 +6,7 @@ terra status
 terra auth status
 
 isLoggedIn=$(terra auth status --format=json | jq .loggedIn)
-if [[ "true" = "$isLoggedIn" ]]
-then
+if [[ "true" = "$isLoggedIn" ]]; then
   currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Deleting the current workspace."
   terra workspace delete --quiet

--- a/src/test/resources/testscripts/DeleteWorkspace.sh
+++ b/src/test/resources/testscripts/DeleteWorkspace.sh
@@ -6,7 +6,7 @@ terra status
 terra auth status
 
 isLoggedIn=$(terra auth status --format=json | jq .loggedIn)
-if [[ "true" = "$isLoggedIn" ]]; then
+if [[ "true" == "$isLoggedIn" ]]; then
   currentUser=$(terra auth status --format=json | jq .userEmail)
   echo "User $currentUser is logged in. Deleting the current workspace."
   terra workspace delete --quiet

--- a/tools/build-docker.sh
+++ b/tools/build-docker.sh
@@ -9,21 +9,21 @@ set -e
 ##        ./tools/build-docker.sh test123 terracli/branchA   --> builds local Docker image terracli/branchA:test123
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
 # generate a tag from the commit hash if no tag was provided
 localImageTag=$1
-if [ -z "$localImageTag" ]; then
+if [[ -z "$localImageTag" ]]; then
   echo "Generating an image tag from the Git commit hash"
   localImageTag=$(git rev-parse --short HEAD)
 fi
 
 # set the local image name if no name was provided
 localImageName=$2
-if [ -z "$localImageName" ]; then
+if [[ -z "$localImageName" ]]; then
     localImageName="terra-cli/local"
 fi
 

--- a/tools/build-docker.sh
+++ b/tools/build-docker.sh
@@ -10,7 +10,7 @@ set -e
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 

--- a/tools/build-docker.sh
+++ b/tools/build-docker.sh
@@ -23,8 +23,7 @@ fi
 
 # set the local image name if no name was provided
 localImageName=$2
-if [ -z "$localImageName" ]
-  then
+if [ -z "$localImageName" ]; then
     localImageName="terra-cli/local"
 fi
 

--- a/tools/create-break-glass-bq.sh
+++ b/tools/create-break-glass-bq.sh
@@ -13,13 +13,13 @@
 ## Usage: ./tools/create-break-glass-bq.sh [projectId]
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
 projectId=$1
-if [ -z "$projectId" ]; then
+if [[ -z "$projectId" ]]; then
     >&2 echo "ERROR: Usage: ./tools/create-break-glass-bq.sh [projectId]"
     exit 1
 fi

--- a/tools/create-break-glass-bq.sh
+++ b/tools/create-break-glass-bq.sh
@@ -14,15 +14,13 @@
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
-usage="Usage: ./tools/create-break-glass-bq.sh [projectId]"
-
 projectId=$1
 if [ -z "$projectId" ]; then
-    echo $usage
+    >&2 echo "ERROR: Usage: ./tools/create-break-glass-bq.sh [projectId]"
     exit 1
 fi
 

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -12,11 +12,11 @@ if [[ -n "$(which java)" ]]; then
   # Get the current major version of Java: "11.0.12" => "11"
   readonly CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
   if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
-    echo "Error with Java version: set to ${CUR_JAVA_VERSION}, exiting..."
+    >&2 echo "ERROR: Java version detected (${CUR_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
     exit 1
   fi
 else
-  echo "Error determining Java version, exiting"
+  >&2 echo "ERROR: No Java installation detected"
   exit 1
 fi
 
@@ -41,7 +41,7 @@ fi
 archiveFileName="terra-cli.tar"
 curl -L "$releaseTarUrl" > $archiveFileName
 if [ ! -f "${archiveFileName}" ]; then
-    echo "Error downloading release: ${archiveFileName}"
+    >&2 echo "ERROR: Error downloading release: ${archiveFileName}"
     exit 1
 fi
 
@@ -51,7 +51,7 @@ rm -rf "$archiveDir"
 mkdir -p "$archiveDir"
 tar -C "$archiveDir" --strip-components=1 -xf $archiveFileName
 if [ ! -f "$archiveDir/install.sh" ]; then
-    echo "Error unarchiving release: ${archiveFileName}"
+    >&2 echo "ERROR: unarchiving release: ${archiveFileName}"
     exit 1
 fi
 

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -8,12 +8,10 @@ set -e
 
 readonly REQ_JAVA_VERSION=17
 echo "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
-if [[ -n "$(which java)" ]];
-then
+if [[ -n "$(which java)" ]]; then
   # Get the current major version of Java: "11.0.12" => "11"
   readonly CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
-  if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]];
-  then
+  if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
     echo "Error with Java version: set to ${CUR_JAVA_VERSION}, exiting..."
     exit 1
   fi

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -14,7 +14,7 @@ then
   readonly CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
   if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]];
   then
-    echo "Java version set to ${CUR_JAVA_VERSION}, is \$JAVA_HOME set correctly?, exiTing..."
+    echo "Java version set to ${CUR_JAVA_VERSION}, exiting..."
     exit 1
   fi
 else

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -14,11 +14,11 @@ then
   readonly CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
   if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]];
   then
-    echo "Java version set to ${CUR_JAVA_VERSION}, exiting..."
+    echo "Error with Java version: set to ${CUR_JAVA_VERSION}, exiting..."
     exit 1
   fi
 else
-  echo "Java installation not found, exiting"
+  echo "Error determining Java version, exiting"
   exit 1
 fi
 

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -6,6 +6,22 @@ set -e
 ## Usage: ./download-install.sh                            --> installs the latest version
 ##        TERRA_CLI_VERSION=0.1.0 ./download-install.sh    --> installs version 0.1.0
 
+readonly REQ_JAVA_VERSION=17
+echo "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
+if [[ -n "$(which java)" ]];
+then
+  # Get the current major version of Java: "11.0.12" => "11"
+  readonly CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+  if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]];
+  then
+    echo "Java version set to ${CUR_JAVA_VERSION}, is \$JAVA_HOME set correctly?, exiTing..."
+    exit 1
+  fi
+else
+  echo "Java installation not found, exiting"
+  exit 1
+fi
+
 echo "--  Checking if specific version requested"
 if [[ -z "${TERRA_CLI_VERSION}" ]]; then
   terraCliVersion="latest"

--- a/tools/download-install.sh
+++ b/tools/download-install.sh
@@ -32,7 +32,7 @@ fi
 echo "--  Downloading release archive from GitHub"
 ghRepoReleasesUrl="https://github.com/DataBiosphere/terra-cli/releases"
 installPackageFileName="terra-cli.tar"
-if [ "$terraCliVersion" == "latest" ]; then
+if [[ "$terraCliVersion" == "latest" ]]; then
   releaseTarUrl="$ghRepoReleasesUrl/latest/download/$installPackageFileName"
 else
   releaseTarUrl="$ghRepoReleasesUrl/download/$terraCliVersion/$installPackageFileName"
@@ -40,7 +40,7 @@ fi
 
 archiveFileName="terra-cli.tar"
 curl -L "$releaseTarUrl" > $archiveFileName
-if [ ! -f "${archiveFileName}" ]; then
+if [[ ! -f "${archiveFileName}" ]]; then
     >&2 echo "ERROR: Error downloading release: ${archiveFileName}"
     exit 1
 fi
@@ -50,7 +50,7 @@ archiveDir=$PWD/terra-cli-install
 rm -rf "$archiveDir"
 mkdir -p "$archiveDir"
 tar -C "$archiveDir" --strip-components=1 -xf $archiveFileName
-if [ ! -f "$archiveDir/install.sh" ]; then
+if [[ ! -f "$archiveDir/install.sh" ]]; then
     >&2 echo "ERROR: unarchiving release: ${archiveFileName}"
     exit 1
 fi

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -11,7 +11,7 @@ set -e
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
@@ -48,8 +48,8 @@ elif [ "$installMode" = "GITHUB_RELEASE" ]; then
   curl -L https://github.com/DataBiosphere/terra-cli/releases/$versionPath/download-install.sh | bash
 
 else
-  echo "Usage: tools/install-for-testing.sh installMode [version]"
-  echo "       installMode = SOURCE_CODE, GITHUB_RELEASE"
-  echo "           version = version to  install (latest if none passed)"
+  >&2 echo "ERROR: Usage: tools/install-for-testing.sh installMode [version]"
+  >&2 echo "       installMode = SOURCE_CODE, GITHUB_RELEASE"
+  >&2 echo "           version = version to  install (latest if none passed)"
   exit 1
 fi

--- a/tools/install-for-testing.sh
+++ b/tools/install-for-testing.sh
@@ -10,7 +10,7 @@ set -e
 ##        ./tools/install-for-testing.sh GITHUB_RELEASE
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
@@ -18,7 +18,7 @@ fi
 # Tests currently assume Docker is available and running.
 installMode=$1
 echo "installMode: $installMode"
-if [ "$installMode" = "SOURCE_CODE" ]; then
+if [[ "$installMode" == "SOURCE_CODE" ]]; then
   echo "Assuming the Java code is already built and installed by Gradle"
   terra=$(pwd)/build/install/terra-cli/bin/terra
 
@@ -28,9 +28,9 @@ if [ "$installMode" = "SOURCE_CODE" ]; then
   echo "Pulling the default Docker image"
   docker pull $($terra config get image)
 
-elif [ "$installMode" = "GITHUB_RELEASE" ]; then
+elif [[ "$installMode" == "GITHUB_RELEASE" ]]; then
 
-  if [ -z "$2" ]; then
+  if [[ -z "$2" ]]; then
     versionPath="latest/download"
   else
     # We want to download the specificed version of the install script AND

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -12,7 +12,7 @@ if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_
 elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
   terraCliDockerMode="DOCKER_AVAILABLE"
 else
-  echo "Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
+  >&2 echo "ERROR: Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
   exit 1
 fi
 
@@ -21,7 +21,7 @@ echo "--  Docker availability mode is $terraCliDockerMode"
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD
 if [ ! -f "$archiveDir/install.sh" ]; then
-  echo "Script must be run from the same directory (i.e. ./install.sh, not terra-0.1.0/install.sh)"
+  >&2 echo "ERROR: Script must be run from the same directory (i.e. ./install.sh, not terra-0.1.0/install.sh)"
   exit 1
 fi
 
@@ -29,7 +29,7 @@ echo "--  Checking for application directory"
 applicationDir="${HOME}/.terra"
 mkdir -p "$applicationDir"
 if [ ! -d "${applicationDir}" ]; then
-    echo "Error creating application directory: ${applicationDir}"
+    >&2 echo "ERROR: Error creating application directory: ${applicationDir}"
     exit 1
 fi
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -7,9 +7,9 @@ set -e
 # # Dependencies: docker, gcloud
 ## Usage: ./install.sh
 
-if [ -z "$TERRA_CLI_DOCKER_MODE" ] || [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]; then
+if [[ -z "$TERRA_CLI_DOCKER_MODE" ]] || [[ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_NOT_AVAILABLE" ]]; then
   terraCliDockerMode="DOCKER_NOT_AVAILABLE"
-elif [ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]; then
+elif [[ "$TERRA_CLI_DOCKER_MODE" == "DOCKER_AVAILABLE" ]]; then
   terraCliDockerMode="DOCKER_AVAILABLE"
 else
   >&2 echo "ERROR: Unsupported TERRA_CLI_DOCKER_MODE specified: $TERRA_CLI_DOCKER_MODE"
@@ -20,7 +20,7 @@ echo "--  Docker availability mode is $terraCliDockerMode"
 
 echo "--  Checking that script is being run from the same directory"
 archiveDir=$PWD
-if [ ! -f "$archiveDir/install.sh" ]; then
+if [[ ! -f "$archiveDir/install.sh" ]]; then
   >&2 echo "ERROR: Script must be run from the same directory (i.e. ./install.sh, not terra-0.1.0/install.sh)"
   exit 1
 fi
@@ -28,13 +28,13 @@ fi
 echo "--  Checking for application directory"
 applicationDir="${HOME}/.terra"
 mkdir -p "$applicationDir"
-if [ ! -d "${applicationDir}" ]; then
+if [[ ! -d "${applicationDir}" ]]; then
     >&2 echo "ERROR: Error creating application directory: ${applicationDir}"
     exit 1
 fi
 
 echo "--  Moving JARs to application directory"
-if [ -f "${applicationDir}/lib" ] || [ -d "${applicationDir}/lib" ]; then
+if [[ -f "${applicationDir}/lib" ]] || [[ -d "${applicationDir}/lib" ]]; then
   rm -R "${applicationDir:?}/lib"
 fi
 cp -R "$archiveDir"/lib "$applicationDir"/lib
@@ -47,7 +47,7 @@ echo "--  Deleting the archive directory"
 cd "$archiveDir"/..
 rm -R "$archiveDir"
 
-if [ "$terraCliDockerMode" == "DOCKER_NOT_AVAILABLE" ]; then
+if [[ "$terraCliDockerMode" == "DOCKER_NOT_AVAILABLE" ]]; then
   echo "Installing without docker image because TERRA_CLI_DOCKER_MODE is DOCKER_NOT_AVAILABLE."
   ./terra config set app-launch LOCAL_PROCESS
 else

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -5,7 +5,7 @@
 ## Usage: source tools/local-dev.sh
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ "$(basename "$PWD")" != 'terra-cli' ]; then
+if [[ "$(basename "$PWD")" != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -6,7 +6,7 @@
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ "$(basename "$PWD")" != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -11,18 +11,16 @@ set -e
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
-
-usage="Usage: tools/publish-docker.sh [remoteImageTag] [remoteImageName] [localImageTag] [localImageName]"
 
 # check required arguments
 remoteImageTag=$1
 remoteImageName=$2
 localImageTag=$3
 if [ -z "$remoteImageTag" ] || [ -z "$remoteImageName" ] || [ -z "$localImageTag" ]; then
-    echo $usage
+    >&2 echo "ERROR: Usage: tools/publish-docker.sh [remoteImageTag] [remoteImageName] [localImageTag] [localImageName]"
     exit 1
 fi
 

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -21,16 +21,14 @@ usage="Usage: tools/publish-docker.sh [remoteImageTag] [remoteImageName] [localI
 remoteImageTag=$1
 remoteImageName=$2
 localImageTag=$3
-if [ -z "$remoteImageTag" ] || [ -z "$remoteImageName" ] || [ -z "$localImageTag" ]
-  then
+if [ -z "$remoteImageTag" ] || [ -z "$remoteImageName" ] || [ -z "$localImageTag" ]; then
     echo $usage
     exit 1
 fi
 
 # set the local image name if no name was provided
 localImageName=$4
-if [ -z "$localImageName" ]
-  then
+if [ -z "$localImageName" ]; then
     localImageName="terra-cli/local"
 fi
 

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -10,7 +10,7 @@ set -e
 ##        ./tools/publish-docker.sh test123 terra-cli/v0.0 test123ab terracli/branchA
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
@@ -19,14 +19,14 @@ fi
 remoteImageTag=$1
 remoteImageName=$2
 localImageTag=$3
-if [ -z "$remoteImageTag" ] || [ -z "$remoteImageName" ] || [ -z "$localImageTag" ]; then
+if [[ -z "$remoteImageTag" ]] || [[ -z "$remoteImageName" ]] || [[ -z "$localImageTag" ]]; then
     >&2 echo "ERROR: Usage: tools/publish-docker.sh [remoteImageTag] [remoteImageName] [localImageTag] [localImageName]"
     exit 1
 fi
 
 # set the local image name if no name was provided
 localImageName=$4
-if [ -z "$localImageName" ]; then
+if [[ -z "$localImageName" ]]; then
     localImageName="terra-cli/local"
 fi
 
@@ -49,7 +49,7 @@ echo "Pushing the image to GCR"
 docker push $remoteImageNameAndTag
 
 echo "Restoring the current gcloud user"
-if [ -n "$currentGcloudUser" ]; then
+if [[ -n "$currentGcloudUser" ]]; then
   gcloud config set account $currentGcloudUser
 else
   echo "No current gcloud user to restore"

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -13,15 +13,13 @@ set -e
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
-usage="Usage: tools/publish-release.sh [releaseVersion] [isRegularRelease]"
-
 releaseVersion=$1
 if [ -z "$releaseVersion" ]; then
-    echo $usage
+    >&2 echo "ERROR: Usage: tools/publish-release.sh [releaseVersion] [isRegularRelease]"
     exit 1
 fi
 isRegularRelease=$2
@@ -33,7 +31,7 @@ echo "-- Validating version string"
 # Docker image name cannot contain any uppercase letters, so this would prevent using the same
 # version number for both the Java code and Docker image
 if [[ $releaseVersion =~ [A-Z] ]]; then
-  echo "Release version cannot contain any uppercase letters"
+  >&2 echo "ERROR: Release version cannot contain any uppercase letters"
   exit 1
 fi
 
@@ -42,7 +40,7 @@ echo "-- Checking if this version matches the value in build.gradle"
 # related to downloading Gradle are not suppressed (https://github.com/gradle/gradle/issues/5098)
 buildGradleVersion=$(./gradlew --quiet getBuildVersion)
 if [ "$releaseVersion" != "$buildGradleVersion" ]; then
-  echo "Release version ($releaseVersion) does not match build.gradle version ($buildGradleVersion)"
+  >&2 echo "ERROR: Release version ($releaseVersion) does not match build.gradle version ($buildGradleVersion)"
   exit 1
 else
   echo "Release version matches build.gradle version"
@@ -52,7 +50,7 @@ echo "-- Checking if there is a tag that matches this version"
 releaseTag=$releaseVersion
 foundReleaseTag=$(git tag -l $releaseVersion)
 if [ -z "$foundReleaseTag" ]; then
-  echo "No tag found matching this version"
+  >&2 echo "ERROR: No tag found matching this version"
   exit 1
 else
   echo "Found tag matching this version"

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -12,18 +12,18 @@ set -e
 ## Usage: ./publish-release.sh  0.0.0 true   --> publishes version 0.0.0 as a regular release
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
 releaseVersion=$1
-if [ -z "$releaseVersion" ]; then
+if [[ -z "$releaseVersion" ]]; then
     >&2 echo "ERROR: Usage: tools/publish-release.sh [releaseVersion] [isRegularRelease]"
     exit 1
 fi
 isRegularRelease=$2
-if [ "$isRegularRelease" != "true" ]; then
+if [[ "$isRegularRelease" != "true" ]]; then
   isRegularRelease="false"
 fi
 
@@ -39,7 +39,7 @@ echo "-- Checking if this version matches the value in build.gradle"
 # note that the --quiet flag has to be before the task name, otherwise log statements
 # related to downloading Gradle are not suppressed (https://github.com/gradle/gradle/issues/5098)
 buildGradleVersion=$(./gradlew --quiet getBuildVersion)
-if [ "$releaseVersion" != "$buildGradleVersion" ]; then
+if [[ "$releaseVersion" != "$buildGradleVersion" ]]; then
   >&2 echo "ERROR: Release version ($releaseVersion) does not match build.gradle version ($buildGradleVersion)"
   exit 1
 else
@@ -49,7 +49,7 @@ fi
 echo "-- Checking if there is a tag that matches this version"
 releaseTag=$releaseVersion
 foundReleaseTag=$(git tag -l $releaseVersion)
-if [ -z "$foundReleaseTag" ]; then
+if [[ -z "$foundReleaseTag" ]]; then
   >&2 echo "ERROR: No tag found matching this version"
   exit 1
 else
@@ -73,7 +73,7 @@ distributionArchivePath=$(ls build/distributions/*tar)
 
 echo "-- Creating a new GitHub release with the install archive and download script"
 gh config set prompt disabled
-if [ "$isRegularRelease" == "true" ]; then
+if [[ "$isRegularRelease" == "true" ]]; then
   echo "Creating regular release"
   preReleaseFlag=""
 else

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -6,7 +6,7 @@
 ## Usage: ./tools/render-config.sh
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
@@ -28,11 +28,11 @@ readFromVault () {
   vaultPath=$1
   fileName=$2
   decodeBase64=$3
-  if [ -z "$vaultPath" ] || [ -z "$fileName" ]; then
+  if [[ -z "$vaultPath" ]] || [[ -z "$fileName" ]]; then
     >&2 echo "ERROR: Two arguments required for readFromVault function"
     exit 1
   fi
-  if [ -z "$decodeBase64" ]; then
+  if [[ -z "$decodeBase64" ]]; then
     docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
               vault read -format json $vaultPath \
               | jq -r .data > "rendered/broad/$fileName"

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -7,7 +7,7 @@
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
@@ -29,7 +29,7 @@ readFromVault () {
   fileName=$2
   decodeBase64=$3
   if [ -z "$vaultPath" ] || [ -z "$fileName" ]; then
-    echo "Two arguments required for readFromVault function"
+    >&2 echo "ERROR: Two arguments required for readFromVault function"
     exit 1
   fi
   if [ -z "$decodeBase64" ]; then

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -22,16 +22,14 @@ set -e
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [ $(basename $PWD) != 'terra-cli' ]; then
-  echo "Script must be run from top-level directory 'terra-cli/'"
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 terra=$PWD/build/install/terra-cli/bin/terra
 
-usage="Usage: ./setup-test-users.sh [adminUsersGroupEmail]"
-
 adminUsersGroupEmail=$1
 if [ -z "$adminUsersGroupEmail" ]; then
-    echo $usage
+    >&2 echo "ERROR: Usage: ./setup-test-users.sh [adminUsersGroupEmail]"
     exit 1
 fi
 

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -21,14 +21,14 @@ set -e
 # TODO(PF-1339): Rename to setup-broad-test-users.sh, add testconfig flag, and get test users from testconfig.
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [ $(basename $PWD) != 'terra-cli' ]; then
+if [[ $(basename $PWD) != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 terra=$PWD/build/install/terra-cli/bin/terra
 
 adminUsersGroupEmail=$1
-if [ -z "$adminUsersGroupEmail" ]; then
+if [[ -z "$adminUsersGroupEmail" ]]; then
     >&2 echo "ERROR: Usage: ./setup-test-users.sh [adminUsersGroupEmail]"
     exit 1
 fi
@@ -37,7 +37,7 @@ fi
 echo
 echo "Checking whether the server requires inviting new users."
 requiresInvite=$($terra config get server --format=json | jq .samInviteRequiresAdmin)
-if [ $requiresInvite == "true" ]; then
+if [[ $requiresInvite == "true" ]]; then
   echo "Inviting test users."
   declare -a testUsers=("Penelope.TwilightsHammer@test.firecloud.org"
                   "John.Whiteclaw@test.firecloud.org"

--- a/tools/setup-test-users.sh
+++ b/tools/setup-test-users.sh
@@ -47,8 +47,7 @@ if [ $requiresInvite == "true" ]; then
                   "Brooklyn.Thunderlord@test.firecloud.org"
                   "Noah.Frostwolf@test.firecloud.org"
                   "Ethan.Bonechewer@test.firecloud.org")
-  for testUser in "${testUsers[@]}"
-  do
+  for testUser in "${testUsers[@]}"; do
     $terra user status --email="$testUser" || $terra user invite --email="$testUser"
   done
 else


### PR DESCRIPTION
Problem statement - Terra CLI needs java 17 installed. There is no check during cli installation, but execution fails
Fix - add a check for java version during installation

with this change, install will fail if Java is set to <17. 
terra command would still fail if the java version is changed after install. Keeping this use case out of scope for now


Testing  - install fails with java set to version 11

```
clicheck-test >> ls
download-install.sh
clicheck-test >> jenv versions
...
* 11.0 (set by /Users/dexamundsen/clicheck-test/.java-version)
...
clicheck-test >> java --version
openjdk 11.0.16.1 2022-07-19 LTS
OpenJDK Runtime Environment Zulu11.58+23-CA (build 11.0.16.1+1-LTS)
OpenJDK 64-Bit Server VM Zulu11.58+23-CA (build 11.0.16.1+1-LTS, mixed mode)
clicheck-test >> ./download-install.sh 
--  Checking if installed Java version is 17 or higher
Java version set to 11, exiting...
```

Testing  - install succeeds with java set to version 17
```
clicheck-test >> jenv local 17.0.3
clicheck-test >> jenv versions
...
* 17.0.3 (set by /Users/dexamundsen/.jenv/version)
...
clicheck-test >> java --version
openjdk 17.0.3 2022-04-19
OpenJDK Runtime Environment Temurin-17.0.3+7 (build 17.0.3+7)
OpenJDK 64-Bit Server VM Temurin-17.0.3+7 (build 17.0.3+7, mixed mode)
clicheck-test >> ./download-install.sh 
....
--   Install complete
....
clicheck-test >> 
```
