### PR TITLE
PF-1889: Do not cache workspace in context.json

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -88,7 +88,10 @@ public abstract class CommandRunner {
 
     terraEnvVars.put("TERRA_USER_EMAIL", Context.requireUser().getEmail());
     terraEnvVars.put("GOOGLE_SERVICE_ACCOUNT_EMAIL", Context.requireUser().getPetSaEmail());
-    terraEnvVars.put("GOOGLE_CLOUD_PROJECT", Context.requireWorkspace().getGoogleProjectId());
+    if (Context.requireWorkspace().getGoogleProjectId().isPresent()) {
+      terraEnvVars.put(
+          "GOOGLE_CLOUD_PROJECT", Context.requireWorkspace().getGoogleProjectId().get());
+    }
 
     for (Map.Entry<String, String> workspaceReferenceEnvVar : terraEnvVars.entrySet()) {
       if (envVars.get(workspaceReferenceEnvVar.getKey()) != null) {
@@ -139,7 +142,7 @@ public abstract class CommandRunner {
     // build a map of reference string -> resolved value
     Map<String, String> terraReferences = new HashMap<>();
     Context.requireWorkspace()
-        .listResourcesAndSync()
+        .listResources()
         .forEach(
             resource -> {
               String envVariable = convertToEnvironmentVariable(resource.getName());

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -134,7 +134,7 @@ public abstract class Resource {
   protected void updatePropertiesAndSync(UpdateResourceParams updateParams) {
     this.name = updateParams.name == null ? name : updateParams.name;
     this.description = updateParams.description == null ? description : updateParams.description;
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
   }
 
   /** Delete an existing resource in the workspace. */
@@ -149,7 +149,7 @@ public abstract class Resource {
       default:
         throw new IllegalArgumentException("Unknown stewardship type: " + stewardshipType);
     }
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
   }
 
   /** Call WSM to delete a referenced resource. */

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -209,7 +209,7 @@ public class User {
     // just log an error here instead of throwing an exception, so that the workspace load will
     // will succeed and the user can delete the corrupted workspace
     Workspace currentWorkspace = Context.requireWorkspace();
-    String googleProjectId = currentWorkspace.getGoogleProjectId();
+    String googleProjectId = currentWorkspace.getGoogleProjectId().orElse(null);
     if (Strings.isNullOrEmpty(googleProjectId)) {
       logger.error("No Google context for the current workspace. Skip fetching pet SA from SAM.");
       return;
@@ -346,7 +346,7 @@ public class User {
 
   /** Get the access token for the pet SA credentials. */
   public AccessToken getPetSaAccessToken() {
-    String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
+    String googleProjectId = Context.requireWorkspace().getRequiredGoogleProjectId();
     String accessTokenStr =
         SamService.forUser(this).getPetSaAccessTokenForProject(googleProjectId, PET_SA_SCOPES);
     return new AccessToken(accessTokenStr, null);

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -53,7 +53,6 @@ public class Workspace {
     } else if (wsmObject.getAzureContext() != null) {
       cloudPlatform = CloudPlatform.AZURE;
     }
-    }
   }
 
   /** Build an instance of this class from the serialized format on disk. */

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -2,7 +2,6 @@ package bio.terra.cli.businessobject;
 
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
-import bio.terra.cli.serialization.persisted.PDResource;
 import bio.terra.cli.serialization.persisted.PDWorkspace;
 import bio.terra.cli.service.SamService;
 import bio.terra.cli.service.WorkspaceManagerService;
@@ -23,9 +22,7 @@ import com.google.api.services.cloudresourcemanager.v3.model.SetIamPolicyRequest
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,64 +40,27 @@ public class Workspace {
   private static final Logger logger = LoggerFactory.getLogger(Workspace.class);
   private UUID uuid;
   private String userFacingId;
-  private String name; // not unique
-  private String description;
   private CloudPlatform cloudPlatform;
   private String googleProjectId;
-  private Map<String, String> properties;
-
-  // name of the server where this workspace exists
-  private String serverName;
-
-  // email of the user that loaded the workspace to this machine
-  private String userEmail;
-
-  // list of resources (controlled & referenced)
-  private List<Resource> resources;
-
-  private OffsetDateTime createdDate;
-  private OffsetDateTime lastUpdatedDate;
 
   /** Build an instance of this class from the WSM client library WorkspaceDescription object. */
   private Workspace(WorkspaceDescription wsmObject) {
     this.uuid = wsmObject.getId();
     this.userFacingId = wsmObject.getUserFacingId();
-    this.name = wsmObject.getDisplayName() == null ? "" : wsmObject.getDisplayName();
-    this.description = wsmObject.getDescription() == null ? "" : wsmObject.getDescription();
     if (wsmObject.getGcpContext() != null) {
-      this.cloudPlatform = CloudPlatform.GCP;
+      cloudPlatform = CloudPlatform.GCP;
+      googleProjectId = wsmObject.getGcpContext().getProjectId();
     } else if (wsmObject.getAzureContext() != null) {
-      this.cloudPlatform = CloudPlatform.AZURE;
-    } else {
-      throw new SystemException("CloudPlatform not initialized.");
+      cloudPlatform = CloudPlatform.AZURE;
     }
-    this.googleProjectId =
-        wsmObject.getGcpContext() == null ? null : wsmObject.getGcpContext().getProjectId();
-    this.properties = propertiesToStringMap(wsmObject.getProperties());
-    this.serverName = Context.getServer().getName();
-    this.userEmail = Context.requireUser().getEmail();
-    this.resources = new ArrayList<>();
-    this.createdDate = wsmObject.getCreatedDate();
-    this.lastUpdatedDate = wsmObject.getLastUpdatedDate();
   }
 
   /** Build an instance of this class from the serialized format on disk. */
   public Workspace(PDWorkspace configFromDisk) {
     this.uuid = configFromDisk.uuid;
     this.userFacingId = configFromDisk.userFacingId;
-    this.name = configFromDisk.name;
-    this.description = configFromDisk.description;
-    this.cloudPlatform = configFromDisk.cloudPlatform;
     this.googleProjectId = configFromDisk.googleProjectId;
-    this.properties = configFromDisk.properties;
-    this.serverName = configFromDisk.serverName;
-    this.userEmail = configFromDisk.userEmail;
-    this.resources =
-        configFromDisk.resources.stream()
-            .map(PDResource::deserializeToInternal)
-            .collect(Collectors.toList());
-    this.createdDate = configFromDisk.createdDate;
-    this.lastUpdatedDate = configFromDisk.lastUpdatedDate;
+    this.cloudPlatform = configFromDisk.cloudPlatform;
   }
 
   /** Create a new workspace and set it as the current workspace. */
@@ -152,7 +112,7 @@ public class Workspace {
     // call WSM to fetch the existing workspace object and backing Google context
     WorkspaceDescription loadedWorkspace = WorkspaceManagerService.fromContext().getWorkspace(id);
     logger.info("Loaded workspace: {}", loadedWorkspace);
-    return convertWorkspaceDescriptionToWorkspace(loadedWorkspace);
+    return new Workspace(loadedWorkspace);
   }
 
   /** Fetch an existing workspace by userFacingId, with resources populated */
@@ -161,15 +121,7 @@ public class Workspace {
     WorkspaceDescription loadedWorkspace =
         WorkspaceManagerService.fromContext().getWorkspaceByUserFacingId(userFacingId);
     logger.info("Loaded workspace: {}", loadedWorkspace);
-    return convertWorkspaceDescriptionToWorkspace(loadedWorkspace);
-  }
-
-  /** Convert what's returned from WSM API to CLI object. */
-  private static Workspace convertWorkspaceDescriptionToWorkspace(
-      WorkspaceDescription workspaceDescription) {
-    Workspace workspace = new Workspace(workspaceDescription);
-    workspace.populateResources();
-    return workspace;
+    return new Workspace(loadedWorkspace);
   }
 
   /**
@@ -290,49 +242,23 @@ public class Workspace {
   }
 
   /**
-   * Get a resource by name and expect a specific type.
-   *
-   * @throws UserActionableException if the resource is not found or is the wrong type
-   */
-  public <T extends Resource> T getResourceOfType(String name, Resource.Type type) {
-    Resource resource = getResource(name);
-    if (!resource.getResourceType().equals(type)) {
-      throw new UserActionableException("Invalid resource type: " + resource.getResourceType());
-    }
-    return (T) resource;
-  }
-
-  /**
    * Get a resource by name.
    *
    * @throws UserActionableException if there is no resource with that name
    */
   public Resource getResource(String name) {
     Optional<Resource> resourceOpt =
-        resources.stream().filter(resource -> resource.name.equals(name)).findFirst();
+        listResources().stream().filter(resource -> resource.name.equals(name)).findFirst();
     return resourceOpt.orElseThrow(
         () -> new UserActionableException("Resource not found: " + name));
   }
 
-  /** Populate the list of resources for this workspace. Does not sync to disk. */
-  private void populateResources() {
+  /** Fetch the list of resources for the current workspace. */
+  public List<Resource> listResources() {
     List<ResourceDescription> wsmObjects =
         WorkspaceManagerService.fromContext()
             .enumerateAllResources(uuid, Context.getConfig().getResourcesCacheSize());
-    List<Resource> resources =
-        wsmObjects.stream().map(Resource::deserializeFromWsm).collect(Collectors.toList());
-
-    this.resources = resources;
-  }
-
-  /**
-   * Fetch the list of resources for the current workspace. Sync the cached list of resources to
-   * disk.
-   */
-  public List<Resource> listResourcesAndSync() {
-    populateResources();
-    Context.synchronizeToDisk();
-    return resources;
+    return wsmObjects.stream().map(Resource::deserializeFromWsm).collect(Collectors.toList());
   }
 
   /** Fetch the list of folders for this workspace */
@@ -410,48 +336,22 @@ public class Workspace {
     return userFacingId;
   }
 
-  public String getName() {
-    return name;
+  public Optional<String> getGoogleProjectId() {
+    return Optional.ofNullable(googleProjectId);
   }
 
-  public String getDescription() {
-    return description;
+  public String getRequiredGoogleProjectId() {
+    return getGoogleProjectId()
+        .orElseThrow(
+            () ->
+                new UserActionableException("No GCP project available in the current workspace."));
   }
 
   public CloudPlatform getCloudPlatform() {
     return cloudPlatform;
   }
 
-  public String getGoogleProjectId() {
-    return googleProjectId;
-  }
-
-  public Map<String, String> getProperties() {
-    return properties;
-  }
-
-  public Optional<String> getProperty(String key) {
-    return Optional.ofNullable(properties.get(key));
-  }
-
-  public String getServerName() {
-    return serverName;
-  }
-
-  public String getUserEmail() {
-    return userEmail;
-  }
-
-  /** Calls listResourceAndSync instead if you care about the freshness of the resource list. */
-  public List<Resource> getResources() {
-    return Collections.unmodifiableList(resources);
-  }
-
-  public OffsetDateTime getCreatedDate() {
-    return createdDate;
-  }
-
-  public OffsetDateTime getLastUpdatedDate() {
-    return lastUpdatedDate;
+  public WorkspaceDescription getWorkspaceDescription() {
+    return WorkspaceManagerService.fromContext().getWorkspace(uuid);
   }
 }

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqDataset.java
@@ -71,7 +71,7 @@ public class BqDataset extends Resource {
     logger.info("Created BQ dataset: {}", addedResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new BqDataset(addedResource);
   }
 
@@ -90,7 +90,7 @@ public class BqDataset extends Resource {
     logger.info("Created BQ dataset: {}", createdResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new BqDataset(createdResource);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/BqTable.java
@@ -64,7 +64,7 @@ public class BqTable extends Resource {
     logger.info("Created BQ data table: {}", addedResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new BqTable(addedResource);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcpNotebook.java
@@ -74,7 +74,7 @@ public class GcpNotebook extends Resource {
     logger.info("Created GCP notebook: {}", createdResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new GcpNotebook(createdResource);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsBucket.java
@@ -61,7 +61,7 @@ public class GcsBucket extends Resource {
     logger.info("Created GCS bucket: {}", addedResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new GcsBucket(addedResource);
   }
 
@@ -80,7 +80,7 @@ public class GcsBucket extends Resource {
     logger.info("Created GCS bucket: {}", createdResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new GcsBucket(createdResource);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcsObject.java
@@ -61,7 +61,7 @@ public class GcsObject extends Resource {
     logger.info("Created GCS bucket object: {}", addedResource);
 
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new GcsObject(addedResource);
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GitRepo.java
@@ -54,7 +54,7 @@ public class GitRepo extends Resource {
             .createReferencedGitRepo(Context.requireWorkspace().getUuid(), addGitRepoParams);
     logger.info("Created Git repo reference: {}", addedResource);
     // convert the WSM object to a CLI object
-    Context.requireWorkspace().listResourcesAndSync();
+    Context.requireWorkspace().listResources();
     return new GitRepo(addedResource);
   }
 

--- a/src/main/java/bio/terra/cli/command/app/passthrough/Git.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Git.java
@@ -68,7 +68,7 @@ public class Git extends ToolCommand {
   }
 
   private Set<String> getGitReposInWorkspace() {
-    return Context.requireWorkspace().listResourcesAndSync().stream()
+    return Context.requireWorkspace().listResources().stream()
         .filter(resource -> Resource.Type.GIT_REPO == resource.getResourceType())
         .map(Resource::resolve)
         .collect(Collectors.toSet());

--- a/src/main/java/bio/terra/cli/command/cromwell/GenerateConfig.java
+++ b/src/main/java/bio/terra/cli/command/cromwell/GenerateConfig.java
@@ -46,7 +46,7 @@ public class GenerateConfig extends BaseCommand {
       return;
     }
 
-    String googleProjectId = Context.requireWorkspace().getGoogleProjectId();
+    String googleProjectId = Context.requireWorkspace().getRequiredGoogleProjectId();
     String petSaEmail = Context.requireUser().getPetSaEmail();
 
     // Force local process runner, so the generated file exists on local filesystem (as opposed to

--- a/src/main/java/bio/terra/cli/command/resource/List.java
+++ b/src/main/java/bio/terra/cli/command/resource/List.java
@@ -43,7 +43,7 @@ public class List extends WsmBaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     java.util.List<UFResource> resources =
-        Context.requireWorkspace().listResourcesAndSync().stream()
+        Context.requireWorkspace().listResources().stream()
             .filter(
                 (resource) -> {
                   boolean stewardshipMatches =

--- a/src/main/java/bio/terra/cli/command/resource/ListTree.java
+++ b/src/main/java/bio/terra/cli/command/resource/ListTree.java
@@ -33,7 +33,7 @@ public class ListTree extends WsmBaseCommand {
 
     // Get all resources and folders in the workspace and sort by name
     List<UFResource> resources =
-        Context.requireWorkspace().listResourcesAndSync().stream()
+        Context.requireWorkspace().listResources().stream()
             .sorted(Comparator.comparing(Resource::getName))
             .map(Resource::serializeToCommand)
             .toList();

--- a/src/main/java/bio/terra/cli/command/shared/options/NotebookInstance.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/NotebookInstance.java
@@ -41,7 +41,7 @@ public class NotebookInstance {
           .build();
     } else {
       return InstanceName.builder()
-          .projectId(workspace.getGoogleProjectId())
+          .projectId(workspace.getRequiredGoogleProjectId())
           .location(location)
           .instanceId(argGroup.instanceId)
           .build();

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -8,6 +8,8 @@ import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
+import bio.terra.workspace.model.GcpContext;
+import bio.terra.workspace.model.WorkspaceDescription;
 import com.google.api.client.util.DateTime;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import com.google.cloud.bigquery.BigQuery;
@@ -146,9 +148,14 @@ public class BreakGlass extends WsmBaseCommand {
     rowContent.put("serverName", Context.getServer().getName());
     rowContent.put("serverWsmUri", Context.getServer().getWorkspaceManagerUri());
     rowContent.put("workspaceId", Context.requireWorkspace().getUuid().toString());
-    rowContent.put("googleProjectId", Context.requireWorkspace().getGoogleProjectId());
-    rowContent.put("workspaceName", Context.requireWorkspace().getName());
-    rowContent.put("workspaceDescription", Context.requireWorkspace().getDescription());
+    WorkspaceDescription workspaceDescription =
+        Context.requireWorkspace().getWorkspaceDescription();
+    GcpContext gcpContext = workspaceDescription.getGcpContext();
+    if (gcpContext != null) {
+      rowContent.put("googleProjectId", gcpContext.getProjectId());
+    }
+    rowContent.put("workspaceName", workspaceDescription.getDisplayName());
+    rowContent.put("workspaceDescription", workspaceDescription.getDescription());
     rowContent.put("granterEmail", Context.requireUser().getEmail());
     rowContent.put("requestNotes", notes);
 

--- a/src/main/java/bio/terra/cli/command/workspace/DeleteProperty.java
+++ b/src/main/java/bio/terra/cli/command/workspace/DeleteProperty.java
@@ -29,7 +29,7 @@ public class DeleteProperty extends WsmBaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     Workspace updatedWorkspace = Context.requireWorkspace().deleteProperties(propertyKeys);
-    updatedWorkspace.listResourcesAndSync();
+    updatedWorkspace.listResources();
     formatOption.printReturnValue(new UFWorkspace(updatedWorkspace), this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -45,7 +45,7 @@ public class List extends WsmBaseCommand {
     formatOption.printReturnValue(
         UserIO.sortAndMap(
             Workspace.list(offset, limit),
-            Comparator.comparing(Workspace::getName),
+            Comparator.comparing(Workspace::getUserFacingId),
             UFWorkspaceLight::new),
         this::printText);
   }

--- a/src/main/java/bio/terra/cli/command/workspace/SetProperty.java
+++ b/src/main/java/bio/terra/cli/command/workspace/SetProperty.java
@@ -31,7 +31,7 @@ public class SetProperty extends WsmBaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     Workspace updatedWorkspace = Context.requireWorkspace().updateProperties(workspaceProperties);
-    updatedWorkspace.listResourcesAndSync();
+    updatedWorkspace.listResources();
     formatOption.printReturnValue(new UFWorkspace(updatedWorkspace), this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/workspace/Update.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Update.java
@@ -28,7 +28,7 @@ public class Update extends WsmBaseCommand {
     workspaceOption.overrideIfSpecified();
     Workspace updatedWorkspace =
         Context.requireWorkspace().update(argGroup.id, argGroup.name, argGroup.description);
-    updatedWorkspace.listResourcesAndSync();
+    updatedWorkspace.listResources();
     formatOption.printReturnValue(new UFWorkspace(updatedWorkspace), this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/persisted/PDWorkspace.java
@@ -1,15 +1,10 @@
 package bio.terra.cli.serialization.persisted;
 
-import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.workspace.model.CloudPlatform;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * External representation of a workspace for writing to disk.
@@ -22,65 +17,30 @@ import java.util.stream.Collectors;
 public class PDWorkspace {
   public final UUID uuid;
   public final String userFacingId;
-  public final String name;
-  public final String description;
-  public final CloudPlatform cloudPlatform;
   public final String googleProjectId;
-  public final Map<String, String> properties;
-  public final String serverName;
-  public final String userEmail;
-  public final List<PDResource> resources;
-  public final OffsetDateTime createdDate;
-  public final OffsetDateTime lastUpdatedDate;
+  public final CloudPlatform cloudPlatform;
 
   /** Serialize an instance of the internal class to the disk format. */
   public PDWorkspace(Workspace internalObj) {
     this.uuid = internalObj.getUuid();
     this.userFacingId = internalObj.getUserFacingId();
-    this.name = internalObj.getName();
-    this.description = internalObj.getDescription();
+    this.googleProjectId = internalObj.getGoogleProjectId().orElse(null);
     this.cloudPlatform = internalObj.getCloudPlatform();
-    this.googleProjectId = internalObj.getGoogleProjectId();
-    this.properties = internalObj.getProperties();
-    this.serverName = internalObj.getServerName();
-    this.userEmail = internalObj.getUserEmail();
-    this.resources =
-        internalObj.getResources().stream()
-            .map(Resource::serializeToDisk)
-            .collect(Collectors.toList());
-    this.createdDate = internalObj.getCreatedDate();
-    this.lastUpdatedDate = internalObj.getLastUpdatedDate();
   }
 
   private PDWorkspace(PDWorkspace.Builder builder) {
     this.uuid = builder.uuid;
     this.userFacingId = builder.userFacingId;
-    this.name = builder.name;
-    this.description = builder.description;
-    this.cloudPlatform = builder.cloudPlatform;
     this.googleProjectId = builder.googleProjectId;
-    this.properties = builder.properties;
-    this.serverName = builder.serverName;
-    this.userEmail = builder.userEmail;
-    this.resources = builder.resources;
-    this.createdDate = builder.createdDate;
-    this.lastUpdatedDate = builder.lastUpdatedDate;
+    this.cloudPlatform = builder.cloudPlatform;
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
   public static class Builder {
     private UUID uuid;
     private String userFacingId;
-    private String name;
-    private String description;
-    private CloudPlatform cloudPlatform;
     private String googleProjectId;
-    private Map<String, String> properties;
-    private String serverName;
-    private String userEmail;
-    private List<PDResource> resources;
-    private OffsetDateTime createdDate;
-    private OffsetDateTime lastUpdatedDate;
+    private CloudPlatform cloudPlatform;
 
     /** Default constructor for Jackson. */
     public Builder() {}
@@ -95,53 +55,13 @@ public class PDWorkspace {
       return this;
     }
 
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    public Builder description(String description) {
-      this.description = description;
-      return this;
-    }
-
-    public Builder cloudPlatform(CloudPlatform cloudPlatform) {
-      this.cloudPlatform = cloudPlatform;
-      return this;
-    }
-
     public Builder googleProjectId(String googleProjectId) {
       this.googleProjectId = googleProjectId;
       return this;
     }
 
-    public Builder properties(Map<String, String> properties) {
-      this.properties = properties;
-      return this;
-    }
-
-    public Builder serverName(String serverName) {
-      this.serverName = serverName;
-      return this;
-    }
-
-    public Builder userEmail(String userEmail) {
-      this.userEmail = userEmail;
-      return this;
-    }
-
-    public Builder resources(List<PDResource> resources) {
-      this.resources = resources;
-      return this;
-    }
-
-    public Builder createdDate(OffsetDateTime createdDate) {
-      this.createdDate = createdDate;
-      return this;
-    }
-
-    public Builder lastUpdatedDate(OffsetDateTime lastUpdatedDate) {
-      this.lastUpdatedDate = lastUpdatedDate;
+    public Builder cloudPlatform(CloudPlatform cloudPlatform) {
+      this.cloudPlatform = cloudPlatform;
       return this;
     }
 

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspace.java
@@ -28,7 +28,7 @@ public class UFWorkspace extends UFWorkspaceLight {
    */
   public UFWorkspace(Workspace internalObj) {
     super(internalObj);
-    this.numResources = internalObj.getResources().size();
+    this.numResources = internalObj.listResources().size();
   }
 
   /** Constructor for Jackson deserialization during testing. */

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -1,13 +1,18 @@
 package bio.terra.cli.serialization.userfacing;
 
+import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.utils.UserIO;
 import bio.terra.workspace.model.CloudPlatform;
+import bio.terra.workspace.model.Properties;
+import bio.terra.workspace.model.Property;
+import bio.terra.workspace.model.WorkspaceDescription;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /** This is used instead of UFWorkspace, if workspace resources aren't needed. */
 public class UFWorkspaceLight {
@@ -32,15 +37,17 @@ public class UFWorkspaceLight {
    */
   public UFWorkspaceLight(Workspace internalObj) {
     this.id = internalObj.getUserFacingId();
-    this.name = internalObj.getName();
-    this.description = internalObj.getDescription();
+    this.googleProjectId = internalObj.getGoogleProjectId().orElse(null);
     this.cloudPlatform = internalObj.getCloudPlatform();
-    this.googleProjectId = internalObj.getGoogleProjectId();
-    this.properties = internalObj.getProperties();
-    this.serverName = internalObj.getServerName();
-    this.userEmail = internalObj.getUserEmail();
-    this.createdDate = internalObj.getCreatedDate();
-    this.lastUpdatedDate = internalObj.getLastUpdatedDate();
+
+    WorkspaceDescription workspaceDescription = internalObj.getWorkspaceDescription();
+    this.name = workspaceDescription.getDisplayName();
+    this.description = workspaceDescription.getDescription();
+    this.properties = propertiesToStringMap(workspaceDescription.getProperties());
+    this.userEmail = Context.requireUser().getEmail();
+    this.serverName = Context.getServer().getName();
+    this.createdDate = workspaceDescription.getCreatedDate();
+    this.lastUpdatedDate = workspaceDescription.getLastUpdatedDate();
   }
 
   /** Constructor for Jackson deserialization during testing. */
@@ -85,11 +92,10 @@ public class UFWorkspaceLight {
           "Cloud console:     https://console.cloud.google.com/home/dashboard?project="
               + googleProjectId);
     }
-    if (properties == null) {
-      return;
+    if (properties != null) {
+      OUT.println("Properties:");
+      properties.forEach((key, value) -> OUT.println("  " + key + ": " + value));
     }
-    OUT.println("Properties:");
-    properties.forEach((key, value) -> OUT.println("  " + key + ": " + value));
     OUT.println("Created:           " + createdDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
     OUT.println("Last updated:      " + lastUpdatedDate.format(DateTimeFormatter.ISO_LOCAL_DATE));
   }
@@ -166,5 +172,9 @@ public class UFWorkspaceLight {
     public UFWorkspaceLight build() {
       return new UFWorkspaceLight(this);
     }
+  }
+
+  private static Map<String, String> propertiesToStringMap(Properties properties) {
+    return properties.stream().collect(Collectors.toMap(Property::getKey, Property::getValue));
   }
 }


### PR DESCRIPTION
This is to avoid stale cache.

Only cache workspace id, user facing id, googleProjectId, cloudPlatform which are not changeable once a workspace is created.

`googleProjectId` is used in many app execute run so it's worth caching it for optimization reasons. 

```
"workspace" : {
    "uuid" : "cf70600a-bddd-47d4-b34a-736edfda7747",
    "userFacingId" : "yu-workspace-2",
    "googleProjectId" : "terra-vdevel-strong-berry-3842",
    "cloudPlatform" : "GCP"
  },
```