### PR TITLE
Basic support for Bash tab-completion

### DIFF
--- a/bash_tab_complete
+++ b/bash_tab_complete
@@ -23,7 +23,10 @@ _go_with_options()
 _magic_options_for_terra()
 {
     local cmdline_options
-    cmdline_options=$(2>&1 terra | sed -n '/Commands:/,/Exit codes/{/Commands/b;/Exit codes/b;p}' | awk '{ print $1 }' | sort | uniq | xargs)
+    # The command line options are in between "Commands:" and "Exit codes"
+    local start="Commands:"
+    local end="Exit codes"
+    cmdline_options=$(2>&1 terra | sed -n "/$start/,/$end/{/$start/b;/$end/b;p}" | awk '{ print $1 }' | sort | uniq | xargs)
     _go_with_options "${cmdline_options}"
 }
 

--- a/bash_tab_complete
+++ b/bash_tab_complete
@@ -1,0 +1,30 @@
+# To use, in the Bash shell:
+# source bash_tab_complete
+#
+# Then you can use the "tab" key to auto-complete options in the
+# command line for terra.
+#
+# terra --con<TAB>
+# terra --config
+#
+# If you update terra, you can source this file again
+# to update the tab completion rules.
+
+
+_go_with_options()
+{
+    local options="$@"
+    local cur
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=( $(compgen -W "${options}" -- ${cur}) )
+    return 0
+}
+
+_magic_options_for_terra()
+{
+    local cmdline_options
+    cmdline_options=$(2>&1 terra | sed -n '/Commands:/,/Exit codes/{/Commands/b;/Exit codes/b;p}' | awk '{ print $1 }' | sort | uniq | xargs)
+    _go_with_options "${cmdline_options}"
+}
+
+complete -o default -F _magic_options_for_terra terra


### PR DESCRIPTION
Basic support for Bash tab-completion. Makes the Terra users' life a bit easier.

![image](https://user-images.githubusercontent.com/6879774/215205284-79335d2a-8e9b-4738-bb9e-33f137cea751.png)


A future PR may add support for additional parameters and commands.

