### PR TITLE
[PF-2333] Fix test failures caused by IAM delay

### DIFF
--- a/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
@@ -6,13 +6,21 @@ import bio.terra.cloudres.google.bigquery.BigQueryCow;
 import bio.terra.cloudres.google.cloudresourcemanager.CloudResourceManagerCow;
 import bio.terra.cloudres.google.notebooks.AIPlatformNotebooksCow;
 import bio.terra.cloudres.google.storage.StorageCow;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.time.Duration;
+import org.apache.http.HttpStatus;
 
 /** Utilities for working with the Terra Cloud Resource Library. */
 public class CrlUtils {
+
+  // For GCP permissions propagation, retry for up to 5 minutes.
+  public static final int GCP_RETRY_COUNT = 30;
+  public static final Duration GCP_RETRY_SLEEP_DURATION = Duration.ofSeconds(10);
+
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-cli").build();
 
@@ -48,5 +56,22 @@ public class CrlUtils {
     } catch (GeneralSecurityException | IOException ex) {
       throw new SystemException("Error creating Big Query client.", ex);
     }
+  }
+
+  public static boolean isGcpPermissionsError(Exception e) {
+    return ((e instanceof GoogleJsonResponseException)
+            && (((GoogleJsonResponseException) e).getStatusCode() == HttpStatus.SC_FORBIDDEN))
+        || ((e.getCause() instanceof GoogleJsonResponseException)
+            && (((GoogleJsonResponseException) e.getCause()).getStatusCode()
+                == HttpStatus.SC_FORBIDDEN));
+  }
+
+  public static <T, E extends Exception> T callGcpWithRetries(
+      HttpUtils.SupplierWithCheckedException<T, E> makeRequest) throws E, InterruptedException {
+    return HttpUtils.callWithRetries(
+        makeRequest,
+        CrlUtils::isGcpPermissionsError,
+        CrlUtils.GCP_RETRY_COUNT,
+        CrlUtils.GCP_RETRY_SLEEP_DURATION);
   }
 }

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
+import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -275,7 +276,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create a controlled dataset, specifying all options")
-  void createWithAllOptions() throws IOException {
+  void createWithAllOptions() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id --format=json`
@@ -318,8 +319,11 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         "create output matches private user name");
 
     Dataset createdDatasetOnCloud =
-        ExternalBQDatasets.getBQClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
-            .getDataset(DatasetId.of(workspace.googleProjectId, datasetId));
+        CrlUtils.callGcpWithRetries(
+            () ->
+                ExternalBQDatasets.getBQClient(
+                        workspaceCreator.getCredentialsWithCloudPlatformScope())
+                    .getDataset(DatasetId.of(workspace.googleProjectId, datasetId)));
     assertNotNull(createdDatasetOnCloud, "looking up dataset via BQ API succeeded");
     assertEquals(
         location, createdDatasetOnCloud.getLocation(), "dataset location matches create input");

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.cli.serialization.userfacing.input.GcsStorageClass;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
+import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.workspace.model.AccessScope;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -249,7 +250,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create a controlled bucket, specifying all options except lifecycle")
-  void createWithAllOptionsExceptLifecycle() throws IOException {
+  void createWithAllOptionsExceptLifecycle() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
@@ -291,8 +292,11 @@ public class GcsBucketControlled extends SingleWorkspaceUnit {
         "create output matches private user name");
 
     Bucket createdBucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
-            .get(bucketName);
+        CrlUtils.callGcpWithRetries(
+            () ->
+                ExternalGCSBuckets.getStorageClient(
+                        workspaceCreator.getCredentialsWithCloudPlatformScope())
+                    .get(bucketName));
     assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         location, createdBucketOnCloud.getLocation(), "bucket location matches create input");

--- a/src/test/java/unit/GcsBucketReferenced.java
+++ b/src/test/java/unit/GcsBucketReferenced.java
@@ -6,8 +6,10 @@ import static unit.GcsBucketControlled.listBucketResourcesWithName;
 import static unit.GcsBucketControlled.listOneBucketResourceWithName;
 
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
+import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import com.google.cloud.Identity;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
 import harness.TestCommand;
 import harness.TestUser;
@@ -55,6 +57,14 @@ public class GcsBucketReferenced extends SingleWorkspaceUnit {
     shareeUser.login();
     ExternalGCSBuckets.grantReadAccess(
         externalSharedBucket, Identity.group(Auth.getProxyGroupEmail()));
+
+    // Poll until the test user can fetch the actual GCS bucket, which may be delayed.
+    Bucket createdBucketOnCloud =
+        CrlUtils.callGcpWithRetries(
+            () ->
+                ExternalGCSBuckets.getStorageClient(
+                        shareeUser.getCredentialsWithCloudPlatformScope())
+                    .get(externalSharedBucket.getName()));
   }
 
   @AfterAll

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -9,11 +9,16 @@ import bio.terra.cli.serialization.userfacing.input.AddGitRepoParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
 import bio.terra.cli.serialization.userfacing.resource.UFBqDataset;
 import bio.terra.cli.service.WorkspaceManagerService;
+import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.StewardshipType;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.api.gax.paging.Page;
 import com.google.cloud.Identity;
+import com.google.cloud.storage.Bucket;
 import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import harness.TestCommand;
 import harness.TestContext;
 import harness.baseclasses.SingleWorkspaceUnit;
@@ -186,18 +191,31 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("`gsutil ls` and `gcloud alpha storage ls`")
-  void gsutilGcloudAlphaStorageLs() throws IOException {
+  void gsutilGcloudAlphaStorageLs() throws IOException, InterruptedException {
 
     workspaceCreator.login(/*writeGcloudAuthFiles=*/ true);
 
     // `terra workspace set --id=$id`
-    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
+    UFWorkspace createdWorkspace =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFWorkspace.class, "workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName --format=json`
     String name = "resourceName";
     String bucketName = UUID.randomUUID().toString();
     TestCommand.runCommandExpectSuccess(
         "resource", "create", "gcs-bucket", "--name=" + name, "--bucket-name=" + bucketName);
+
+    Storage localProjectStorageClient =
+        StorageOptions.newBuilder()
+            .setProjectId(createdWorkspace.googleProjectId)
+            .setCredentials(workspaceCreator.getCredentialsWithCloudPlatformScope())
+            .build()
+            .getService();
+
+    // Poll until the test user can list GCS buckets in the workspace project, which may be delayed.
+    Page<Bucket> createdBucketOnCloud =
+        CrlUtils.callGcpWithRetries(localProjectStorageClient::list);
 
     // `terra gsutil ls`
     TestCommand.Result cmd = TestCommand.runCommand("gsutil", "ls");


### PR DESCRIPTION
GCP has been slow to propagate IAM permissions for the past ~week and a number of CLI tests have been failing as a result. This adds polling to the appropriate places to verify that a user has permission in a project.