### PR TITLE
[PF-2138] Lower-case email stored in User, WorkspaceUser

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -86,7 +86,7 @@ public abstract class CommandRunner {
     // Keep in sync with notebook instance environment variables:
     // https://github.com/DataBiosphere/terra-workspace-manager/blob/42a96e3efe78908d2969d1ac826cd84a11a16714/service/src/main/java/bio/terra/workspace/service/resource/controlled/cloud/gcp/ainotebook/post-startup.sh#L165
 
-    terraEnvVars.put("TERRA_USER_EMAIL", Context.requireUser().getEmail().toLowerCase());
+    terraEnvVars.put("TERRA_USER_EMAIL", Context.requireUser().getEmail());
     terraEnvVars.put("GOOGLE_SERVICE_ACCOUNT_EMAIL", Context.requireUser().getPetSaEmail());
     terraEnvVars.put("GOOGLE_CLOUD_PROJECT", Context.requireWorkspace().getGoogleProjectId());
 

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -77,7 +77,8 @@ public class User {
   /** Build an instance of this class from the serialized format on disk. */
   public User(PDUser configFromDisk) {
     this.id = configFromDisk.id;
-    this.email = configFromDisk.email;
+    // PDUser email should already be lower-case, but lower-case just in case.
+    this.email = configFromDisk.email.toLowerCase();
     this.proxyGroupEmail = configFromDisk.proxyGroupEmail;
     this.petSAEmail = configFromDisk.petSAEmail;
     this.logInMode = configFromDisk.useApplicationDefaultCredentials;

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -267,7 +267,7 @@ public class User {
     SamService samService = SamService.forUser(this);
     UserStatusInfo userInfo = samService.getUserInfoOrRegisterUser();
     id = userInfo.getUserSubjectId();
-    email = userInfo.getUserEmail();
+    email = userInfo.getUserEmail().toLowerCase();
     proxyGroupEmail = samService.getProxyGroupEmail(email);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/WorkspaceUser.java
+++ b/src/main/java/bio/terra/cli/businessobject/WorkspaceUser.java
@@ -27,7 +27,7 @@ public class WorkspaceUser {
   private UUID workspaceId;
 
   private WorkspaceUser(String email, List<Role> roles) {
-    this.email = email;
+    this.email = email.toLowerCase();
     this.roles = roles;
   }
 


### PR DESCRIPTION
This way, callers of User.getEmail() or WorkspaceUser.getEmail() don't have to lower-case themselves, which is error-prone.

Ran PassthroughApps.workspaceEnvVars multiple times, still not flaky.