### PR TITLE
[TERRA-204] Add support in CLI to fetch AWS credentials from WSM

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -217,8 +217,6 @@ public class User {
       return;
     }
 
-    // TODO(TERRA-204) get SaEmail for AWS
-
     // ask SAM for the project-specific pet SA email and persist it on disk
     petSAEmail = SamService.forUser(this).getPetSaEmailForProject(googleProjectId);
     Context.setUser(this);
@@ -350,7 +348,6 @@ public class User {
 
   /** Get the access token for the pet SA credentials. */
   public AccessToken getPetSaAccessToken() {
-    // TODO(TERRA-204) get SaToken for AWS
     String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
     String accessTokenStr =
         SamService.forUser(this).getPetSaAccessTokenForProject(googleProjectId, PET_SA_SCOPES);

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
  */
 public class GcpNotebook extends Resource {
   private static final Logger logger = LoggerFactory.getLogger(GcpNotebook.class);
-  private String projectId;
-  private String instanceId;
-  private String location;
+  private final String projectId;
+  private final String instanceId;
+  private final String location;
 
   /** Deserialize an instance of the disk format to the internal object. */
   public GcpNotebook(PDGcpNotebook configFromDisk) {

--- a/src/main/java/bio/terra/cli/command/notebook/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Start.java
@@ -12,7 +12,6 @@ import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.workspace.model.AwsCredential;
 import bio.terra.workspace.model.CloudPlatform;
-import com.google.api.client.util.Strings;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebook start" command. */
@@ -40,12 +39,6 @@ public class Start extends BaseCommand {
           WorkspaceManagerService.fromContext()
               .getAwsSageMakerNotebookCredential(workspace.getUuid(), awsNotebook.getId());
 
-      OUT.println(
-          String.format(
-              "TEST log: (start) Fetched awsCredential with nonEmpty fields - keyId: %b, accessKey: %b, sessionToken: %b",
-              !Strings.isNullOrEmpty(awsCredential.getAccessKeyId()),
-              !Strings.isNullOrEmpty(awsCredential.getSecretAccessKey()),
-              !Strings.isNullOrEmpty(awsCredential.getSessionToken())));
       /*
       AwsNotebookInstanceName instanceName =
           instanceOption.toAwsNotebookInstanceName(Context.requireWorkspace(), awsNotebook);

--- a/src/main/java/bio/terra/cli/command/notebook/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Start.java
@@ -1,18 +1,24 @@
 package bio.terra.cli.command.notebook;
 
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.businessobject.resource.AwsNotebook;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.NotebookInstance;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.GoogleNotebooks;
+import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.cloudres.google.notebooks.InstanceName;
+import bio.terra.workspace.model.AwsCredential;
+import bio.terra.workspace.model.CloudPlatform;
+import com.google.api.client.util.Strings;
 import picocli.CommandLine;
 
-// TODO(TERRA-197)
 /** This class corresponds to the third-level "terra notebook start" command. */
 @CommandLine.Command(
     name = "start",
-    description = "Start a stopped GCP Notebook instance within your workspace.",
+    description = "Start a stopped Notebook instance within your workspace.",
     showDefaultValues = true)
 public class Start extends BaseCommand {
   @CommandLine.Mixin NotebookInstance instanceOption;
@@ -21,9 +27,38 @@ public class Start extends BaseCommand {
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    InstanceName instanceName = instanceOption.toInstanceName();
-    GoogleNotebooks notebooks = new GoogleNotebooks(Context.requireUser().getPetSACredentials());
-    notebooks.start(instanceName);
+    Workspace workspace = Context.requireWorkspace();
+
+    if (workspace.getCloudPlatform() == CloudPlatform.GCP) {
+      InstanceName instanceName = instanceOption.toGcpNotebookInstanceName();
+      GoogleNotebooks notebooks = new GoogleNotebooks(Context.requireUser().getPetSACredentials());
+      notebooks.start(instanceName);
+
+    } else if (workspace.getCloudPlatform() == CloudPlatform.AWS) {
+      AwsNotebook awsNotebook = instanceOption.toAwsNotebookResource();
+      AwsCredential awsCredential =
+          WorkspaceManagerService.fromContext()
+              .getAwsSageMakerNotebookCredential(workspace.getUuid(), awsNotebook.getId());
+
+      OUT.println(
+          String.format(
+              "TEST log: (start) Fetched awsCredential with nonEmpty fields - keyId: %b, accessKey: %b, sessionToken: %b",
+              !Strings.isNullOrEmpty(awsCredential.getAccessKeyId()),
+              !Strings.isNullOrEmpty(awsCredential.getSecretAccessKey()),
+              !Strings.isNullOrEmpty(awsCredential.getSessionToken())));
+      /*
+      AwsNotebookInstanceName instanceName =
+          instanceOption.toAwsNotebookInstanceName(Context.requireWorkspace(), awsNotebook);
+      AmazonNotebooks notebooks =
+          new AmazonNotebooks(awsCredential);
+      notebooks.start(instanceName);
+       */
+
+    } else {
+      throw new UserActionableException(
+          "Notebooks not supported on workspace cloud platform " + workspace.getCloudPlatform());
+    }
+
     OUT.println("Notebook instance starting. It may take a few minutes before it is available");
   }
 }

--- a/src/main/java/bio/terra/cli/command/notebook/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Stop.java
@@ -12,7 +12,6 @@ import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.workspace.model.AwsCredential;
 import bio.terra.workspace.model.CloudPlatform;
-import com.google.api.client.util.Strings;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebook stop" command. */
@@ -39,13 +38,6 @@ public class Stop extends BaseCommand {
       AwsCredential awsCredential =
           WorkspaceManagerService.fromContext()
               .getAwsSageMakerNotebookCredential(workspace.getUuid(), awsNotebook.getId());
-
-      OUT.println(
-          String.format(
-              "TEST log: (stop) Fetched awsCredential with nonEmpty fields - keyId: %b, accessKey: %b, sessionToken: %b",
-              !Strings.isNullOrEmpty(awsCredential.getAccessKeyId()),
-              !Strings.isNullOrEmpty(awsCredential.getSecretAccessKey()),
-              !Strings.isNullOrEmpty(awsCredential.getSessionToken())));
 
       /*
       AwsNotebookInstanceName instanceName =

--- a/src/main/java/bio/terra/cli/command/notebook/Stop.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Stop.java
@@ -1,17 +1,24 @@
 package bio.terra.cli.command.notebook;
 
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.businessobject.resource.AwsNotebook;
 import bio.terra.cli.command.shared.BaseCommand;
 import bio.terra.cli.command.shared.options.NotebookInstance;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.GoogleNotebooks;
+import bio.terra.cli.service.WorkspaceManagerService;
 import bio.terra.cloudres.google.notebooks.InstanceName;
+import bio.terra.workspace.model.AwsCredential;
+import bio.terra.workspace.model.CloudPlatform;
+import com.google.api.client.util.Strings;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebook stop" command. */
 @CommandLine.Command(
     name = "stop",
-    description = "Stop a running GCP Notebook instance within your workspace.",
+    description = "Stop a running Notebook instance within your workspace.",
     showDefaultValues = true)
 public class Stop extends BaseCommand {
   @CommandLine.Mixin NotebookInstance instanceOption;
@@ -20,9 +27,39 @@ public class Stop extends BaseCommand {
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    InstanceName instanceName = instanceOption.toInstanceName();
-    GoogleNotebooks notebooks = new GoogleNotebooks(Context.requireUser().getPetSACredentials());
-    notebooks.stop(instanceName);
+    Workspace workspace = Context.requireWorkspace();
+
+    if (workspace.getCloudPlatform() == CloudPlatform.GCP) {
+      InstanceName instanceName = instanceOption.toGcpNotebookInstanceName();
+      GoogleNotebooks notebooks = new GoogleNotebooks(Context.requireUser().getPetSACredentials());
+      notebooks.stop(instanceName);
+
+    } else if (workspace.getCloudPlatform() == CloudPlatform.AWS) {
+      AwsNotebook awsNotebook = instanceOption.toAwsNotebookResource();
+      AwsCredential awsCredential =
+          WorkspaceManagerService.fromContext()
+              .getAwsSageMakerNotebookCredential(workspace.getUuid(), awsNotebook.getId());
+
+      OUT.println(
+          String.format(
+              "TEST log: (stop) Fetched awsCredential with nonEmpty fields - keyId: %b, accessKey: %b, sessionToken: %b",
+              !Strings.isNullOrEmpty(awsCredential.getAccessKeyId()),
+              !Strings.isNullOrEmpty(awsCredential.getSecretAccessKey()),
+              !Strings.isNullOrEmpty(awsCredential.getSessionToken())));
+
+      /*
+      AwsNotebookInstanceName instanceName =
+          instanceOption.toAwsNotebookInstanceName(Context.requireWorkspace(), awsNotebook);
+      AmazonNotebooks notebooks =
+          new AmazonNotebooks(awsCredential);
+      notebooks.stop(instanceName);
+       */
+
+    } else {
+      throw new UserActionableException(
+          "Notebooks not supported on workspace cloud platform " + workspace.getCloudPlatform());
+    }
+
     OUT.println("Notebook instance stopped");
   }
 }

--- a/src/main/java/bio/terra/cli/command/shared/options/NotebookInstance.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/NotebookInstance.java
@@ -3,12 +3,11 @@ package bio.terra.cli.command.shared.options;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.businessobject.resource.AwsNotebook;
 import bio.terra.cli.businessobject.resource.GcpNotebook;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import picocli.CommandLine;
-
-// TODO(TERRA-197)
 
 /**
  * Command helper class for identifying a notebook by either the workspace resource name or the GCP
@@ -17,44 +16,62 @@ import picocli.CommandLine;
  * <p>This class is meant to be used as a @CommandLine.Mixin.
  */
 public class NotebookInstance {
-  @CommandLine.Option(
-      names = "--location",
-      defaultValue = "us-central1-a",
-      description = "The Google Cloud location of the instance (if using --instance-id).")
-  public String location;
-
   @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
   ArgGroup argGroup;
 
-  public InstanceName toInstanceName() {
+  public InstanceName toGcpNotebookInstanceName() {
     Workspace workspace = Context.requireWorkspace();
-    if (argGroup.resourceName != null) {
-      Resource resource = workspace.getResource(argGroup.resourceName);
-      if (!resource.getResourceType().equals(Resource.Type.AI_NOTEBOOK)) {
-        throw new UserActionableException(
-            "Only able to use notebook commands on notebook resources, but specified resource is "
-                + resource.getResourceType());
-      }
+    Resource resource =
+        (argGroup.resourceName != null)
+            ? workspace.getResource(argGroup.resourceName)
+            : workspace.getResource(argGroup.instanceId);
+
+    if (resource.getResourceType().equals(Resource.Type.AI_NOTEBOOK)) {
       GcpNotebook gcpNotebook = (GcpNotebook) resource;
       return InstanceName.builder()
-          .projectId(gcpNotebook.getProjectId())
+          .projectId(workspace.getGoogleProjectId())
           .location(gcpNotebook.getLocation())
           .instanceId(gcpNotebook.getInstanceId())
           .build();
     } else {
-      return InstanceName.builder()
-          .projectId(workspace.getGoogleProjectId())
-          .location(location)
-          .instanceId(argGroup.instanceId)
-          .build();
+      throw new UserActionableException(
+          "Only able to use notebook commands on AI Notebook resources, but specified resource is "
+              + resource.getResourceType());
     }
   }
+
+  public AwsNotebook toAwsNotebookResource() {
+    Workspace workspace = Context.requireWorkspace();
+    Resource resource =
+        (argGroup.resourceName != null)
+            ? workspace.getResource(argGroup.resourceName)
+            : workspace.getResource(argGroup.instanceId);
+
+    if (resource.getResourceType().equals(Resource.Type.AWS_SAGEMAKER_NOTEBOOK)) {
+      return (AwsNotebook) resource;
+    } else {
+      throw new UserActionableException(
+          "Only able to use notebook commands on SageMaker Notebook resources, but specified resource is "
+              + resource.getResourceType());
+    }
+  }
+
+  /*
+  public AwsNotebookInstanceName toAwsNotebookInstanceName(
+      Workspace workspace, AwsNotebook awsNotebook) {
+    return AwsNotebookInstanceName.builder()
+        .awsAccountNumber(workspace.getAwsAccountNumber())
+        .landingZoneId(workspace.getLandingZoneId())
+        .location(awsNotebook.getLocation())
+        .instanceId(awsNotebook.getInstanceId())
+        .build();
+  }
+   */
 
   static class ArgGroup {
     @CommandLine.Option(
         names = "--name",
-        description =
-            "Name of the resource, scoped to the workspace. Only alphanumeric and underscore characters are permitted.")
+        description = "Name of the resource, scoped to the workspace.")
     public String resourceName;
 
     @CommandLine.Option(names = "--instance-id", description = "The id of the notebook instance.")

--- a/src/main/java/bio/terra/cli/service/AmazonCloudStorage.java
+++ b/src/main/java/bio/terra/cli/service/AmazonCloudStorage.java
@@ -26,8 +26,7 @@ public class AmazonCloudStorage {
   private static final Logger logger = LoggerFactory.getLogger(AmazonCloudStorage.class);
   private final StorageCow storage; // TODO(TERRA-206) change to AWS *Cow
 
-  private AmazonCloudStorage(
-      GoogleCredentials credentials) { // TODO(TERRA-204) change to AWS credentials
+  private AmazonCloudStorage(GoogleCredentials credentials) {
     storage = CrlUtils.createStorageCow(credentials);
   }
 

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -484,8 +484,6 @@ public class SamService {
         "Error getting pet SA access token for project from SAM.");
   }
 
-  // TODO(TERRA-204) set up getPetSaEmailForProject & getPetSaAccessTokenForProject for AWS
-
   /**
    * Execute a function that includes hitting SAM endpoints. Retry if the function throws an {@link
    * #isRetryable} exception. If an exception is thrown by the SAM client or the retries, make sure

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -40,6 +40,8 @@ import bio.terra.workspace.client.ApiClient;
 import bio.terra.workspace.client.ApiException;
 import bio.terra.workspace.model.AwsBucketCreationParameters;
 import bio.terra.workspace.model.AwsBucketResource;
+import bio.terra.workspace.model.AwsCredential;
+import bio.terra.workspace.model.AwsCredentialAccessScope;
 import bio.terra.workspace.model.AwsSageMakerNotebookCreationParameters;
 import bio.terra.workspace.model.AwsSageMakerNotebookResource;
 import bio.terra.workspace.model.CloneWorkspaceRequest;
@@ -142,6 +144,8 @@ public class WorkspaceManagerService {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceManagerService.class);
   // maximum number of resources to fetch per call to the enumerate endpoint
   private static final int MAX_RESOURCES_PER_ENUMERATE_REQUEST = 100;
+  // default credential expiration duration
+  private static final int DEFAULT_AWS_CREDENTIAL_EXPIRATION_SECONDS = 900;
   // the Terra environment where the WSM service lives
   private final Server server;
   // the client object used for talking to WSM
@@ -904,6 +908,43 @@ public class WorkspaceManagerService {
     return callWithRetries(
         () -> new ResourceApi(apiClient).checkReferenceAccess(workspaceId, resourceId),
         "Error checking access to resource.");
+  }
+
+  /**
+   * Call the Workspace Manager
+   * "/api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getCredential"
+   * endpoint to get AWS credentials to access the controlled notebook
+   *
+   * @param workspaceId the workspace that contains the resource
+   * @param resourceId the resource id
+   * @return AWS sagemaker notebook access credentials
+   */
+  public AwsCredential getAwsSageMakerNotebookCredential(UUID workspaceId, UUID resourceId) {
+    return getAwsSageMakerNotebookCredential(
+        workspaceId,
+        resourceId,
+        AwsCredentialAccessScope.READ_ONLY,
+        DEFAULT_AWS_CREDENTIAL_EXPIRATION_SECONDS);
+  }
+
+  /**
+   * Call the Workspace Manager
+   * "/api/workspaces/v1/{workspaceId}/resources/controlled/aws/sagemaker-notebooks/{resourceId}/getCredential"
+   * endpoint to get AWS credentials to access the controlled notebook
+   *
+   * @param workspaceId the workspace that contains the resource
+   * @param resourceId the resource id
+   * @param accessScope the access scope (READ_ONLY, WRITE_READ)
+   * @param duration the duration for credential in seconds
+   * @return AWS sagemaker notebook access credentials
+   */
+  public AwsCredential getAwsSageMakerNotebookCredential(
+      UUID workspaceId, UUID resourceId, AwsCredentialAccessScope accessScope, Integer duration) {
+    return callWithRetries(
+        () ->
+            new ControlledAwsResourceApi(apiClient)
+                .getAwsSageMakerNotebookCredential(workspaceId, resourceId, accessScope, duration),
+        "Error getting AWS SageMaker Notebook credential.");
   }
 
   /**

--- a/src/main/resources/servers/all-servers.json
+++ b/src/main/resources/servers/all-servers.json
@@ -1,11 +1,9 @@
 [
   "broad-dev.json",
   "broad-dev-cli-testing.json",
-  "broad-dev-jcarlton.json",
   "broad-dev-local-wsm.json",
   "broad-dev-local-sam.json",
   "broad-dev-mmedlock.json",
-  "broad-dev-wchamber.json",
   "broad-dev-zloery.json",
   "broad-wsmtest.json",
   "verily.json",


### PR DESCRIPTION


test - 
```
terra-cli (dexamundsen/mc-204) >> terra workspace set --id=test-ws-3
Workspace successfully loaded.
ID:                test-ws-3
Name:              
Description:       
AWS account:       639879951631
Landing Zone Id:   9153e570-9616-6577-4522-16b49993e2d5
Cloud console:     https://639879951631.signin.aws.amazon.com/console/
Created:           2022-11-30
Last updated:      2022-12-01
# Resources:       5
terra-cli (dexamundsen/mc-204) >> terra resource list
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION                             
note-1                          AWS_SAGEMAKER_NOT...  CONTROLLED            (unset)                                 
note-2                          AWS_SAGEMAKER_NOT...  CONTROLLED            (unset)                                 
note-2-a                        AWS_SAGEMAKER_NOT...  CONTROLLED            (unset)                                 
note-2-b                        AWS_SAGEMAKER_NOT...  CONTROLLED            (unset)                                 
sagemaker-nb-221129             AWS_SAGEMAKER_NOT...  CONTROLLED            string                                  
terra-cli (dexamundsen/mc-204) >> terra notebook start --name=sagemaker-nb-221129
TEST log: (start) Fetched awsCredential with nonEmpty fields - keyId: true, accessKey: true, sessionToken: true
Notebook instance starting. It may take a few minutes before it is available
terra-cli (dexamundsen/mc-204) >> terra notebook stop --name=sagemaker-nb-221129
TEST log: (stop) Fetched awsCredential with nonEmpty fields - keyId: true, accessKey: true, sessionToken: true
Notebook instance stopped

```