### PR TITLE
[PF-2375] Add retries with sleep to address test failures 

### DIFF
--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -120,6 +121,21 @@ public class TestCommand {
   public static Result runAndGetResultExpectSuccess(String... args) {
     Result cmd = runCommand(args);
     assertEquals(0, cmd.exitCode, "exit code = success");
+    return cmd;
+  }
+
+  /** Helper method to run a command, parse stdout for error strings and retry upto the limit */
+  public static Result runAndGetResultWithRetries(
+      String retryString, int maxTries, Duration sleepDuration, String... args)
+      throws InterruptedException {
+    Result cmd = null;
+    do {
+      cmd = runCommand(args);
+      if ((cmd.exitCode == 0) || !cmd.stdOut.contains(retryString)) {
+        return cmd;
+      }
+      Thread.sleep(sleepDuration.toMillis());
+    } while (maxTries-- > 1);
     return cmd;
   }
 

--- a/src/test/java/harness/utils/ExternalBQDatasets.java
+++ b/src/test/java/harness/utils/ExternalBQDatasets.java
@@ -199,16 +199,13 @@ public class ExternalBQDatasets {
 
     // retry forbidden errors because we often see propagation delays when a user is just granted
     // access
-    HttpUtils.callWithRetries(
-        () -> {
-          return bqClient.getDataset(datasetId);
-        },
+    return HttpUtils.callWithRetries(
+        () -> bqClient.getDataset(datasetId),
         (ex) ->
             (ex instanceof BigQueryException)
                 && ((BigQueryException) ex).getCode() == HttpStatus.SC_FORBIDDEN,
         5,
         Duration.ofMinutes(1));
-    return null;
   }
 
   /**

--- a/src/test/java/harness/utils/ExternalBQDatasets.java
+++ b/src/test/java/harness/utils/ExternalBQDatasets.java
@@ -205,7 +205,7 @@ public class ExternalBQDatasets {
             (ex instanceof BigQueryException)
                 && ((BigQueryException) ex).getCode() == HttpStatus.SC_FORBIDDEN,
         5,
-        Duration.ofMinutes(1));
+        Duration.ofSeconds(30));
   }
 
   /**

--- a/src/test/java/harness/utils/ExternalBQDatasets.java
+++ b/src/test/java/harness/utils/ExternalBQDatasets.java
@@ -12,6 +12,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
@@ -189,6 +190,25 @@ public class ExternalBQDatasets {
                 && ((BigQueryException) ex).getCode() == HttpStatus.SC_FORBIDDEN,
         5,
         Duration.ofMinutes(1));
+  }
+
+  /** Utility method to get an arbitrary dataset. */
+  public static com.google.cloud.bigquery.Dataset getDataset(
+      GoogleCredentials credentials, DatasetId datasetId) throws InterruptedException {
+    BigQuery bqClient = getBQClient(credentials);
+
+    // retry forbidden errors because we often see propagation delays when a user is just granted
+    // access
+    HttpUtils.callWithRetries(
+        () -> {
+          return bqClient.getDataset(datasetId);
+        },
+        (ex) ->
+            (ex instanceof BigQueryException)
+                && ((BigQueryException) ex).getCode() == HttpStatus.SC_FORBIDDEN,
+        5,
+        Duration.ofMinutes(1));
+    return null;
   }
 
   /**

--- a/src/test/java/unit/BqDatasetControlled.java
+++ b/src/test/java/unit/BqDatasetControlled.java
@@ -275,7 +275,7 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create a controlled dataset, specifying all options")
-  void createWithAllOptions() throws IOException {
+  void createWithAllOptions() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id --format=json`
@@ -318,8 +318,9 @@ public class BqDatasetControlled extends SingleWorkspaceUnit {
         "create output matches private user name");
 
     Dataset createdDatasetOnCloud =
-        ExternalBQDatasets.getBQClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
-            .getDataset(DatasetId.of(workspace.googleProjectId, datasetId));
+        ExternalBQDatasets.getDataset(
+            workspaceCreator.getCredentialsWithCloudPlatformScope(),
+            DatasetId.of(workspace.googleProjectId, datasetId));
     assertNotNull(createdDatasetOnCloud, "looking up dataset via BQ API succeeded");
     assertEquals(
         location, createdDatasetOnCloud.getLocation(), "dataset location matches create input");

--- a/src/test/java/unit/BqDatasetLifetime.java
+++ b/src/test/java/unit/BqDatasetLifetime.java
@@ -44,7 +44,8 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create with default partition lifetime only")
-  void createWithDefaultPartitionLifetime(TestInfo testInfo) throws IOException {
+  void createWithDefaultPartitionLifetime(TestInfo testInfo)
+      throws IOException, InterruptedException {
 
     final String name = testInfo.getTestMethod().orElseThrow().getName();
     final Duration lifetime = Duration.ofSeconds(9600);
@@ -58,7 +59,7 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create with default table lifetime only")
-  void createWithDefaultTableLifetime(TestInfo testInfo) throws IOException {
+  void createWithDefaultTableLifetime(TestInfo testInfo) throws IOException, InterruptedException {
 
     final String name = testInfo.getTestMethod().orElseThrow().getName();
     final Duration lifetime = Duration.ofHours(2);
@@ -72,7 +73,7 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create with both default lifetimes")
-  void createWithBothDefaultLifetimes(TestInfo testInfo) throws IOException {
+  void createWithBothDefaultLifetimes(TestInfo testInfo) throws IOException, InterruptedException {
     final String name = testInfo.getTestMethod().orElseThrow().getName();
     final Duration partitionLifetime = Duration.ofSeconds(9600);
     final Duration tableLifetime = Duration.ofSeconds(4800);
@@ -88,7 +89,7 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("create with no default lifetimes and test update calls")
-  void updateDefaultLifetimes(TestInfo testInfo) throws IOException {
+  void updateDefaultLifetimes(TestInfo testInfo) throws IOException, InterruptedException {
     final String name = testInfo.getTestMethod().orElseThrow().getName();
     final Duration partitionLifetime = Duration.ofSeconds(9600);
     final Duration tableLifetime = Duration.ofSeconds(4800);
@@ -179,13 +180,13 @@ public class BqDatasetLifetime extends SingleWorkspaceUnit {
       UFBqDataset bqDataset,
       @Nullable Long defaultPartitionLifetimeMilliseconds,
       @Nullable Long defaultTableLifetimeMilliseconds)
-      throws IOException {
+      throws IOException, InterruptedException {
 
     DatasetId datasetId = DatasetId.of(bqDataset.projectId, bqDataset.datasetId);
 
     Dataset dataset =
-        ExternalBQDatasets.getBQClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
-            .getDataset(datasetId);
+        ExternalBQDatasets.getDataset(
+            workspaceCreator.getCredentialsWithCloudPlatformScope(), datasetId);
 
     assertNotNull(dataset, "looking up dataset via BQ API succeeded");
     assertEquals(dataset.getDefaultPartitionExpirationMs(), defaultPartitionLifetimeMilliseconds);

--- a/src/test/java/unit/BqDatasetNumTables.java
+++ b/src/test/java/unit/BqDatasetNumTables.java
@@ -74,8 +74,13 @@ public class BqDatasetNumTables extends SingleWorkspaceUnit {
             "--name=" + name,
             "--dataset-id=" + datasetId);
 
+    // `terra resource describe --name=$name`
+    UFBqDataset describedDataset =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFBqDataset.class, "resource", "describe", "--name=" + name);
+
     // check that there are initially 0 tables reported in the dataset
-    assertEquals(0, createdDataset.numTables, "created dataset contains 0 tables");
+    assertEquals(0, describedDataset.numTables, "created dataset contains 0 tables");
 
     // create a table in the dataset
     String tableName = "testTable";
@@ -86,7 +91,7 @@ public class BqDatasetNumTables extends SingleWorkspaceUnit {
         tableName);
 
     // `terra resource describe --name=$name`
-    UFBqDataset describedDataset =
+    describedDataset =
         TestCommand.runAndParseCommandExpectSuccess(
             UFBqDataset.class, "resource", "describe", "--name=" + name);
 

--- a/src/test/java/unit/GcsBucketControlled.java
+++ b/src/test/java/unit/GcsBucketControlled.java
@@ -249,7 +249,7 @@ public class GcsBucketControlled extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("create a controlled bucket, specifying all options except lifecycle")
-  void createWithAllOptionsExceptLifecycle() throws IOException {
+  void createWithAllOptionsExceptLifecycle() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
@@ -291,8 +291,9 @@ public class GcsBucketControlled extends SingleWorkspaceUnitGcp {
         "create output matches private user name");
 
     Bucket createdBucketOnCloud =
-        ExternalGCSBuckets.getStorageClient(workspaceCreator.getCredentialsWithCloudPlatformScope())
-            .get(bucketName);
+        ExternalGCSBuckets.getBucket(
+            workspaceCreator.getCredentialsWithCloudPlatformScope(), bucketName);
+
     assertNotNull(createdBucketOnCloud, "looking up bucket via GCS API succeeded");
     assertEquals(
         location, createdBucketOnCloud.getLocation(), "bucket location matches create input");

--- a/src/test/java/unit/GcsBucketLifecycle.java
+++ b/src/test/java/unit/GcsBucketLifecycle.java
@@ -93,7 +93,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle action delete (condition age)")
-  void deleteAction() throws IOException {
+  void deleteAction() throws IOException, InterruptedException {
     String name = "delete_age";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -104,7 +104,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle action set storage class (condition age)")
-  void setStorageClassAction() throws IOException {
+  void setStorageClassAction() throws IOException, InterruptedException {
     String name = "setStorageClass_age";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -115,7 +115,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition created before (action delete)")
-  void createdBeforeCondition() throws IOException {
+  void createdBeforeCondition() throws IOException, InterruptedException {
     String name = "delete_createdBefore";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -129,7 +129,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition custom time before (action delete)")
-  void customTimeBeforeCondition() throws IOException {
+  void customTimeBeforeCondition() throws IOException, InterruptedException {
     String name = "delete_customTimeBefore";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -143,7 +143,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition days since custom time (action delete)")
-  void daysSinceCustomTimeCondition() throws IOException {
+  void daysSinceCustomTimeCondition() throws IOException, InterruptedException {
     String name = "delete_daysSinceCustomTime";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -157,7 +157,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition days since noncurrent time (action delete)")
-  void daysSinceNoncurrentTimeCondition() throws IOException {
+  void daysSinceNoncurrentTimeCondition() throws IOException, InterruptedException {
     String name = "delete_daysSinceNoncurrentTime";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -171,7 +171,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition is live (action set storage class)")
-  void isLiveCondition() throws IOException {
+  void isLiveCondition() throws IOException, InterruptedException {
     String name = "setStorageClass_isLive";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -182,7 +182,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition matches storage class (action set storage class)")
-  void matchesStorageClassCondition() throws IOException {
+  void matchesStorageClassCondition() throws IOException, InterruptedException {
     String name = "setStorageClass_matchesStorageClass";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -198,7 +198,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition noncurrent time before (action set storage class)")
-  void noncurrentTimeBeforeCondition() throws IOException {
+  void noncurrentTimeBeforeCondition() throws IOException, InterruptedException {
     String name = "setStorageClass_noncurrentTimeBefore";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -212,7 +212,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("lifecycle condition number of newer versions (action set storage class)")
-  void numberOfNewerVerionsCondition() throws IOException {
+  void numberOfNewerVerionsCondition() throws IOException, InterruptedException {
     String name = "setStorageClass_numNewerVersions";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -226,7 +226,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("auto-delete option")
-  void autoDeleteOption() throws IOException {
+  void autoDeleteOption() throws IOException, InterruptedException {
     String resourceName = "autodelete";
     String bucketName = UUID.randomUUID().toString();
     int autoDeleteAgeDays = 24;
@@ -254,7 +254,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("multiple lifecycle conditions in one rule")
-  void multipleConditions() throws IOException {
+  void multipleConditions() throws IOException, InterruptedException {
     String name = "multipleConditions";
     BucketInfo.LifecycleRule lifecycleRuleFromGCS =
         createBucketWithOneLifecycleRule(name, name + ".json");
@@ -275,7 +275,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("multiple lifecycle rules")
-  void multipleRules() throws IOException {
+  void multipleRules() throws IOException, InterruptedException {
     String name = "multipleRules";
     List<? extends BucketInfo.LifecycleRule> lifecycleRules =
         createBucketWithLifecycleRules(name, name + ".json");
@@ -284,7 +284,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("update the bucket lifecycle rule")
-  void update() throws IOException {
+  void update() throws IOException, InterruptedException {
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName
     // --lifecycle=$lifecycle1 --cloning=COPY_DEFINITION`
     String resourceName = "bucketToUpdate";
@@ -327,7 +327,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("remove the bucket lifecycle rule")
-  void remove() throws IOException {
+  void remove() throws IOException, InterruptedException {
     // `terra resource create gcs-bucket --name=$name --bucket-name=$bucketName
     // --lifecycle=$lifecycle1`
     String resourceName = "remove";
@@ -363,7 +363,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
    * <p>- Expects that there is a single lifecycle rule, and returns it.
    */
   private BucketInfo.LifecycleRule createBucketWithOneLifecycleRule(
-      String resourceName, String lifecycleFilename) throws IOException {
+      String resourceName, String lifecycleFilename) throws IOException, InterruptedException {
     List<? extends BucketInfo.LifecycleRule> lifecycleRules =
         createBucketWithLifecycleRules(resourceName, lifecycleFilename);
 
@@ -380,7 +380,7 @@ public class GcsBucketLifecycle extends SingleWorkspaceUnitGcp {
    * <p>- Queries GCS directly for the lifecycle rules on the bucket, and returns them.
    */
   private List<? extends BucketInfo.LifecycleRule> createBucketWithLifecycleRules(
-      String resourceName, String lifecycleFilename) throws IOException {
+      String resourceName, String lifecycleFilename) throws IOException, InterruptedException {
     String bucketName = UUID.randomUUID().toString();
     Path lifecycle = TestCommand.getPathForTestInput("gcslifecycle/" + lifecycleFilename);
 

--- a/src/test/java/unit/GcsBucketNumObjects.java
+++ b/src/test/java/unit/GcsBucketNumObjects.java
@@ -88,8 +88,13 @@ public class GcsBucketNumObjects extends SingleWorkspaceUnitGcp {
             "--name=" + name,
             "--bucket-name=" + bucketName);
 
+    // `terra resource describe --name=$name`
+    UFGcsBucket describedBucket =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGcsBucket.class, "resource", "describe", "--name=" + name);
+
     // check that there are initially 0 objects reported in the bucket
-    assertEquals(0, createdBucket.numObjects, "created bucket contains 0 objects");
+    assertEquals(0, describedBucket.numObjects, "created bucket contains 0 objects");
 
     // write a blob to the bucket
     String blobName = "testBlob";
@@ -97,7 +102,7 @@ public class GcsBucketNumObjects extends SingleWorkspaceUnitGcp {
         workspaceCreator.getCredentialsWithCloudPlatformScope(), bucketName, blobName);
 
     // `terra resource describe --name=$name`
-    UFGcsBucket describedBucket =
+    describedBucket =
         TestCommand.runAndParseCommandExpectSuccess(
             UFGcsBucket.class, "resource", "describe", "--name=" + name);
 

--- a/src/test/java/unit/PassthroughApps.java
+++ b/src/test/java/unit/PassthroughApps.java
@@ -389,7 +389,7 @@ public class PassthroughApps extends SingleWorkspaceUnit {
 
   @Test
   @DisplayName("CLI uses the same format as gsutil for setting lifecycle rules")
-  void sameFormatForExternalBucket() throws IOException {
+  void sameFormatForExternalBucket() throws IOException, InterruptedException {
     workspaceCreator.login(/*writeGcloudAuthFiles=*/ true);
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());

--- a/src/test/java/unit/WorkspaceGcp.java
+++ b/src/test/java/unit/WorkspaceGcp.java
@@ -132,15 +132,15 @@ public class WorkspaceGcp extends ClearContextUnit {
         "--dataset-id=" + datasetId);
 
     // `terra workspace describe`
-    Result describeResult2 = TestCommand.runCommand("workspace", "describe");
-    assertEquals(0, describeResult2.exitCode, "Describe was successful.");
+    Result describeResult = TestCommand.runCommand("workspace", "describe");
+    assertEquals(0, describeResult.exitCode, "Describe was successful.");
     assertThat(
         "workspace has 2 resources after creating dataset",
-        describeResult2.stdOut,
+        describeResult.stdOut,
         containsString("# Resources:       2"));
     assertThat(
         "No error message is displayed on second describe.",
-        describeResult2.stdErr,
+        describeResult.stdErr,
         is(emptyString()));
 
     UFWorkspace describedWorkspace3 =

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -20,6 +20,8 @@ terra status
 # Bucket names must be globally unique, so use a random UUID with the dashes removed for the bucket name.
 # Terra resource names must only be unique within the workspace, so use a fixed string for the resource name.
 
+terra workspace describe
+
 resourceName="terraclitesting"
 bucketName=$(uuidgen | tr "[:upper:]" "[:lower:]" | sed -e 's/-//g')
 echo "resourceName: $resourceName, bucketName: $bucketName"


### PR DESCRIPTION
Problem statement - propagation delays when a user is just granted access to an object result is 403 errors
Fix - Create a wrapper with http retries with sleep to retry the call 


[in progress] multiple flaky tests
