### PR TITLE
[PF-2333] More test fixes

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -131,13 +131,9 @@ public class Workspace {
    * @param limit the maximum number of workspaces to return
    * @return list of workspaces
    */
-  public static List<Workspace> list(int offset, int limit) {
+  public static List<WorkspaceDescription> list(int offset, int limit) {
     // fetch the list of workspaces from WSM
-    List<WorkspaceDescription> listedWorkspaces =
-        WorkspaceManagerService.fromContext().listWorkspaces(offset, limit).getWorkspaces();
-
-    // convert the WSM objects to CLI objects
-    return listedWorkspaces.stream().map(Workspace::new).collect(Collectors.toList());
+    return WorkspaceManagerService.fromContext().listWorkspaces(offset, limit).getWorkspaces();
   }
 
   public static Properties stringMapToProperties(@Nullable Map<String, String> map) {

--- a/src/main/java/bio/terra/cli/command/workspace/List.java
+++ b/src/main/java/bio/terra/cli/command/workspace/List.java
@@ -10,6 +10,7 @@ import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspaceLight;
 import bio.terra.cli.utils.UserIO;
+import bio.terra.workspace.model.WorkspaceDescription;
 import java.util.Comparator;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -45,7 +46,7 @@ public class List extends WsmBaseCommand {
     formatOption.printReturnValue(
         UserIO.sortAndMap(
             Workspace.list(offset, limit),
-            Comparator.comparing(Workspace::getUserFacingId),
+            Comparator.comparing(WorkspaceDescription::getUserFacingId),
             UFWorkspaceLight::new),
         this::printText);
   }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -50,6 +50,30 @@ public class UFWorkspaceLight {
     this.lastUpdatedDate = workspaceDescription.getLastUpdatedDate();
   }
 
+  /**
+   * This constructor can be used instead of {@link UFWorkspaceLight#UFWorkspaceLight(Workspace)} if
+   * you already have a WorkspaceDescription object from WSM to avoid making additional calls.
+   *
+   * @param workspaceDescription
+   */
+  public UFWorkspaceLight(WorkspaceDescription workspaceDescription) {
+    this.id = workspaceDescription.getUserFacingId();
+    this.name = workspaceDescription.getDisplayName();
+    this.description = workspaceDescription.getDescription();
+    this.properties = propertiesToStringMap(workspaceDescription.getProperties());
+    this.userEmail = Context.requireUser().getEmail();
+    this.serverName = Context.getServer().getName();
+    this.createdDate = workspaceDescription.getCreatedDate();
+    this.lastUpdatedDate = workspaceDescription.getLastUpdatedDate();
+
+    if (workspaceDescription.getGcpContext() != null) {
+      this.googleProjectId = workspaceDescription.getGcpContext().getProjectId();
+      this.cloudPlatform = CloudPlatform.GCP;
+    } else if (workspaceDescription.getAzureContext() != null) {
+      this.cloudPlatform = CloudPlatform.AZURE;
+    }
+  }
+
   /** Constructor for Jackson deserialization during testing. */
   private UFWorkspaceLight(UFWorkspaceLight.Builder builder) {
     this.id = builder.id;

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -462,8 +462,8 @@ public class WorkspaceManagerService {
                   WorkspaceManagerService::isRetryable,
                   // Context creation will wait for cloud IAM permissions to sync, so poll for up to
                   // 30 minutes.
-                  /*maxCalls=*/ 120,
-                  /*sleepDuration=*/ Duration.ofSeconds(15));
+                  /*maxCalls=*/ 30,
+                  /*sleepDuration=*/ Duration.ofSeconds(60));
           logger.debug("create workspace context result: {}", createContextResult);
           StatusEnum status = createContextResult.getJobReport().getStatus();
           if (StatusEnum.FAILED == status) {
@@ -657,8 +657,8 @@ public class WorkspaceManagerService {
                     (result) -> isDone(result.getJobReport()),
                     WorkspaceManagerService::isRetryable,
                     // Retry for 30 minutes, as this involves creating a new context
-                    /*maxCalls=*/ 120,
-                    /*sleepDuration=*/ Duration.ofSeconds(15)),
+                    /*maxCalls=*/ 30,
+                    /*sleepDuration=*/ Duration.ofSeconds(60)),
             "Error in cloning workspace.");
     logger.debug("clone workspace polling result: {}", cloneWorkspaceResult);
     throwIfJobNotCompleted(

--- a/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
@@ -19,8 +19,8 @@ import org.apache.http.HttpStatus;
 public class CrlUtils {
 
   // For GCP permissions propagation, retry for up to 30 minutes.
-  public static final int GCP_RETRY_COUNT = 60;
-  public static final Duration GCP_RETRY_SLEEP_DURATION = Duration.ofSeconds(30);
+  public static final int GCP_RETRY_COUNT = 30;
+  public static final Duration GCP_RETRY_SLEEP_DURATION = Duration.ofSeconds(60);
 
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-cli").build();

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -25,6 +25,8 @@ bucketName=$(uuidgen | tr "[:upper:]" "[:lower:]" | sed -e 's/-//g')
 echo "resourceName: $resourceName, bucketName: $bucketName"
 terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
 terra resource list
+# Wait for permissions to propagate on the new bucket before attempting to use it
+sleep 300
 
 # I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
 

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -26,7 +26,7 @@ echo "resourceName: $resourceName, bucketName: $bucketName"
 terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
 terra resource list
 # Wait for permissions to propagate on the new bucket before attempting to use it
-sleep 600
+sleep 900
 
 # I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
 

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -26,7 +26,7 @@ echo "resourceName: $resourceName, bucketName: $bucketName"
 terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
 terra resource list
 # Wait for permissions to propagate on the new bucket before attempting to use it
-sleep 300
+sleep 600
 
 # I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
 


### PR DESCRIPTION
- Fix `workspace list` functionality. Previously, the CLI would make a `get workspace` call for each item in the list due to the way we serialize them, despite all the necessary information already being available. This could cause failures on multithreaded test runs if a workspace was deleted between the `list workspaces` and following `get workspace` call. This also saves us (potentially) several hundred WSM calls per `workspace list` command for real users as well as tests, which is nice.

- Add a wait after creating a bucket in `NextflowRnaseq` test script to allow bucket permissions to propagate
- Decrease polling frequency from 30s to 1m without changing total duration. We're suspicious that more frequent polling may be poisoning caches, but this isn't well established yet.