### PR TITLE
[PF-2348] Wrap command tokens with quotes

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,13 @@ public abstract class CommandRunner {
     String fullCommand = "";
     if (command != null && command.size() > 0) {
       final String argSeparator = " ";
-      fullCommand += argSeparator + String.join(argSeparator, command);
+      fullCommand +=
+          argSeparator
+              + String.join(
+                  argSeparator,
+                  command.stream()
+                      .map(i -> "\"" + i.replace("\"", "\\\"") + "\"")
+                      .collect(Collectors.toList()));
     }
     return fullCommand;
   }


### PR DESCRIPTION
Previously, running a command like 
`terra gcloud compute ssh --zone us-central1-a jupyter@newenv --command "ps aux"`
 would fail to parse, as the space information in the quoted part would be lost when the command is built.