### PR TITLE
Revert "Revert "[PF-2174] check version is out of date for the commands talk to server""

### DIFF
--- a/src/main/java/bio/terra/cli/app/utils/VersionCheckUtils.java
+++ b/src/main/java/bio/terra/cli/app/utils/VersionCheckUtils.java
@@ -1,59 +1,30 @@
 package bio.terra.cli.app.utils;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.VersionCheck;
 import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.workspace.model.SystemVersion;
 import java.lang.module.ModuleDescriptor.Version;
-import java.time.Duration;
-import java.time.OffsetDateTime;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class VersionCheckUtils {
   private static final Logger logger = LoggerFactory.getLogger(VersionCheckUtils.class);
-  private static final Duration VERSION_CHECK_INTERVAL = Duration.ofMinutes(30);
 
   /** Query Workspace Manager for the oldest supported */
   public static boolean isObsolete() {
-    if (checkIntervalElapsed()) {
-      // update last checked time in the context file
-      VersionCheck updatedVersionCheck = new VersionCheck(OffsetDateTime.now());
-      Context.setVersionCheck(updatedVersionCheck);
-
-      // The oldest supported version is exposed on the main WSM /version endpoint
-      SystemVersion wsmVersion =
-          WorkspaceManagerService.unauthenticated(Context.getServer()).getVersion();
-      String oldestSupportedVersion = wsmVersion.getOldestSupportedCliVersion();
-      String currentCliVersion = bio.terra.cli.utils.Version.getVersion();
-      boolean result = isOlder(currentCliVersion, oldestSupportedVersion);
-      logger.debug(
-          "Current CLI version {} is {} than the oldest supported version {}",
-          currentCliVersion,
-          result ? "older" : "newer",
-          oldestSupportedVersion);
-      return result;
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * We don't want to hit the version endpoint on the server with every command invocation, so check
-   * if a certain amount of time has passed since the last time we checked (or the last time is
-   * null/never).
-   *
-   * @return true if we should do the version check again
-   */
-  public static boolean checkIntervalElapsed() {
-    Optional<OffsetDateTime> lastCheckTime =
-        Context.getVersionCheck().map(VersionCheck::getLastVersionCheckTime);
-    return (lastCheckTime.isEmpty()
-        || Duration.between(lastCheckTime.get(), OffsetDateTime.now())
-                .compareTo(VERSION_CHECK_INTERVAL)
-            > 0);
+    // The oldest supported version is exposed on the main WSM /version endpoint
+    SystemVersion wsmVersion =
+        WorkspaceManagerService.unauthenticated(Context.getServer()).getVersion();
+    String oldestSupportedVersion = wsmVersion.getOldestSupportedCliVersion();
+    String currentCliVersion = bio.terra.cli.utils.Version.getVersion();
+    boolean result = isOlder(currentCliVersion, oldestSupportedVersion);
+    logger.debug(
+        "Current CLI version {} is {} than the oldest supported version {}",
+        currentCliVersion,
+        result ? "older" : "newer",
+        oldestSupportedVersion);
+    return result;
   }
 
   /**

--- a/src/main/java/bio/terra/cli/command/resource/CheckAccess.java
+++ b/src/main/java/bio/terra/cli/command/resource/CheckAccess.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.User;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -13,7 +13,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "check-access",
     description = "Check if you have access to a referenced resource.")
-public class CheckAccess extends BaseCommand {
+public class CheckAccess extends WsmBaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/Delete.java
+++ b/src/main/java/bio/terra/cli/command/resource/Delete.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.resource;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.DeletePrompt;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -10,7 +10,7 @@ import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra resource delete" command. */
 @CommandLine.Command(name = "delete", description = "Delete a resource from the workspace.")
-public class Delete extends BaseCommand {
+public class Delete extends WsmBaseCommand {
   @CommandLine.Mixin DeletePrompt deletePromptOption;
   @CommandLine.Mixin ResourceName resourceNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/Describe.java
+++ b/src/main/java/bio/terra/cli/command/resource/Describe.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.resource;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -11,7 +11,7 @@ import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra resource describe" command. */
 @CommandLine.Command(name = "describe", description = "Describe a resource.")
-public class Describe extends BaseCommand {
+public class Describe extends WsmBaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/List.java
+++ b/src/main/java/bio/terra/cli/command/resource/List.java
@@ -6,7 +6,7 @@ import bio.terra.cli.app.utils.tables.ColumnDefinition;
 import bio.terra.cli.app.utils.tables.TablePrinter;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
@@ -18,7 +18,7 @@ import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra resource list" command. */
 @CommandLine.Command(name = "list", description = "List all resources.")
-public class List extends BaseCommand {
+public class List extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/resource/ListTree.java
+++ b/src/main/java/bio/terra/cli/command/resource/ListTree.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.resource;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFResource;
 import bio.terra.workspace.model.Folder;
@@ -17,7 +17,7 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "list-tree",
     description = "List all resources and folders in tree view.")
-public class ListTree extends BaseCommand {
+public class ListTree extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   private static final HashMap<UUID, ArrayList<UUID>> EDGES = new HashMap<>();

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -7,7 +7,7 @@ import bio.terra.cli.businessobject.resource.BqResolvedOptions;
 import bio.terra.cli.businessobject.resource.BqTable;
 import bio.terra.cli.businessobject.resource.GcsBucket;
 import bio.terra.cli.businessobject.resource.GcsObject;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -17,8 +17,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra resource resolve" command. */
 @Command(name = "resolve", description = "Resolve a resource to its cloud id or path.")
-public class Resolve extends BaseCommand {
-
+public class Resolve extends WsmBaseCommand {
   @CommandLine.Mixin ResourceName resourceNameOption;
 
   @CommandLine.Option(

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqDataset.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.addref;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
@@ -16,7 +16,7 @@ import picocli.CommandLine;
     name = "bq-dataset",
     description = "Add a referenced BigQuery dataset.",
     showDefaultValues = true)
-public class BqDataset extends BaseCommand {
+public class BqDataset extends WsmBaseCommand {
   @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin BqDatasetsIds bigQueryIds;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/BqTable.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.addref;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetsIds;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
@@ -16,7 +16,7 @@ import picocli.CommandLine;
     name = "bq-table",
     description = "Add a referenced BigQuery Data Table.",
     showDefaultValues = true)
-public class BqTable extends BaseCommand {
+public class BqTable extends WsmBaseCommand {
   @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin BqDatasetsIds bqDatasetsIds;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsBucket.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.addref;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketName;
 import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
@@ -15,7 +15,7 @@ import picocli.CommandLine;
     name = "gcs-bucket",
     description = "Add a referenced GCS bucket.",
     showDefaultValues = true)
-public class GcsBucket extends BaseCommand {
+public class GcsBucket extends WsmBaseCommand {
   @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin GcsBucketName bucketNameOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GcsObject.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.addref;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -17,7 +17,7 @@ import picocli.CommandLine;
     name = "gcs-object",
     description = "Add a referenced GCS bucket object.",
     showDefaultValues = true)
-public class GcsObject extends BaseCommand {
+public class GcsObject extends WsmBaseCommand {
   @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/addref/GitRepo.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.addref;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ReferencedResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -14,7 +14,7 @@ import picocli.CommandLine;
     name = "git-repo",
     description = "Add a referenced git repository.",
     showDefaultValues = true)
-public class GitRepo extends BaseCommand {
+public class GitRepo extends WsmBaseCommand {
   @CommandLine.Mixin ReferencedResourceCreation referencedResourceCreationOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/BqDataset.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.create;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetLifetime;
 import bio.terra.cli.command.shared.options.ControlledResourceCreation;
 import bio.terra.cli.command.shared.options.Format;
@@ -16,7 +16,7 @@ import picocli.CommandLine;
     name = "bq-dataset",
     description = "Add a controlled BigQuery dataset.",
     showDefaultValues = true)
-public class BqDataset extends BaseCommand {
+public class BqDataset extends WsmBaseCommand {
   @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
   @CommandLine.Mixin BqDatasetLifetime bqDatasetLifetimeOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpNotebook.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.create;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.ControlledResourceCreation;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -22,8 +22,7 @@ import picocli.CommandLine;
             + "For a detailed explanation of some parameters, see https://cloud.google.com/vertex-ai/docs/workbench/reference/rest/v1/projects.locations.instances#Instance.",
     showDefaultValues = true,
     sortOptions = false)
-public class GcpNotebook extends BaseCommand {
-
+public class GcpNotebook extends WsmBaseCommand {
   private static final String DEFAULT_VM_IMAGE_PROJECT = "deeplearning-platform-release";
   private static final String DEFAULT_VM_IMAGE_FAMILY = "r-latest-cpu-experimental";
 

--- a/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcsBucket.java
@@ -1,6 +1,6 @@
 package bio.terra.cli.command.resource.create;
 
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.ControlledResourceCreation;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketStorageClass;
@@ -16,7 +16,7 @@ import picocli.CommandLine;
     name = "gcs-bucket",
     description = "Add a controlled GCS bucket.",
     showDefaultValues = true)
-public class GcsBucket extends BaseCommand {
+public class GcsBucket extends WsmBaseCommand {
   @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
   @CommandLine.Mixin GcsBucketStorageClass storageClassOption;
   @CommandLine.Mixin bio.terra.cli.command.shared.options.GcsBucketLifecycle lifecycleOptions;

--- a/src/main/java/bio/terra/cli/command/resource/update/BqDataset.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/BqDataset.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.update;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetLifetime;
 import bio.terra.cli.command.shared.options.BqDatasetNewIds;
 import bio.terra.cli.command.shared.options.CloningInstructionsForUpdate;
@@ -22,7 +22,7 @@ import picocli.CommandLine;
     name = "bq-dataset",
     description = "Update a BigQuery dataset.",
     showDefaultValues = true)
-public class BqDataset extends BaseCommand {
+public class BqDataset extends WsmBaseCommand {
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin BqDatasetLifetime bqDatasetLifetimeOptions;
   @CommandLine.Mixin BqDatasetNewIds bqDatasetNewIds;

--- a/src/main/java/bio/terra/cli/command/resource/update/BqTable.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/BqTable.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.update;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.BqDatasetNewIds;
 import bio.terra.cli.command.shared.options.CloningInstructionsForUpdate;
 import bio.terra.cli.command.shared.options.Format;
@@ -19,7 +19,7 @@ import picocli.CommandLine;
     name = "bq-table",
     description = "Update a BigQuery data table.",
     showDefaultValues = true)
-public class BqTable extends BaseCommand {
+public class BqTable extends WsmBaseCommand {
   @CommandLine.Mixin BqDatasetNewIds bqDatasetNewIds;
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/update/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcpNotebook.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.resource.update;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.NotebookMetadata;
 import bio.terra.cli.command.shared.options.ResourceUpdate;
@@ -16,7 +16,7 @@ import picocli.CommandLine;
     name = "gcp-notebook",
     description = "Update the GCP notebook.",
     showDefaultValues = true)
-public class GcpNotebook extends BaseCommand {
+public class GcpNotebook extends WsmBaseCommand {
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/resource/update/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcsBucket.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.update;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.CloningInstructionsForUpdate;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.GcsBucketNewName;
@@ -22,7 +22,7 @@ import picocli.CommandLine;
     name = "gcs-bucket",
     description = "Update a GCS bucket.",
     showDefaultValues = true)
-public class GcsBucket extends BaseCommand {
+public class GcsBucket extends WsmBaseCommand {
   @CommandLine.Mixin GcsBucketNewName newBucketName;
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin GcsBucketStorageClass storageClassOption;

--- a/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcsObject.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.update;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.CloningInstructionsForUpdate;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceUpdate;
@@ -20,7 +20,7 @@ import picocli.CommandLine;
     name = "gcs-object",
     description = "Update a GCS bucket object.",
     showDefaultValues = true)
-public class GcsObject extends BaseCommand {
+public class GcsObject extends WsmBaseCommand {
   @CommandLine.Mixin CloningInstructionsForUpdate newCloningInstructionsOption;
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/resource/update/GitRepo.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GitRepo.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.resource.update;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Resource.Type;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.CloningInstructionsForUpdate;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceUpdate;
@@ -18,7 +18,7 @@ import picocli.CommandLine;
     name = "git-repo",
     description = "Update a Git Repo.",
     showDefaultValues = true)
-public class GitRepo extends BaseCommand {
+public class GitRepo extends WsmBaseCommand {
   @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
   @CommandLine.Mixin CloningInstructionsForUpdate newCloningInstructionsOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -1,6 +1,5 @@
 package bio.terra.cli.command.shared;
 
-import bio.terra.cli.app.utils.VersionCheckUtils;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.User;
 import bio.terra.cli.command.Main;
@@ -61,14 +60,6 @@ public abstract class BaseCommand implements Callable<Integer> {
     // execute the command
     logger.debug("[COMMAND RUN] terra " + String.join(" ", Main.getArgList()));
     execute();
-
-    //     optionally check if this version of the CLI is out of date
-    if (VersionCheckUtils.isObsolete()) {
-      ERR.printf(
-          "Warning: Version %s of the CLI has expired. Functionality may not work as expected. To install the latest version: curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash ./terra\n"
-              + "If you have added the CLI to your $PATH, this step will need to be repeated after the installation is complete.%n",
-          bio.terra.cli.utils.Version.getVersion());
-    }
 
     // set the command exit code
     return 0;

--- a/src/main/java/bio/terra/cli/command/shared/WsmBaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/WsmBaseCommand.java
@@ -1,0 +1,39 @@
+package bio.terra.cli.command.shared;
+
+import bio.terra.cli.app.utils.VersionCheckUtils;
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.utils.UserIO;
+import java.io.PrintStream;
+
+/**
+ * This class prints a warning if CLI version is too old for WSM version.
+ *
+ * <p>Commands which call WSM should extend this instead of BaseCommand. (This way, if WSM happens
+ * to be down, commands that don't call WSM will still succeed.)
+ */
+public abstract class WsmBaseCommand extends BaseCommand {
+  protected static PrintStream OUT;
+  protected static PrintStream ERR;
+
+  @Override
+  public Integer call() {
+    // pull the output streams from the singleton object setup by the top-level Main class
+    // in the future, these streams could also be controlled by a global context property
+    OUT = UserIO.getOut();
+    ERR = UserIO.getErr();
+
+    // read in the global context and setup logging
+    Context.initializeFromDisk();
+
+    // Check if this version of the CLI is out of date
+    if (VersionCheckUtils.isObsolete()) {
+      ERR.printf(
+          "Warning: Version %s of the CLI has expired. Functionality may not work as expected. To install the latest version: curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash ./terra\n"
+              + "If you have added the CLI to your $PATH, this step will need to be repeated after the installation is complete.%n",
+          bio.terra.cli.utils.Version.getVersion());
+      return 0;
+    }
+
+    return super.call();
+  }
+}

--- a/src/main/java/bio/terra/cli/command/workspace/AddUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/AddUser.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.WorkspaceUser;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
@@ -11,8 +11,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace add-user" command. */
 @Command(name = "add-user", description = "Add a user or group to the workspace.")
-public class AddUser extends BaseCommand {
-
+public class AddUser extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.businessobject.WorkspaceUser;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
@@ -32,7 +32,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace break-glass" command. */
 @Command(name = "break-glass", description = "Grant break-glass access to a workspace user.")
-public class BreakGlass extends BaseCommand {
+public class BreakGlass extends WsmBaseCommand {
   private static final Logger logger = LoggerFactory.getLogger(BreakGlass.class);
   // pointers to the central BQ dataset where break-glass requests are logged
   // keep the dataset/table names here consistent with those in tools/create-break-glass-bq.sh

--- a/src/main/java/bio/terra/cli/command/workspace/Clone.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Clone.java
@@ -3,7 +3,7 @@ package bio.terra.cli.command.workspace;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceNameAndDescription;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
@@ -20,7 +20,7 @@ import picocli.CommandLine.Command;
 
 /** This corresponds to the third-level "terra workspace clone" command. */
 @Command(name = "clone", description = "Clone an existing workspace.")
-public class Clone extends BaseCommand {
+public class Clone extends WsmBaseCommand {
   @CommandLine.Option(names = "--new-id", required = true, description = "ID for new workspace")
   // Variable is `id` instead of `userFacingId` because user sees it with `terra workspace clone`
   private String id;

--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceNameAndDescription;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -12,8 +12,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace create" command. */
 @Command(name = "create", description = "Create a new workspace.")
-public class Create extends BaseCommand {
-
+public class Create extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceNameAndDescription workspaceNameAndDescription;
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/Delete.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Delete.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.DeletePrompt;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace delete" command. */
 @Command(name = "delete", description = "Delete an existing workspace.")
-public class Delete extends BaseCommand {
+public class Delete extends WsmBaseCommand {
   @CommandLine.Mixin DeletePrompt deletePromptOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/DeleteProperty.java
+++ b/src/main/java/bio/terra/cli/command/workspace/DeleteProperty.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -12,7 +12,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace delete-property" command. */
 @Command(name = "delete-property", description = "Delete the workspace properties.")
-public class DeleteProperty extends BaseCommand {
+public class DeleteProperty extends WsmBaseCommand {
   @CommandLine.Option(
       names = "--keys",
       required = true,

--- a/src/main/java/bio/terra/cli/command/workspace/Describe.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Describe.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -10,8 +10,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace describe" command. */
 @Command(name = "describe", description = "Describe the workspace.", showDefaultValues = true)
-public class Describe extends BaseCommand {
-
+public class Describe extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -6,7 +6,7 @@ import bio.terra.cli.app.utils.tables.ColumnDefinition;
 import bio.terra.cli.app.utils.tables.TablePrinter;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceLight;
 import bio.terra.cli.utils.UserIO;
@@ -21,7 +21,7 @@ import picocli.CommandLine.Command;
     name = "list",
     description = "List all workspaces the current user can access.",
     showDefaultValues = true)
-public class List extends BaseCommand {
+public class List extends WsmBaseCommand {
 
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ListUsers.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.WorkspaceUser;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceUser;
@@ -13,8 +13,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace list-users" command. */
 @Command(name = "list-users", description = "List the users of the workspace.")
-public class ListUsers extends BaseCommand {
-
+public class ListUsers extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
+++ b/src/main/java/bio/terra/cli/command/workspace/RemoveUser.java
@@ -2,15 +2,14 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.WorkspaceUser;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace remove-user" command. */
 @Command(name = "remove-user", description = "Remove a user or group from the workspace.")
-public class RemoveUser extends BaseCommand {
-
+public class RemoveUser extends WsmBaseCommand {
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   @CommandLine.Option(names = "--email", required = true, description = "User or group email.")

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -1,7 +1,7 @@
 package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import picocli.CommandLine;
@@ -9,7 +9,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace set" command. */
 @Command(name = "set", description = "Set the workspace to an existing one.")
-public class Set extends BaseCommand {
+public class Set extends WsmBaseCommand {
   @CommandLine.Mixin Format formatOption;
 
   @CommandLine.Option(names = "--id", required = true, description = "Workspace id.")

--- a/src/main/java/bio/terra/cli/command/workspace/SetProperty.java
+++ b/src/main/java/bio/terra/cli/command/workspace/SetProperty.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -14,7 +14,7 @@ import picocli.CommandLine.Command;
 // This is set-property instead of add-property because this can be used to 1) Add property 2)
 // Update existing property.
 @Command(name = "set-property", description = "Set the workspace properties.")
-public class SetProperty extends BaseCommand {
+public class SetProperty extends WsmBaseCommand {
   @CommandLine.Mixin Format formatOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -2,7 +2,7 @@ package bio.terra.cli.command.workspace;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
-import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
@@ -11,7 +11,7 @@ import picocli.CommandLine.Command;
 
 /** This class corresponds to the third-level "terra workspace update" command. */
 @Command(name = "update", description = "Update an existing workspace.")
-public class Update extends BaseCommand {
+public class Update extends WsmBaseCommand {
 
   @CommandLine.ArgGroup(
       exclusive = false,


### PR DESCRIPTION
Reverts DataBiosphere/terra-cli#362

This ticket is the revert - revert version of the [PF-2174](https://broadworkbench.atlassian.net/browse/PF-2174 ) 
We already fix the downstream error for current version check. #364