### PR TITLE
fix terra 'group' command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Commands:
   delete       Delete an existing Terra group.
   describe     Describe the group.
   list         List the groups to which the current user belongs.
-  list-users   List all resources and folders in tree view.
+  list-users   List the users in a group.
   remove-user  Remove a user from a group with a given policy.
 ```
 


### PR DESCRIPTION
I believe this was a cut & paste error in an earlier edit of the README.