### PR TITLE
Check Java version in local-dev.sh

### DIFF
--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
+set -e
 
 ## This script sets up the environment for local development.
 ## Dependencies: docker, chmod
 ## Usage: source tools/local-dev.sh
 
+REQ_JAVA_VERSION=17
+echo "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
+if [[ -n "$(which java)" ]]; then
+  # Get the current major version of Java: "11.0.12" => "11"
+  CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+  if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
+    >&2 echo "ERROR: Java version detected (${CUR_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
+    return 1
+  fi
+else
+  >&2 echo "ERROR: No Java installation detected"
+  return 1
+fi
+
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [[ "$(basename "$PWD")" != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
-  exit 1
+  return 1
 fi
 
 echo "Building Java code"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -22,6 +22,7 @@ function check_java_version() {
 }
 
 if ! check_java_version; then
+  unset check_java_version
   return 1
 fi
 

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -25,7 +25,6 @@ if ! check_java_version; then
   unset check_java_version
   return 1
 fi
-
 unset check_java_version
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -29,7 +29,7 @@ fi
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [[ "$(basename "$PWD")" != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
-  exit 1
+  return 1
 fi
 
 echo "Building Java code"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -22,7 +22,7 @@ fi
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [[ "$(basename "$PWD")" != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
-  return 1
+  exit 1
 fi
 
 echo "Building Java code"

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
-set -e
 
 ## This script sets up the environment for local development.
 ## Dependencies: docker, chmod
 ## Usage: source tools/local-dev.sh
 
-REQ_JAVA_VERSION=17
-echo "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
-if [[ -n "$(which java)" ]]; then
-  # Get the current major version of Java: "11.0.12" => "11"
-  CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
-  if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
-    >&2 echo "ERROR: Java version detected (${CUR_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
+function check_java_version() {
+  local REQ_JAVA_VERSION=17
+
+  echo "--  Checking if installed Java version is ${REQ_JAVA_VERSION} or higher"
+  if [[ -n "$(which java)" ]]; then
+    # Get the current major version of Java: "11.0.12" => "11"
+    local CUR_JAVA_VERSION="$(java -version 2>&1 | awk -F\" '{ split($2,a,"."); print a[1]}')"
+    if [[ "${CUR_JAVA_VERSION}" -lt ${REQ_JAVA_VERSION} ]]; then
+      >&2 echo "ERROR: Java version detected (${CUR_JAVA_VERSION}) is less than required (${REQ_JAVA_VERSION})"
+      return 1
+    fi
+  else
+    >&2 echo "ERROR: No Java installation detected"
     return 1
   fi
-else
-  >&2 echo "ERROR: No Java installation detected"
+}
+
+if ! check_java_version; then
+  unset check_java_version
   return 1
 fi
 

--- a/tools/local-dev.sh
+++ b/tools/local-dev.sh
@@ -22,9 +22,10 @@ function check_java_version() {
 }
 
 if ! check_java_version; then
-  unset check_java_version
   return 1
 fi
+
+unset check_java_version
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
 if [[ "$(basename "$PWD")" != 'terra-cli' ]]; then


### PR DESCRIPTION
Similar to the check we have in [download-install.sh](https://github.com/DataBiosphere/terra-cli/blob/main/tools/download-install.sh).

Some questions that may come up:

> This code looks almost exactly copy-pasted from `download-install.sh`. Why not move it to a common util script?

In the main Readme we suggest users call the download-install script by running `curl -L https://github.com/DataBiosphere/terra-cli/releases/latest/download/download-install.sh | bash`. Moving the common code out to a utility script would break that flow.  

> Why isn't the code exactly copy-pasted? What changes did you make?

In the failure case, instead of doing `exit 1` I do a `return 1`. This is because the usage of this script is `source local-dev.sh`, which means we run it in the current shell. I don't want to exit from the current shell. 
