### PR TITLE
[PF-1955] Explicitly lower case the TERRA_USER_EMAIL value.

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -86,7 +86,7 @@ public abstract class CommandRunner {
     // Keep in sync with notebook instance environment variables:
     // https://github.com/DataBiosphere/terra-workspace-manager/blob/42a96e3efe78908d2969d1ac826cd84a11a16714/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh#L165
 
-    terraEnvVars.put("TERRA_USER_EMAIL", Context.requireUser().getEmail());
+    terraEnvVars.put("TERRA_USER_EMAIL", Context.requireUser().getEmail().toLowerCase());
     terraEnvVars.put("GOOGLE_SERVICE_ACCOUNT_EMAIL", Context.requireUser().getPetSaEmail());
     terraEnvVars.put("GOOGLE_CLOUD_PROJECT", Context.requireWorkspace().getGoogleProjectId());
 


### PR DESCRIPTION
Source email address may be mixed case.
People and applications would expect consistent values.

Fixes flaky test added in #320 .