### PR TITLE
[PF-1755] `terra workspace list` long workspace id is  truncated 

### DIFF
--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -69,7 +69,7 @@ public class List extends BaseCommand {
 
   /** Column information for table output with `terra workspace list` */
   private enum Columns implements ColumnDefinition<UFWorkspaceLight> {
-    ID("ID", w -> w.id, 36, LEFT),
+    ID("ID", w -> w.id, 40, LEFT),
     NAME("NAME", w -> w.name, 30, LEFT),
     GOOGLE_PROJECT("GOOGLE PROJECT", w -> w.googleProjectId, 30, LEFT),
     DESCRIPTION("DESCRIPTION", w -> w.description, 40, LEFT);


### PR DESCRIPTION
### [PF-1755](https://broadworkbench.atlassian.net/browse/PF-1755)
The `terra workspace list` could not show full id because it long. Change the column size from 36 to 40 then manually test it. 
**Before**
```
   ID                                    NAME                            GOOGLE PROJECT                  DESCRIPTION                                                           
   a-6bc4a502-8600-4449-b224-0104d80...  (unset)                         terra-vdevel-speedy-lemon-8435  (unset)                                 
   clonetestname                         (unset)                         terra-vdevel-cold-lime-8223     (unset)     
```
**After**
```
ginay-macbookpro:terra-cli ginay$ terra workspace list
   ID                                        NAME                            GOOGLE PROJECT                  DESCRIPTION                                                       
   a-993ca64d-c4c8-462e-b56b-219e24cc4932    (unset)                         terra-vdevel-happy-sprout-8067  (unset)                                 
   aa191d41b-e69b-4c09-abd1-6f2ae0f4775a     (unset)                         terra-vdevel-cold-apple-38      (unset)                                                                                          
   xxxtest                                   xxxtest                         terra-vdevel-perky-onion-5358   (unset)            
```