### PR TITLE
[PF-2333] Continued test fixes

### DIFF
--- a/src/test/java/unit/GcloudBuildsSubmit.java
+++ b/src/test/java/unit/GcloudBuildsSubmit.java
@@ -53,20 +53,11 @@ public class GcloudBuildsSubmit extends SingleWorkspaceUnitGcp {
 
     // `terra resource create gcs-bucket --name=$name --format=json`
     String bucketResourceName = "resourceName";
-    UFGcsBucket createdBucket =
-        TestCommand.runAndParseCommandExpectSuccess(
+    TestCommand.runAndParseCommandExpectSuccess(
             UFGcsBucket.class, "resource", "create", "gcs-bucket", "--name=" + bucketResourceName);
 
-    // Poll until the test user can fetch the bucket, which may be delayed.
-    Storage ownerClient =
-        ExternalGCSBuckets.getStorageClient(
-            workspaceCreator.getCredentialsWithCloudPlatformScope());
-    Page<Blob> bucketContents =
-        CrlUtils.callGcpWithPermissionExceptionRetries(
-            () -> ownerClient.get(createdBucket.bucketName).list());
-
     // `builds submit --async --gcs-bucket-resource=bucketName --tag=$tag`
-    TestCommand.runCommandExpectSuccess(
+    TestCommand.runCommandExpectSuccessWithRetries(
         "gcloud",
         "builds",
         "submit",

--- a/src/test/resources/testscripts/NextflowRnaseq.sh
+++ b/src/test/resources/testscripts/NextflowRnaseq.sh
@@ -26,7 +26,9 @@ echo "resourceName: $resourceName, bucketName: $bucketName"
 terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
 terra resource list
 # Wait for permissions to propagate on the new bucket before attempting to use it
-sleep 900
+# TODO(PF-2333): It may be possible to lower this time in the future, but currently the users pet regularly does not
+#  have access by 15 minutes post-waiting.
+sleep 1200
 
 # I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
 


### PR DESCRIPTION
I'll leave this branch open for a while to see PR runs and keep adding more fixes over time as I see more failures pop up in nightly tests.

So far:

- Bump Nextflow sleep from 15m to 20m, as the test user's pet frequently does not have bucket permission after 15m.
- Retry `gcloud builds submit` test command directly instead of polling `list bucket` first as permissions can flip-flop