### PR TITLE
[PF-2268] fix the currentVersion is null cause NPE 

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -37,7 +37,7 @@ task runTestsWithTag(type: Test) {
             // used to get the default docker image id.
             systemProperty("TERRA_JAR_IMPLEMENTATION_VERSION",
                     "${project.properties['dockerRepoPath']}/${project.properties['dockerImageName']}/${project.version}:${project.properties['dockerImageTag']}")
-            systemProperty("TERRA_VERSION", "${project.version}")
+            systemProperty("TERRA_CLI_VERSION", "${project.version}")
         } else if (testTag == "integration") {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
             // for an installation directly from source code, this points to the build/install/terra-cli/bin directory (i.e. the output of ./gradlew install)

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -37,6 +37,7 @@ task runTestsWithTag(type: Test) {
             // used to get the default docker image id.
             systemProperty("TERRA_JAR_IMPLEMENTATION_VERSION",
                     "${project.properties['dockerRepoPath']}/${project.properties['dockerImageName']}/${project.version}:${project.properties['dockerImageTag']}")
+            systemProperty("TERRA_VERSION", "${project.version}")
         } else if (testTag == "integration") {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
             // for an installation directly from source code, this points to the build/install/terra-cli/bin directory (i.e. the output of ./gradlew install)

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -37,6 +37,7 @@ task runTestsWithTag(type: Test) {
             // used to get the default docker image id.
             systemProperty("TERRA_JAR_IMPLEMENTATION_VERSION",
                     "${project.properties['dockerRepoPath']}/${project.properties['dockerImageName']}/${project.version}:${project.properties['dockerImageTag']}")
+            // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
             systemProperty("TERRA_CLI_VERSION", "${project.version}")
         } else if (testTag == "integration") {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)

--- a/src/main/java/bio/terra/cli/utils/Version.java
+++ b/src/main/java/bio/terra/cli/utils/Version.java
@@ -1,7 +1,10 @@
 package bio.terra.cli.utils;
 
+import org.slf4j.LoggerFactory;
+
 /** Utility methods for the currently installed version of the Terra CLI. */
 public class Version {
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Version.class);
   /** Getter for the Terra CLI version of the current JAR. */
   public static String getVersion() {
     // read from the JAR Manifest file
@@ -9,6 +12,8 @@ public class Version {
     if (version != null) {
       return version;
     }
+    logger.warn(
+        "Implementation version not defined in the JAR manifest. This is expected when testing, not during normal operation.");
     return System.getProperty("TERRA_CLI_VERSION");
   }
 }

--- a/src/main/java/bio/terra/cli/utils/Version.java
+++ b/src/main/java/bio/terra/cli/utils/Version.java
@@ -9,6 +9,6 @@ public class Version {
     if (version != null) {
       return version;
     }
-    return System.getProperty("TERRA_VERSION");
+    return System.getProperty("TERRA_CLI_VERSION");
   }
 }

--- a/src/main/java/bio/terra/cli/utils/Version.java
+++ b/src/main/java/bio/terra/cli/utils/Version.java
@@ -5,6 +5,10 @@ public class Version {
   /** Getter for the Terra CLI version of the current JAR. */
   public static String getVersion() {
     // read from the JAR Manifest file
-    return Version.class.getPackage().getSpecificationVersion();
+    String version = Version.class.getPackage().getSpecificationVersion();
+    if (version != null) {
+      return version;
+    }
+    return System.getProperty("TERRA_VERSION");
   }
 }


### PR DESCRIPTION
Background:

- This PR comes from the ticket [PF-2268](https://broadworkbench.atlassian.net/browse/PF-2268). The [PF-2174](https://broadworkbench.atlassian.net/browse/PF-2174). 
- The error only happens in Verily server. and shows the current version is null. see [details](https://scans.gradle.com/s/tt2z6g6zxrn4w/tests/overview)
- We dive deep into the code, and find the reason is https://github.com/DataBiosphere/terra-cli/blob/main/src/main/java/bio/terra/cli/app/utils/VersionCheckUtils.java#L65 verily server set the oldest version, so it could not go into the if statement there, when the current version is null. then in L72 it could not parse. 

The way for solve the problem is which learn from `Config.java` https://github.com/DataBiosphere/terra-cli/blob/main/src/main/java/bio/terra/cli/businessobject/Config.java#L51. we add one more if sentence to deal with this situation.