### PR TITLE
[PF-940] Use broad-appsec-blessed JRE image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Java 17 base image
-FROM eclipse-temurin:17.0.4_8-jre-focal
+# see https://github.com/broadinstitute/dsp-appsec-blessed-images/tree/main/jre
+FROM us.gcr.io/broad-dsp-gcr-public/base/jre:17-debian
 
 # working directory when the docker is run
 WORKDIR /usr


### PR DESCRIPTION
Problem statement - Standard eclipse temurin images potentially have app-security concerns
Fix - use the broad app-security-approved images from https://github.com/broadinstitute/dsp-appsec-blessed-images

No further checks were performed since the major version is the same, minor version is a downgrade