### PR TITLE
Fix OOB auth flow in cli.

### DIFF
--- a/src/main/java/bio/terra/cli/cloud/gcp/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/cloud/gcp/GoogleOauth.java
@@ -127,7 +127,10 @@ public final class GoogleOauth {
     } else {
       // print the url to stdout and ask the user to copy/paste the token response to stdin
       credential =
-          new AuthorizationCodeInstalledApp(flow, new StdinReceiver(), new NoLaunchBrowser())
+          new AuthorizationCodeInstalledApp(
+                  flow,
+                  new StdinReceiver(readClientSecrets().getInstalled().getRedirectUris().get(0)),
+                  new NoLaunchBrowser())
               .authorize(CREDENTIAL_STORE_KEY);
     }
 
@@ -299,9 +302,15 @@ public final class GoogleOauth {
    * https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server
    */
   private static class StdinReceiver extends AbstractPromptReceiver {
+    private String redirectUri;
+
+    public StdinReceiver(String redirectUri) {
+      this.redirectUri = redirectUri;
+    }
+
     @Override
     public String getRedirectUri() {
-      return "urn:ietf:wg:oauth:2.0:oob";
+      return redirectUri;
     }
   }
 

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -1,14 +1,11 @@
 {
   "installed": {
-    "client_id": "590500654757-hdnr1eh33s0gn4hg050cs4gp8cdddup4.apps.googleusercontent.com",
+    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
     "project_id": "terra-ots0-prod",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "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",
-    "redirect_uris": [
-      "urn:ietf:wg:oauth:2.0:oob",
-      "http://localhost"
-    ]
+    "client_secret": "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",
+    "redirect_uris": ["https://terra.verily.com/authcode"]
   }
 }


### PR DESCRIPTION
- Must redirect to an acutal URI, in this case a TVC URI for Verily's config.
- New ClientID (type web) is required in order to support redirect_uri.

context: https://developers.google.com/identity/protocols/oauth2/resources/oob-migration