### PR TITLE
move platformStorageName to base class in unit tests

### DIFF
--- a/src/main/java/bio/terra/cli/command/server/List.java
+++ b/src/main/java/bio/terra/cli/command/server/List.java
@@ -45,7 +45,7 @@ public class List extends BaseCommand {
 
   /** Column information for table output with `terra server list` */
   private enum Columns implements ColumnDefinition<UFServer> {
-    NAME("NAME", s -> s.name, 21, LEFT), // longest is "broad-dev-cli-testing"
+    NAME("NAME", s -> s.name, 30, LEFT),
     DESCRIPTION("DESCRIPTION", s -> s.description, 120, LEFT);
 
     private final String columnLabel;

--- a/src/test/java/harness/TestConfig.java
+++ b/src/test/java/harness/TestConfig.java
@@ -3,6 +3,7 @@ package harness;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.utils.FileUtils;
 import bio.terra.cli.utils.JacksonMapper;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.io.FileNotFoundException;
@@ -13,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Test config that can vary between Terra deployments. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class TestConfig {
   private static final Logger logger = LoggerFactory.getLogger(TestConfig.class);
   private static final String TESTCONFIGS_RESOURCE_DIRECTORY = "testconfigs";

--- a/src/test/java/harness/baseclasses/ClearContextUnit.java
+++ b/src/test/java/harness/baseclasses/ClearContextUnit.java
@@ -23,14 +23,24 @@ import org.junit.jupiter.api.TestInstance;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClearContextUnit {
   protected static final TestUser workspaceCreator = TestUser.chooseTestUserWithSpendAccess();
-  private CloudPlatform cloudPlatform = CloudPlatform.GCP; // default platform
+
+  // default platform: GCP
+  private CloudPlatform cloudPlatform = CloudPlatform.GCP;
+  private String platformStorageName = "gcs-bucket";
 
   protected void setCloudPlatform(CloudPlatform cloudPlatform) {
+    if (cloudPlatform == CloudPlatform.GCP) {
+      platformStorageName = "gcs-bucket";
+    }
     this.cloudPlatform = cloudPlatform;
   }
 
   protected CloudPlatform getCloudPlatform() {
     return cloudPlatform;
+  }
+
+  protected String getPlatformStorageName() {
+    return platformStorageName;
   }
 
   /**

--- a/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
+++ b/src/test/java/harness/baseclasses/SingleWorkspaceUnit.java
@@ -1,8 +1,6 @@
 package harness.baseclasses;
 
-import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
-import bio.terra.workspace.model.CloudPlatform;
 import harness.TestCommand;
 import harness.TestContext;
 import harness.utils.WorkspaceUtils;
@@ -23,17 +21,9 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
     return userFacingId;
   }
 
-  private String platformStorageName;
-
   @BeforeAll
   protected void setupOnce() throws Exception {
     super.setupOnce();
-    if (getCloudPlatform() == CloudPlatform.GCP) {
-      platformStorageName = "gcs-bucket";
-    } else {
-      throw new UserActionableException("Unsupported cloud platform " + getCloudPlatform());
-    }
-
     workspaceCreator.login();
 
     UFWorkspace createdWorkspace =
@@ -61,7 +51,7 @@ public class SingleWorkspaceUnit extends ClearContextUnit {
     TestCommand.runCommandExpectSuccess(
         "resource",
         "create",
-        platformStorageName,
+        getPlatformStorageName(),
         "--name=" + resourceName,
         "--bucket-name=" + bucketName);
   }


### PR DESCRIPTION
- Minor change: move platformStorageName to base class in unit tests
- Reason: 1) Use gcs-bucket as the default storage type, aligning with the default platform (GCP). prior to the change, this is not set and an exception is thrown. 

- Add JsonIgnoreProperties to testConfig.java to ignore unknown properties in the test config file 
