### PR TITLE
[PF-2438] Add quietConsole option to tests

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -67,21 +67,21 @@ jobs:
       run: |
         echo "Running unit tests for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-unit
-        ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit
+        ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit -PquietConsole
     - name: Run integration tests against source code
       id: run_integration_tests_against_source_code
       if: always()
       run: |
         echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-source
-        ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source
+        ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source -PquietConsole
     - name: Run integration tests against release
       id: run_integration_tests_against_release
       if: always()
       run: |
         echo "Running integration tests against release for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-release
-        ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release
+        ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release -PquietConsole
     - name: Compile logs and context files for all test runs
       id: compile_logs_and_context_files
       if: always()

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -112,7 +112,7 @@ jobs:
         # runs against the default server: broad-dev
         echo "Running tests with tag: ${{ matrix.testTag }}"
         echo "Using docker image (uses default if blank): $TEST_DOCKER_IMAGE"
-        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} --scan $TEST_DOCKER_IMAGE
+        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} --scan $TEST_DOCKER_IMAGE -PquietConsole
       env:
         TEST_DOCKER_IMAGE: ${{ steps.build_docker_image.outputs.test_docker_image }}
     - name: Archive logs and context file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,9 @@ Both types of tests:
   `./gradlew runTestsWithTag -PtestTag=integration -PtestInstallFromGitHub`
 - Run a single test by specifying the `--tests` option:
   `./gradlew runTestsWithTag -PtestTag=unit --tests Workspace.createFailsWithoutSpendAccess`
+- Suppress console display of the test command's stdIn & stdOut by specifying the `-PquietConsole` option
+  `./gradlew runTestsWithTag -PtestTag=unit -PquietConsole`
+
 
 By default, tests are run against all cloud platforms supported by the CLI server. Add the platform to target tests for a single platform
 - CloudPlatform.GCS `./gradlew runTestsWithTag -PtestTag=unit -Pplatform=gcp`

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -56,12 +56,12 @@ task runTestsWithTag(type: Test) {
             // for an installation from a GH release, this points to the build/test-install directory (i.e. where the curl install command is run)
             boolean testInstallFromGitHub = project.hasProperty('testInstallFromGitHub')
             String installDir = testInstallFromGitHub ? "${project.buildDir}/test-install" : "${project.buildDir}/install/${project.group}/bin"
-            systemProperty 'TERRA_INSTALL_DIR', installDir
+            systemProperty('TERRA_INSTALL_DIR', installDir)
 
             // [for integration tests] specify the working directory to use when running scripts. this makes
             // it easier to clean up after tests (./gradlew clean) that generate files.
             mkdir "${project.buildDir}/test-working-dir/"
-            systemProperty 'TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/"
+            systemProperty('TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/")
 
             if (cloudPlatform == 'gcp') {
                 allTestTags.add('integration-gcp')
@@ -116,14 +116,18 @@ task runTestsWithTag(type: Test) {
 
     // set which file in src/test/resources/testconfigs to use
     String terraTestConfigName = project.hasProperty('testConfig') ? project.findProperty('testConfig') : 'broad'
-    systemProperty 'TERRA_TEST_CONFIG_NAME', terraTestConfigName
+    systemProperty('TERRA_TEST_CONFIG_NAME', terraTestConfigName)
+
+    // suppress console logging ('stdin' & 'stdout' display)
+    String terraTestQuietConsole = project.hasProperty('quietConsole') ? 'true' : 'false'
+    systemProperty('TERRA_TEST_QUIET_CONSOLE', terraTestQuietConsole)
 
     // specify the Docker image to run tests with (e.g. -PdockerImage=terra-cli/local:b5fdce0). if unspecified, tests use the default Docker image
     String terraDockerImage = project.hasProperty('dockerImage') ? project.findProperty('dockerImage') : ''
     environment 'TERRA_DOCKER_IMAGE', terraDockerImage
 
     // generate a unique id for each test run
-    systemProperty 'TEST_RUN_ID', UUID.randomUUID().toString()
+    systemProperty('TEST_RUN_ID', UUID.randomUUID().toString())
 
     dependsOn runInstallForTesting
     // run the install-for-testing.sh script before any tests
@@ -161,14 +165,18 @@ task cleanupTestUserWorkspaces(type: JavaExec) {
     mkdir "${project.buildDir}/test-context/"
 
     // [required] specify the server to cleanup (e.g. -Pserver=broad-dev). no default value, force caller to specify this
-    systemProperty 'TERRA_SERVER', project.findProperty('server')
+    systemProperty('TERRA_SERVER', project.findProperty('server'))
 
     // set which file in src/test/resources/testconfigs to use
     String terraTestConfigName = project.hasProperty('testConfig') ? project.findProperty('testConfig') : 'broad'
-    systemProperty 'TERRA_TEST_CONFIG_NAME', terraTestConfigName
+    systemProperty('TERRA_TEST_CONFIG_NAME', terraTestConfigName)
+
+    // suppress console logging ('stdin' & 'stdout' display)
+    String terraTestQuietConsole = project.hasProperty('quietConsole') ? 'true' : 'false'
+    systemProperty('TERRA_TEST_QUIET_CONSOLE', terraTestQuietConsole)
 
     // [optional] specify that this is a dry run (e.g. -PdryRun)
-    systemProperty 'DRY_RUN', project.hasProperty('dryRun').toString()
+    systemProperty('DRY_RUN', project.hasProperty('dryRun').toString())
 
     dependsOn compileJava
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
-enableFeaturePreview('ONE_LOCKFILE_PER_PROJECT')
 rootProject.name = 'terra-cli'

--- a/src/test/java/harness/TestCommand.java
+++ b/src/test/java/harness/TestCommand.java
@@ -59,16 +59,24 @@ public class TestCommand {
     // log the stdout, stdin and stderr to the console
     String stdOutStr = stdOut.toString(StandardCharsets.UTF_8);
     String stdErrStr = stdErr.toString(StandardCharsets.UTF_8);
-    System.out.println("STDOUT --------------");
-    System.out.println(stdOutStr);
-    if (stdIn != null)
+
+    if (!TestConfig.getQuietConsole()) {
+      System.out.println("STDOUT --------------");
+      System.out.println(stdOutStr);
+    }
+
+    if (stdIn != null) {
       try {
-        System.out.println("STDIN --------------");
         stdIn.reset();
-        System.out.println(new String(stdIn.readAllBytes(), StandardCharsets.UTF_8));
+        if (!TestConfig.getQuietConsole()) {
+          System.out.println("STDIN --------------");
+          System.out.println(new String(stdIn.readAllBytes(), StandardCharsets.UTF_8));
+        }
       } catch (IOException ioEx) {
         throw new RuntimeException("Error logging stdin to console", ioEx);
       }
+    }
+
     if (!stdErrStr.isEmpty()) {
       System.out.println("STDERR --------------");
       System.out.println(stdErrStr);

--- a/src/test/java/harness/TestConfig.java
+++ b/src/test/java/harness/TestConfig.java
@@ -5,13 +5,12 @@ import bio.terra.cli.utils.FileUtils;
 import bio.terra.cli.utils.JacksonMapper;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Test config that can vary between Terra deployments. */
 public final class TestConfig {


### PR DESCRIPTION
Add quietConsole option to tests

Problem statement - at time the console output of PR checks (especially unit tests) run into 50k+ lines. This is difficult to debug and the page load is often slow. 

Solution - add an option to suppress STDIN and STDOUT of the test commands from being printed on the console. 

No changes to stderr 

Testing -- 

```
terra-cli (dexamundsen/pf-2438) >> ./gradlew :runTestsWithTag --tests "unit.Workspace.statusDescribeListReflectDelete" -PtestTag=unit -PquietConsole
...
Workspace STANDARD_OUT
    17:12:37.218 [Test worker] DEBUG harness.TestConfig - Reading test config from testconfigs/broad.json
    COMMAND: config set logging --console --level=OFF
    17:12:37.525 [Test worker] WARN bio.terra.cli.utils.UserIO - Printing setup called multiple times. This is expected when testing, not during normal operation.
    17:12:37.530 [Test worker] DEBUG bio.terra.cli.businessobject.Context - Context file not found. Re-initializing with default values
    17:12:37.530 [Test worker] WARN bio.terra.cli.businessobject.Config - Implementation version not defined in the JAR manifest. This is expected when testing, not during normal operation.
    COMMAND: config set logging --file --level=DEBUG
    COMMAND: server set --name broad-dev --quiet
    COMMAND: config set image --default
    Logging in test user: Lily.Shadowmoon@test.firecloud.org
=========================================================
Running test: statusDescribeListReflectDelete() [unit.Workspace]

Workspace > status, describe, workspace list reflect workspace delete STANDARD_OUT
    COMMAND: config set logging --console --level=DEBUG
    Running "class unit.Workspace: status, describe, workspace list reflect workspace delete" on worker 3. Logs will be in /Users/dexamundsen/github/databiosphere/terra-cli/build/test-context/3/.terra/logs
    COMMAND: config set logging --console --level=OFF
    COMMAND: config set logging --file --level=DEBUG
    COMMAND: server set --name broad-dev --quiet
    COMMAND: config set image --default
    Logging in test user: John.Whiteclaw@test.firecloud.org
    COMMAND: workspace delete --quiet
    COMMAND: status --format=json
    COMMAND: workspace describe
    STDERR --------------
    No workspace set.

    COMMAND: workspace list --limit=500 --format=json
Finished running test statusDescribeListReflectDelete() [unit.Workspace] with result: SUCCESS
...
```

```
terra-cli (dexamundsen/pf-2438) >> ./gradlew :runTestsWithTag --tests "unit.Workspace.statusDescribeListReflectDelete" -PtestTag=unit

Workspace STANDARD_OUT
    17:22:26.125 [Test worker] DEBUG harness.TestConfig - Reading test config from testconfigs/broad.json
    COMMAND: config set logging --console --level=OFF
    17:22:26.440 [Test worker] WARN bio.terra.cli.utils.UserIO - Printing setup called multiple times. This is expected when testing, not during normal operation.
    17:22:26.445 [Test worker] DEBUG bio.terra.cli.businessobject.Context - Context file not found. Re-initializing with default values
    17:22:26.446 [Test worker] WARN bio.terra.cli.businessobject.Config - Implementation version not defined in the JAR manifest. This is expected when testing, not during normal operation.
    STDOUT --------------
    CONSOLE logging level set to: OFF

    COMMAND: config set logging --file --level=DEBUG
    STDOUT --------------
    FILE logging level set to: DEBUG

    COMMAND: server set --name broad-dev --quiet
    STDOUT --------------
    Terra server is set to broad-dev (CHANGED).

    COMMAND: config set image --default
    STDOUT --------------
    Docker image: gcr.io/terra-cli-dev/terra-cli/0.298.0:stable (UNCHANGED)

    Logging in test user: Brooklyn.Thunderlord@test.firecloud.org
=========================================================
Running test: statusDescribeListReflectDelete() [unit.Workspace]

Workspace > status, describe, workspace list reflect workspace delete STANDARD_OUT
    COMMAND: config set logging --console --level=DEBUG
    STDOUT --------------
    CONSOLE logging level set to: DEBUG

    Running "class unit.Workspace: status, describe, workspace list reflect workspace delete" on worker 4. Logs will be in /Users/dexamundsen/github/databiosphere/terra-cli/build/test-context/4/.terra/logs
    COMMAND: config set logging --console --level=OFF
    STDOUT --------------
    CONSOLE logging level set to: OFF

    COMMAND: config set logging --file --level=DEBUG
    STDOUT --------------
    FILE logging level set to: DEBUG

    COMMAND: server set --name broad-dev --quiet
    STDOUT --------------
    Terra server is set to broad-dev (CHANGED).

    COMMAND: config set image --default
    STDOUT --------------
    Docker image: gcr.io/terra-cli-dev/terra-cli/0.298.0:stable (UNCHANGED)

    Logging in test user: Lily.Shadowmoon@test.firecloud.org
    COMMAND: workspace create --id=a-5a621d88-06d2-4b1a-84c9-f9c6eb100511 --platform=GCP --format=json
    STDOUT --------------
    {
      "id" : "a-5a621d88-06d2-4b1a-84c9-f9c6eb100511",
      "name" : null,
      "description" : null,
      "cloudPlatform" : "GCP",
      "googleProjectId" : "terra-wsm-d-smart-emerald-2385",
      "properties" : { },
      "serverName" : "broad-dev",
      "userEmail" : "lily.shadowmoon@test.firecloud.org",
      "createdDate" : "2023-01-26T01:22:29.328976Z",
      "lastUpdatedDate" : "2023-01-26T01:26:06.511859Z",
      "numResources" : 0
    }

    COMMAND: workspace delete --quiet
    STDOUT --------------
    ID:                a-5a621d88-06d2-4b1a-84c9-f9c6eb100511
    Name:              null
    Description:       null
    Cloud Platform:    GCP
    Google project:    terra-wsm-d-smart-emerald-2385
    Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-wsm-d-smart-emerald-2385
    Properties:
    Created:           2023-01-26
    Last updated:      2023-01-26
    # Resources:       0
    Workspace successfully deleted.

    COMMAND: status --format=json
    STDOUT --------------
    {
      "server" : {
        "name" : "broad-dev",
        "description" : "Broad main development environment",
        "samUri" : "https://sam.dsde-dev.broadinstitute.org",
        "samInviteRequiresAdmin" : false,
        "workspaceManagerUri" : "https://workspace.dsde-dev.broadinstitute.org",
        "wsmDefaultSpendProfile" : "wm-default-spend-profile",
        "dataRepoUri" : "https://jade.datarepo-dev.broadinstitute.org",
        "supportsIdToken" : false,
        "supportedCloudPlatforms" : [ "GCP" ]
      },
      "workspace" : null
    }

    COMMAND: workspace describe
    STDOUT --------------

    STDERR --------------
    No workspace set.

    COMMAND: workspace list --limit=500 --format=json
.......
```


