### PR TITLE
[PF-2273] Remove deprecated server names

### DIFF
--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,11 +1,9 @@
 [
   "broad-dev.json",
   "broad-dev-cli-testing.json",
-  "broad-dev-jcarlton.json",
   "broad-dev-local-wsm.json",
   "broad-dev-local-sam.json",
   "broad-dev-mmedlock.json",
-  "broad-dev-wchamber.json",
   "broad-dev-zloery.json",
   "broad-wsmtest.json",
   "verily.json",


### PR DESCRIPTION
Remove deprecated server names from the list of all servers. 
The config of removed server names were removed as part of - https://github.com/DataBiosphere/terra-cli/pull/366