### PR TITLE
PF-2376: add a ssh-key add command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,24 @@ for more details.
 
 #### User
 
+#### ssh-key
+
+`terra user ssh-key` is how Terra do source control in a notebook environment. 
+It handles the ssh key of the current user. There is one single Terra ssh key
+per user in a given server (e.g. broad-dev). With this SSH key, you can perform
+source control in a terra-managed notebook instance using git.
+
+To set up an ssh key, run `terra user ssh-key add` to add the terra ssh key
+to your local machine. You should see in the output an ssh public key starting 
+with `ssh-rsa`. Then copy the public key from the command output and 
+add it to GitHub. [Github instruction link](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+
+If you think your key is compromised (e.g. the private key on your local machine
+is leaked to other user), you must delete the key from your Github account and
+run `terra user ssh-key generate` to generate a new Terra ssh key. Once a new 
+key is generated, you need to associate this new key with your GitHub account
+again. [Github instruction link](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
+
 These commands are intended for admin users. Admins,
 see [ADMIN.md](https://github.com/DataBiosphere/terra-cli/blob/main/ADMIN.md#users)
 for more details.

--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -27,7 +27,7 @@ public abstract class CommandRunner {
    *
    * @param command the command and arguments (e.g. {gsutil, ls, gs://my-bucket})
    */
-  protected static String buildFullCommand(List<String> command) {
+  public static String buildFullCommand(List<String> command) {
     String fullCommand = "";
     if (command != null && command.size() > 0) {
       final String argSeparator = " ";
@@ -37,7 +37,7 @@ public abstract class CommandRunner {
   }
 
   // Note: `foo-bar` and `foo_bar` will have the same env variable. PF-1907 will fix this.
-  public static final String convertToEnvironmentVariable(String string) {
+  public static String convertToEnvironmentVariable(String string) {
     return "TERRA_" + string.replace("-", "_");
   }
 

--- a/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/LocalProcessCommandRunner.java
@@ -78,6 +78,10 @@ public class LocalProcessCommandRunner extends CommandRunner {
       }
     }
 
+    return runBashCommand(command, envVars);
+  }
+
+  public static int runBashCommand(String command, Map<String, String> envVars) {
     List<String> processCommand = new ArrayList<>();
     processCommand.add("bash");
     processCommand.add("-ce");

--- a/src/main/java/bio/terra/cli/command/SshKey.java
+++ b/src/main/java/bio/terra/cli/command/SshKey.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.command;
 
+import bio.terra.cli.command.user.sshkey.Add;
 import bio.terra.cli.command.user.sshkey.Generate;
 import bio.terra.cli.command.user.sshkey.Get;
 import picocli.CommandLine.Command;
@@ -7,5 +8,5 @@ import picocli.CommandLine.Command;
 @Command(
     name = "ssh-key",
     description = "Get and generate an terra managed ssh key pair.",
-    subcommands = {Get.class, Generate.class})
+    subcommands = {Get.class, Generate.class, Add.class})
 public class SshKey {}

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
@@ -1,0 +1,55 @@
+package bio.terra.cli.command.user.sshkey;
+
+import static bio.terra.cli.utils.FileUtils.writeStringToFile;
+import static org.apache.commons.io.FilenameUtils.concat;
+
+import bio.terra.cli.app.LocalProcessCommandRunner;
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.service.ExternalCredentialsManagerService;
+import bio.terra.externalcreds.model.SshKeyPair;
+import bio.terra.externalcreds.model.SshKeyPairType;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import picocli.CommandLine.Command;
+
+@Command(name = "add", description = "Save your Terra SSH key to ~/.ssh and add it to ssh agent.")
+public class Add extends BaseCommand {
+
+  @Override
+  protected void execute() {
+    ExternalCredentialsManagerService ecmService = ExternalCredentialsManagerService.fromContext();
+    var sshKeyPair = ecmService.getSshKeyPair(SshKeyPairType.GITHUB);
+    saveKeyFileAndSshAdd(sshKeyPair);
+  }
+
+  protected static void saveKeyFileAndSshAdd(SshKeyPair sshKeyPair) {
+    var dir = System.getProperty("user.home") + "/.ssh/";
+    var privateKeyPath = concat(dir, "terra_id_rsa");
+    var publicKeyPath = concat(dir, "terra_id_rsa.pub");
+    try {
+      writeStringToFile(new File(privateKeyPath), sshKeyPair.getPrivateKey());
+      writeStringToFile(new File(publicKeyPath), sshKeyPair.getPublicKey());
+      OUT.println("Saved the terra ssh key to ~/.ssh/terra_id_rsa and ~/.ssh/terra_id_rsa.pub");
+    } catch (IOException e) {
+      OUT.print("Failed to write the ssh key to ${HOME}/.ssh");
+    }
+
+    // Removes read, write, execute permissions from the group and other users.
+    // Then add the private key to the ssh agent.
+    // chmod go-rwx ~/.ssh/terra_id_rsa && eval "$(ssh-agent -s)" && ssh-add ~/.ssh/terra_id_rsa
+    LocalProcessCommandRunner.runBashCommand(
+        LocalProcessCommandRunner.buildFullCommand(
+            List.of(
+                "chmod",
+                "go-rwx",
+                privateKeyPath,
+                "&&",
+                "eval \"$(ssh-agent -s)\"",
+                "&&",
+                "ssh-add",
+                privateKeyPath)),
+        Collections.emptyMap());
+  }
+}

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
@@ -5,6 +5,8 @@ import static org.apache.commons.io.FilenameUtils.concat;
 
 import bio.terra.cli.app.LocalProcessCommandRunner;
 import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.serialization.userfacing.UFSshKeyPair;
 import bio.terra.cli.service.ExternalCredentialsManagerService;
 import bio.terra.externalcreds.model.SshKeyPair;
 import bio.terra.externalcreds.model.SshKeyPairType;
@@ -12,16 +14,20 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "add", description = "Save your Terra SSH key to ~/.ssh and add it to ssh agent.")
 public class Add extends BaseCommand {
+
+  @CommandLine.Mixin Format formatOption;
 
   @Override
   protected void execute() {
     ExternalCredentialsManagerService ecmService = ExternalCredentialsManagerService.fromContext();
     var sshKeyPair = ecmService.getSshKeyPair(SshKeyPairType.GITHUB);
     saveKeyFileAndSshAdd(sshKeyPair);
+    formatOption.printReturnValue(UFSshKeyPair.createUFSshKey(sshKeyPair), UFSshKeyPair::print);
   }
 
   protected static void saveKeyFileAndSshAdd(SshKeyPair sshKeyPair) {

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
@@ -26,7 +26,7 @@ public class Generate extends BaseCommand {
     confirmationPrompt.confirmOrThrow(
         "Generating a new Terra SSH key will replace the old Terra SSH key if it exists. "
             + "You must associate the new SSH public key with your GitHub account using "
-            + "https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent. "
+            + "https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account "
             + "Are you sure you want to proceed (y/N)?",
         "Generating new SSH key is aborted");
     var sshKeyPair =

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
@@ -6,9 +6,6 @@ import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFSshKeyPair;
 import bio.terra.cli.service.ExternalCredentialsManagerService;
 import bio.terra.externalcreds.model.SshKeyPairType;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -32,21 +29,10 @@ public class Generate extends BaseCommand {
             + "https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent. "
             + "Are you sure you want to proceed (y/N)?",
         "Generating new SSH key is aborted");
-    var ecmService = ExternalCredentialsManagerService.fromContext();
-    var sshKeyPair = ecmService.generateSshKeyPair(SshKeyPairType.GITHUB);
+    var sshKeyPair =
+        ExternalCredentialsManagerService.fromContext().generateSshKeyPair(SshKeyPairType.GITHUB);
     if (saveToFile) {
-      try {
-        BufferedWriter privateWriter = new BufferedWriter(new FileWriter("terra_id_rsa"));
-        privateWriter.write(sshKeyPair.getPrivateKey());
-        privateWriter.close();
-        BufferedWriter publicWriter = new BufferedWriter(new FileWriter("terra_id_rsa.pub"));
-        publicWriter.write(sshKeyPair.getPublicKey());
-        publicWriter.close();
-        OUT.println(
-            "Ssh private key is saved in terra_id_rsa and Ssh public key is saved in terra_id_rsa.pub. You can move them under ~/.ssh/.");
-      } catch (IOException e) {
-        OUT.println("Failed to write to file");
-      }
+      Add.saveKeyFileAndSshAdd(sshKeyPair);
     } else {
       formatOption.printReturnValue(UFSshKeyPair.createUFSshKey(sshKeyPair), UFSshKeyPair::print);
     }

--- a/src/test/java/unit/SshKeyPair.java
+++ b/src/test/java/unit/SshKeyPair.java
@@ -94,11 +94,13 @@ public class SshKeyPair extends SingleWorkspaceUnit {
   }
 
   private void assertSshKeyAdded() {
-    assertTrue(Files.exists(Paths.get(System.getProperty("user.home") + "/.ssh/terra_id_rsa")));
-    assertTrue(
-        Files.exists(Paths.get(System.getProperty("user.home"), ".ssh", "terra_id_rsa.pub")));
+    String privateKey = System.getProperty("user.home") + "/.ssh/terra_id_rsa";
+    String publicKey = System.getProperty("user.home") + "/.ssh/terra_id_rsa.pub";
+    assertTrue(Files.exists(Paths.get(privateKey)));
+    assertTrue(Files.exists(Paths.get(publicKey)));
 
-    FileUtils.deleteQuietly(new File(System.getProperty("user.home") + "/.ssh/terra_id_rsa"));
-    FileUtils.deleteQuietly(new File(System.getProperty("user.home") + "/.ssh/terra_id_rsa.pub"));
+    // clean up
+    FileUtils.deleteQuietly(new File(privateKey));
+    FileUtils.deleteQuietly(new File(publicKey));
   }
 }

--- a/src/test/java/unit/SshKeyPair.java
+++ b/src/test/java/unit/SshKeyPair.java
@@ -45,8 +45,7 @@ public class SshKeyPair extends SingleWorkspaceUnit {
   @Test
   void addSshKey() throws IOException {
     testUser.login();
-    TestCommand.runAndParseCommandExpectSuccess(
-        UFSshKeyPair.class, "user", "ssh-key", "generate", "--quiet");
+    TestCommand.runCommandExpectSuccess("user", "ssh-key", "generate", "--quiet");
 
     TestCommand.runCommandExpectSuccess("user", "ssh-key", "add");
 
@@ -74,8 +73,7 @@ public class SshKeyPair extends SingleWorkspaceUnit {
   void generateSshKey_saveToFile() throws IOException {
     testUser.login();
 
-    TestCommand.runAndParseCommandExpectSuccess(
-        UFSshKeyPair.class, "user", "ssh-key", "generate", "--quiet", "--save-to-file");
+    TestCommand.runCommandExpectSuccess("user", "ssh-key", "generate", "--quiet", "--save-to-file");
 
     assertSshKeyAdded();
   }
@@ -96,17 +94,10 @@ public class SshKeyPair extends SingleWorkspaceUnit {
   }
 
   private void assertSshKeyAdded() {
-    assertTrue(Files.exists(Paths.get(System.getProperty("user.home"), ".ssh", "terra_id_rsa")));
+    assertTrue(Files.exists(Paths.get(System.getProperty("user.home") + "/.ssh/terra_id_rsa")));
     assertTrue(
-        Files.exists(Paths.get(System.getProperty("user.home"), ".ssh", "terra_id_rsa", ".pub")));
+        Files.exists(Paths.get(System.getProperty("user.home"), ".ssh", "terra_id_rsa.pub")));
 
-    // `terra git clone`
-    TestCommand.runCommandExpectSuccess(
-        "git", "clone", "git@github.com:DataBiosphere/terra-examples.git");
-    // assert ssh key is set up
-    assertTrue(
-        Files.exists(Paths.get(System.getProperty("user.dir"), "terra-example-notebooks", ".git")));
-    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/terra-example-notebooks"));
     FileUtils.deleteQuietly(new File(System.getProperty("user.home") + "/.ssh/terra_id_rsa"));
     FileUtils.deleteQuietly(new File(System.getProperty("user.home") + "/.ssh/terra_id_rsa.pub"));
   }


### PR DESCRIPTION
There is a user friction when a user created an AI notebook for the first time and didn't set up an ssh key. Or they regenerate a new ssh key and deleted the old one from their github account after a notebook is already created. 

Right now there's no easy way to get and add the new terra ssh key to the notebook.

Adding a `terra user ssh-key add` command to get and save the key and add it to the ssh-agent.

Also did a refactor to achieve the same with `terra user ssh-key generate --save-to-file`.

```
yuhuyoyo-macbookpro3% terra user ssh-key add
Saved the terra ssh key to ~/.ssh/terra_id_rsa and ~/.ssh/terra_id_rsa.pub
Agent pid 39723
Identity added: /Users/yuhuyoyo/.ssh/terra_id_rsa (/Users/yuhuyoyo/.ssh/terra_id_rsa)
ssh-rsa <my-key>
```