### PR TITLE
Support running tests by single tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 
 // TODO(PF-1981) - Move version to settings.gradle
 // The tools/publish-release.sh script depends on this version string being of the format "version = '1.2.3'"
-version = '0.303.0'
+version = '0.304.0'
 group = 'terra-cli'
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -134,20 +134,21 @@ task runTestsWithTag(type: Test) {
 
     outputs.upToDateWhen { false } // force tests to always be re-run
 
-    retry {
-        // This is set automatically on Github Actions runners, and never set
-        // otherwise.
-        if (System.getenv().containsKey('CI')) {
-            // Max retries per test.
-            maxRetries = 1
-            // Max total test failures.
-            // This is an estimate based on current failure rates, but if more
-            // than 5 tests fail in a run it's likely a real source of failure
-            // and we should stop retrying.
-            maxFailures = 5
-        }
-        failOnPassedAfterRetry = true
-    }
+    // TODO(PF-2465): Re-enable retries once flakiness is under control.
+    //    retry {
+    //        // This is set automatically on Github Actions runners, and never set
+    //        // otherwise.
+    //        if (System.getenv().containsKey('CI')) {
+    //            // Max retries per test.
+    //            maxRetries = 1
+    //            // Max total test failures.
+    //            // This is an estimate based on current failure rates, but if more
+    //            // than 5 tests fail in a run it's likely a real source of failure
+    //            // and we should stop retrying.
+    //            maxFailures = 5
+    //        }
+    //        failOnPassedAfterRetry = true
+    //    }
 }
 
 // cleanup workspaces owned by test users.

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -31,7 +31,7 @@ task runTestsWithTag(type: Test) {
         def allTestTags = [testTag] // non-platform specific tests
         String cloudPlatform = project.findProperty('platform')
 
-        if (testTag == 'unit') {
+        if (testTag.startsWith('unit')) {
             // [for unit tests] specify the implementation version that's set in the JAR manifest. unit tests
             // run against the code directly, and so there is no JAR manifest. this implementation version is
             // used to get the default docker image id.
@@ -40,17 +40,20 @@ task runTestsWithTag(type: Test) {
             // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
             systemProperty('TERRA_CLI_VERSION', "${project.version}")
 
-            if (cloudPlatform == 'gcp') {
-                allTestTags.add('unit-gcp')
-            } else if (cloudPlatform == 'aws') {
-                allTestTags.add('unit-aws')
-            } else if (cloudPlatform == 'azure') {
-                allTestTags.add('unit-azure')
-            } else if (cloudPlatform == null) {  // run all tests
-                allTestTags.addAll(['unit-gcp', 'unit-aws', 'unit-azure'])
+            if (testTag == 'unit') {
+                if (cloudPlatform == 'gcp') {
+                    allTestTags.add('unit-gcp')
+                } else if (cloudPlatform == 'aws') {
+                    allTestTags.add('unit-aws')
+                } else if (cloudPlatform == 'azure') {
+                    allTestTags.add('unit-azure')
+                } else if (cloudPlatform == null) {  // run all tests
+                    allTestTags.addAll(['unit-gcp', 'unit-aws', 'unit-azure'])
+                }
             }
+            // else only run on supplied tag, ignoring platform
 
-        } else if (testTag == 'integration') {
+        } else if (testTag.startsWith('integration')) {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
             // for an installation directly from source code, this points to the build/install/terra-cli/bin directory (i.e. the output of ./gradlew install)
             // for an installation from a GH release, this points to the build/test-install directory (i.e. where the curl install command is run)
@@ -63,15 +66,18 @@ task runTestsWithTag(type: Test) {
             mkdir "${project.buildDir}/test-working-dir/"
             systemProperty('TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/")
 
-            if (cloudPlatform == 'gcp') {
-                allTestTags.add('integration-gcp')
-            } else if (cloudPlatform == 'aws') {
-                allTestTags.add('integration-aws')
-            } else if (cloudPlatform == 'azure') {
-                allTestTags.add('integration-azure')
-            } else if (cloudPlatform == null) {  // run all tests
-                allTestTags.addAll(['integration-gcp', 'integration-aws', 'integration-azure'])
+            if (testTag == 'integration') {
+                if (cloudPlatform == 'gcp') {
+                    allTestTags.add('integration-gcp')
+                } else if (cloudPlatform == 'aws') {
+                    allTestTags.add('integration-aws')
+                } else if (cloudPlatform == 'azure') {
+                    allTestTags.add('integration-azure')
+                } else if (cloudPlatform == null) {  // run all tests
+                    allTestTags.addAll(['integration-gcp', 'integration-aws', 'integration-azure'])
+                }
             }
+            // else only run on supplied tag, ignoring platform
         }
 
         // tell junit to run tests with this tag: unit or integration
@@ -86,6 +92,7 @@ task runTestsWithTag(type: Test) {
         // Running them in parallel will cause runners to clobber this state, so these tests must be run serially.
         maxParallelForks = (testTag == 'unit' ? localCores : 1)
     }
+
     beforeTest { descriptor ->
         println '========================================================='
         println "Running test: ${descriptor.name} [${descriptor.className}]"

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -7,6 +7,50 @@ task runInstallForTesting(type: Exec) {
     dependsOn installDist
 }
 
+// Builds and returns a complete list of test tags to be executed on
+//      testType: 'unit' / 'integration'
+//      testTag: input from gradle command run
+//      cloudPlatform: input from gradle command run
+def getAllTestTags(String testType, String testTag, String cloudPlatform) {
+    def allTestTags = []
+    switch (testTag) {
+
+        case testType:
+            allTestTags.add(testType)
+            if (cloudPlatform == 'gcp') {
+                allTestTags.add(testType + '-gcp')
+            } else if (cloudPlatform == 'aws') {
+                allTestTags.add(testType + '-aws')
+            } else if (cloudPlatform == 'azure') {
+                allTestTags.add(testType + '-azure')
+            } else if (cloudPlatform == null) {  // run all tests
+                allTestTags.addAll([testType + '-gcp', testType + '-aws', testType + '-azure'])
+            }
+            break
+
+        case testType + '-gcp':
+            if ((cloudPlatform == 'gcp') || (cloudPlatform == null)) {
+                allTestTags.add(testType + '-gcp')
+            }
+            break
+
+        case testType + '-aws':
+            if ((cloudPlatform == 'aws') || (cloudPlatform == null)) {
+                allTestTags.add(testType + '-aws')
+            }
+            break
+
+        case testType + '-azure':
+            if ((cloudPlatform == 'azure') || (cloudPlatform == null)) {
+                allTestTags.add(testType + '-azure')
+            }
+            break
+        default:
+            break // no tests
+    }
+    return allTestTags
+}
+
 // run tests with the specified tag and install mode.
 // 1) run unit tests directly against the source code
 //    ./gradlew runTestsWithTag -PtestTag=unit
@@ -40,41 +84,7 @@ task runTestsWithTag(type: Test) {
             // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
             systemProperty('TERRA_CLI_VERSION', "${project.version}")
 
-            switch (testTag) {
-                case 'unit':
-                    allTestTags.add('unit')
-                    if (cloudPlatform == 'gcp') {
-                        allTestTags.add('unit-gcp')
-                    } else if (cloudPlatform == 'aws') {
-                        allTestTags.add('unit-aws')
-                    } else if (cloudPlatform == 'azure') {
-                        allTestTags.add('unit-azure')
-                    } else if (cloudPlatform == null) {  // run all tests
-                        allTestTags.addAll(['unit-gcp', 'unit-aws', 'unit-azure'])
-                    }
-                    break
-
-                case 'unit-gcp':
-                    if ((cloudPlatform == 'gcp') || (cloudPlatform == null)) {
-                        allTestTags.add('unit-gcp')
-                    }
-                    break
-
-                case 'unit-aws':
-                    if ((cloudPlatform == 'aws') || (cloudPlatform == null)) {
-                        allTestTags.add('unit-aws')
-                    }
-                    break
-
-                case 'unit-azure':
-                    if ((cloudPlatform == 'azure') || (cloudPlatform == null)) {
-                        allTestTags.add('unit-azure')
-                    }
-                    break
-
-                default:
-                    break // no tests
-            }
+            allTestTags = getAllTestTags('unit', testTag, cloudPlatform)
 
         } else if (testTag.startsWith('integration')) {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
@@ -89,41 +99,7 @@ task runTestsWithTag(type: Test) {
             mkdir "${project.buildDir}/test-working-dir/"
             systemProperty('TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/")
 
-            switch (testTag) {
-                case 'integration':
-                    allTestTags.add('integration')
-                    if (cloudPlatform == 'gcp') {
-                        allTestTags.add('integration-gcp')
-                    } else if (cloudPlatform == 'aws') {
-                        allTestTags.add('integration-aws')
-                    } else if (cloudPlatform == 'azure') {
-                        allTestTags.add('integration-azure')
-                    } else if (cloudPlatform == null) {  // run all tests
-                        allTestTags.addAll(['integration-gcp', 'integration-aws', 'integration-azure'])
-                    }
-                    break
-
-                case 'integration-gcp':
-                    if ((cloudPlatform == 'gcp') || (cloudPlatform == null)) {
-                        allTestTags.add('integration-gcp')
-                    }
-                    break
-
-                case 'integration-aws':
-                    if ((cloudPlatform == 'aws') || (cloudPlatform == null)) {
-                        allTestTags.add('integration-aws')
-                    }
-                    break
-
-                case 'integration-azure':
-                    if ((cloudPlatform == 'azure') || (cloudPlatform == null)) {
-                        allTestTags.add('integration-azure')
-                    }
-                    break
-
-                default:
-                    break // no tests
-            }
+            allTestTags = getAllTestTags('integration', testTag, cloudPlatform)
         }
 
         // tell junit to run tests with this tag: unit or integration

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -11,7 +11,7 @@ task runInstallForTesting(type: Exec) {
 //      testType: 'unit' / 'integration'
 //      testTag: input from gradle command run
 //      cloudPlatform: input from gradle command run
-def getAllTestTags(String testType, String testTag, String cloudPlatform) {
+def getAllTestTagsToRun(String testType, String testTag, String cloudPlatform) {
     def allTestTags = []
     switch (testTag) {
         case testType:
@@ -48,7 +48,7 @@ def getAllTestTags(String testType, String testTag, String cloudPlatform) {
         default:
             break // no tests
     }
-    return allTestTags
+    return allTestTags as String[]
 }
 
 // run tests with the specified tag and install mode.
@@ -72,10 +72,10 @@ task runTestsWithTag(type: Test) {
             throw new GradleException('The testTag Gradle property is required (e.g. -PtestTag=unit, -PtestTag=integration)')
         }
 
-        def allTestTags = []
-        String cloudPlatform = project.findProperty('platform')
-
+        String testType = null
         if (testTag.startsWith('unit')) {
+            testType = 'unit'
+
             // [for unit tests] specify the implementation version that's set in the JAR manifest. unit tests
             // run against the code directly, and so there is no JAR manifest. this implementation version is
             // used to get the default docker image id.
@@ -84,9 +84,9 @@ task runTestsWithTag(type: Test) {
             // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
             systemProperty('TERRA_CLI_VERSION', "${project.version}")
 
-            allTestTags = getAllTestTags('unit', testTag, cloudPlatform)
-
         } else if (testTag.startsWith('integration')) {
+            testType = 'integration'
+
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
             // for an installation directly from source code, this points to the build/install/terra-cli/bin directory (i.e. the output of ./gradlew install)
             // for an installation from a GH release, this points to the build/test-install directory (i.e. where the curl install command is run)
@@ -98,21 +98,19 @@ task runTestsWithTag(type: Test) {
             // it easier to clean up after tests (./gradlew clean) that generate files.
             mkdir "${project.buildDir}/test-working-dir/"
             systemProperty('TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/")
-
-            allTestTags = getAllTestTags('integration', testTag, cloudPlatform)
         }
 
         // tell junit to run tests with this tag: unit or integration
         useJUnitPlatform {
-            includeTags allTestTags as String[]
+            includeTags getAllTestTagsToRun(testType, testTag, project.findProperty('platform'))
         }
 
         // We don't want to use up all the cores on a developer's machine because it locks them out of doing other
         // work, but that's not a concern for dedicated CI machines.
         int localCores = System.getenv().containsKey('CI') ? Runtime.runtime.availableProcessors() : Runtime.runtime.availableProcessors().intdiv(2)
-        // Integration tests wrap various external command-line tools which often maintain their own global state.
+        // Integration te./gradlew runTestsWithTag -PtestTag=unit -Pplatform=aws -Pserver=verily-mc-feature-dev -PtestConfig=verilysts wrap various external command-line tools which often maintain their own global state.
         // Running them in parallel will cause runners to clobber this state, so these tests must be run serially.
-        maxParallelForks = testTag.startsWith('integration') ? 1 : localCores
+        maxParallelForks = (testType == 'integration') ? 1 : localCores
     }
 
     beforeTest { descriptor ->

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -14,7 +14,6 @@ task runInstallForTesting(type: Exec) {
 def getAllTestTags(String testType, String testTag, String cloudPlatform) {
     def allTestTags = []
     switch (testTag) {
-
         case testType:
             allTestTags.add(testType)
             if (cloudPlatform == 'gcp') {
@@ -45,6 +44,7 @@ def getAllTestTags(String testType, String testTag, String cloudPlatform) {
                 allTestTags.add(testType + '-azure')
             }
             break
+
         default:
             break // no tests
     }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -28,7 +28,7 @@ task runTestsWithTag(type: Test) {
             throw new GradleException('The testTag Gradle property is required (e.g. -PtestTag=unit, -PtestTag=integration)')
         }
 
-        def allTestTags = [testTag] // non-platform specific tests
+        def allTestTags = []
         String cloudPlatform = project.findProperty('platform')
 
         if (testTag.startsWith('unit')) {
@@ -40,18 +40,41 @@ task runTestsWithTag(type: Test) {
             // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
             systemProperty('TERRA_CLI_VERSION', "${project.version}")
 
-            if (testTag == 'unit') {
-                if (cloudPlatform == 'gcp') {
-                    allTestTags.add('unit-gcp')
-                } else if (cloudPlatform == 'aws') {
-                    allTestTags.add('unit-aws')
-                } else if (cloudPlatform == 'azure') {
-                    allTestTags.add('unit-azure')
-                } else if (cloudPlatform == null) {  // run all tests
-                    allTestTags.addAll(['unit-gcp', 'unit-aws', 'unit-azure'])
-                }
+            switch (testTag) {
+                case 'unit':
+                    allTestTags.add('unit')
+                    if (cloudPlatform == 'gcp') {
+                        allTestTags.add('unit-gcp')
+                    } else if (cloudPlatform == 'aws') {
+                        allTestTags.add('unit-aws')
+                    } else if (cloudPlatform == 'azure') {
+                        allTestTags.add('unit-azure')
+                    } else if (cloudPlatform == null) {  // run all tests
+                        allTestTags.addAll(['unit-gcp', 'unit-aws', 'unit-azure'])
+                    }
+                    break
+
+                case 'unit-gcp':
+                    if ((cloudPlatform == 'gcp') || (cloudPlatform == null)) {
+                        allTestTags.add('unit-gcp')
+                    }
+                    break
+
+                case 'unit-aws':
+                    if ((cloudPlatform == 'aws') || (cloudPlatform == null)) {
+                        allTestTags.add('unit-aws')
+                    }
+                    break
+
+                case 'unit-azure':
+                    if ((cloudPlatform == 'azure') || (cloudPlatform == null)) {
+                        allTestTags.add('unit-azure')
+                    }
+                    break
+
+                default:
+                    break // no tests
             }
-            // else only run on supplied tag, ignoring platform
 
         } else if (testTag.startsWith('integration')) {
             // [for integration tests] specify the install location for the terra application (i.e. launch script)
@@ -66,18 +89,41 @@ task runTestsWithTag(type: Test) {
             mkdir "${project.buildDir}/test-working-dir/"
             systemProperty('TERRA_WORKING_DIR', "${project.buildDir}/test-working-dir/")
 
-            if (testTag == 'integration') {
-                if (cloudPlatform == 'gcp') {
-                    allTestTags.add('integration-gcp')
-                } else if (cloudPlatform == 'aws') {
-                    allTestTags.add('integration-aws')
-                } else if (cloudPlatform == 'azure') {
-                    allTestTags.add('integration-azure')
-                } else if (cloudPlatform == null) {  // run all tests
-                    allTestTags.addAll(['integration-gcp', 'integration-aws', 'integration-azure'])
-                }
+            switch (testTag) {
+                case 'integration':
+                    allTestTags.add('integration')
+                    if (cloudPlatform == 'gcp') {
+                        allTestTags.add('integration-gcp')
+                    } else if (cloudPlatform == 'aws') {
+                        allTestTags.add('integration-aws')
+                    } else if (cloudPlatform == 'azure') {
+                        allTestTags.add('integration-azure')
+                    } else if (cloudPlatform == null) {  // run all tests
+                        allTestTags.addAll(['integration-gcp', 'integration-aws', 'integration-azure'])
+                    }
+                    break
+
+                case 'integration-gcp':
+                    if ((cloudPlatform == 'gcp') || (cloudPlatform == null)) {
+                        allTestTags.add('integration-gcp')
+                    }
+                    break
+
+                case 'integration-aws':
+                    if ((cloudPlatform == 'aws') || (cloudPlatform == null)) {
+                        allTestTags.add('integration-aws')
+                    }
+                    break
+
+                case 'integration-azure':
+                    if ((cloudPlatform == 'azure') || (cloudPlatform == null)) {
+                        allTestTags.add('integration-azure')
+                    }
+                    break
+
+                default:
+                    break // no tests
             }
-            // else only run on supplied tag, ignoring platform
         }
 
         // tell junit to run tests with this tag: unit or integration
@@ -90,7 +136,7 @@ task runTestsWithTag(type: Test) {
         int localCores = System.getenv().containsKey('CI') ? Runtime.runtime.availableProcessors() : Runtime.runtime.availableProcessors().intdiv(2)
         // Integration tests wrap various external command-line tools which often maintain their own global state.
         // Running them in parallel will cause runners to clobber this state, so these tests must be run serially.
-        maxParallelForks = (testTag == 'unit' ? localCores : 1)
+        maxParallelForks = testTag.startsWith('integration') ? 1 : localCores
     }
 
     beforeTest { descriptor ->

--- a/src/main/java/bio/terra/cli/service/SamService.java
+++ b/src/main/java/bio/terra/cli/service/SamService.java
@@ -6,6 +6,7 @@ import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.utils.HttpUtils;
+import bio.terra.cli.utils.HttpClients;
 import bio.terra.cli.utils.JacksonMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.api.client.http.HttpStatusCodes;
@@ -55,6 +56,7 @@ public class SamService {
     this.server = server;
     this.apiClient = new ApiClient();
 
+    this.apiClient.setHttpClient(HttpClients.getSamClient());
     this.apiClient.setBasePath(server.getSamUri());
     this.apiClient.setUserAgent("OpenAPI-Generator/1.0.0 java"); // only logs an error in sam
     if (accessToken != null) {

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -23,6 +23,7 @@ import bio.terra.cli.serialization.userfacing.input.UpdateReferencedGcsBucketPar
 import bio.terra.cli.serialization.userfacing.input.UpdateReferencedGcsObjectParams;
 import bio.terra.cli.serialization.userfacing.input.UpdateReferencedGitRepoParams;
 import bio.terra.cli.service.utils.HttpUtils;
+import bio.terra.cli.utils.HttpClients;
 import bio.terra.cli.utils.JacksonMapper;
 import bio.terra.workspace.api.ControlledGcpResourceApi;
 import bio.terra.workspace.api.FolderApi;
@@ -142,6 +143,7 @@ public class WorkspaceManagerService {
     this.server = server;
     this.apiClient = new ApiClient();
 
+    this.apiClient.setHttpClient(HttpClients.getWsmClient());
     this.apiClient.setBasePath(server.getWorkspaceManagerUri());
     if (accessToken != null) {
       // fetch the user access token

--- a/src/main/java/bio/terra/cli/utils/HttpClients.java
+++ b/src/main/java/bio/terra/cli/utils/HttpClients.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.utils;
+
+import javax.ws.rs.client.Client;
+import okhttp3.OkHttpClient;
+import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
+
+/**
+ * Many client libraries for Terra services maintain their own thread pools, but the CLI constantly
+ * creates and deletes these clients, leading to a lot of hanging threads and memory problems
+ * (especially during tests). To avoid this, we maintain shared client objects
+ */
+public class HttpClients {
+  private static final OkHttpClient samClient;
+  private static final Client wsmClient;
+
+  static {
+    samClient = new ApiClient().getHttpClient();
+    wsmClient = new bio.terra.workspace.client.ApiClient().getHttpClient();
+  }
+
+  private HttpClients() {}
+
+  public static OkHttpClient getSamClient() {
+    return samClient;
+  }
+
+  public static Client getWsmClient() {
+    return wsmClient;
+  }
+}

--- a/src/test/java/harness/TestBashScript.java
+++ b/src/test/java/harness/TestBashScript.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.CoreMatchers;
 
 /**
@@ -21,31 +22,38 @@ public class TestBashScript {
    * Executes a test script in a separate process from the current working directory.
    *
    * @param scriptName name of the script in the test/resources/testscripts directory (e.g.
-   *     NextflowRnaseq.sh)
+   *     NextflowRnaseqSetup.sh)
+   * @param args arguments to pass to the test script
    * @return process exit code
    */
-  public static int runScript(String scriptName) {
+  public static int runScript(String scriptName, List<String> args) {
     // build the command from the script name
     Path script = TestBashScript.getPathFromScriptName(scriptName);
-    List<String> command = Collections.singletonList("bash " + script);
+    String joinedArgs = StringUtils.join(args, " ");
+    String fullCommand = String.join(" ", "bash", script.toString(), joinedArgs);
 
-    return runCommands(command, Collections.emptyMap());
+    return runCommands(List.of(fullCommand), Collections.emptyMap());
+  }
+
+  public static int runScript(String scriptName) {
+    return runScript(scriptName, List.of());
   }
 
   /**
    * Executes a command in a separate process from the given working directory, with the given
    * environment variables set beforehand. Adds `terra` to the $PATH.
    *
-   * @param command the command and arguments to execute
+   * @param commands the commands and arguments to execute. each element of this list should be a
+   *     separate (command + arguments) entry.
    * @param envVars the environment variables to set or overwrite if already defined
    * @return process exit code
    */
-  public static int runCommands(List<String> command, Map<String, String> envVars) {
+  public static int runCommands(List<String> commands, Map<String, String> envVars) {
     // execute the commands via bash
     List<String> bashCommand = new ArrayList<>();
     bashCommand.add("bash");
     bashCommand.add("-cx"); // -x option = print out the commands as they run
-    bashCommand.add(String.join("; ", command));
+    bashCommand.add(String.join("; ", commands));
 
     // add to the $PATH the directory where the CLI is installed
     Map<String, String> envVarsCopy = new HashMap<>(envVars);

--- a/src/test/java/integration/Nextflow.java
+++ b/src/test/java/integration/Nextflow.java
@@ -9,6 +9,7 @@ import harness.baseclasses.ClearContextIntegration;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -55,10 +56,20 @@ public class Nextflow extends ClearContextIntegration {
     int exitCode = TestBashScript.runScript("CreateWorkspace.sh");
     assertEquals(0, exitCode, "workspace created without errors");
 
+    String resourceName = "terraclitesting";
     // run the script that downloads the NF workflow from GH and runs it
-    exitCode = TestBashScript.runScript("NextflowRnaseq.sh");
+    TestBashScript.runScript("NextflowRnaseqSetup.sh", List.of(resourceName));
 
-    // check that the NF script ran successfully
+    // Try running the script once, which will likely (but not definitely) fail due to missing
+    // permissions on the bucket.
+    exitCode = TestBashScript.runScript("NextflowRnaseqWorkflow.sh", List.of(resourceName));
+    if (exitCode != 0) {
+      // Try running the script a second time. After the first run, the user is much more likely to
+      // have bucket permissions.
+      exitCode = TestBashScript.runScript("NextflowRnaseqWorkflow.sh", List.of(resourceName));
+    }
+
+    // check that the NF script ran successfully at least one time.
     assertEquals(0, exitCode, "script completed without errors");
   }
 }

--- a/src/test/java/unit/GcloudBuildsSubmit.java
+++ b/src/test/java/unit/GcloudBuildsSubmit.java
@@ -5,13 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.serialization.userfacing.resource.UFGcsBucket;
-import bio.terra.cli.service.utils.CrlUtils;
-import com.google.api.gax.paging.Page;
-import com.google.cloud.storage.Blob;
-import com.google.cloud.storage.Storage;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnitGcp;
-import harness.utils.ExternalGCSBuckets;
 import java.io.File;
 import java.io.IOException;
 import org.junit.jupiter.api.AfterAll;
@@ -53,20 +48,11 @@ public class GcloudBuildsSubmit extends SingleWorkspaceUnitGcp {
 
     // `terra resource create gcs-bucket --name=$name --format=json`
     String bucketResourceName = "resourceName";
-    UFGcsBucket createdBucket =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFGcsBucket.class, "resource", "create", "gcs-bucket", "--name=" + bucketResourceName);
-
-    // Poll until the test user can fetch the bucket, which may be delayed.
-    Storage ownerClient =
-        ExternalGCSBuckets.getStorageClient(
-            workspaceCreator.getCredentialsWithCloudPlatformScope());
-    Page<Blob> bucketContents =
-        CrlUtils.callGcpWithPermissionExceptionRetries(
-            () -> ownerClient.get(createdBucket.bucketName).list());
+    TestCommand.runAndParseCommandExpectSuccess(
+        UFGcsBucket.class, "resource", "create", "gcs-bucket", "--name=" + bucketResourceName);
 
     // `builds submit --async --gcs-bucket-resource=bucketName --tag=$tag`
-    TestCommand.runCommandExpectSuccess(
+    TestCommand.runCommandExpectSuccessWithRetries(
         "gcloud",
         "builds",
         "submit",

--- a/src/test/resources/testscripts/CreateWorkspace.sh
+++ b/src/test/resources/testscripts/CreateWorkspace.sh
@@ -11,9 +11,6 @@ if [[ "true" == "$isLoggedIn" ]]; then
   echo "User $currentUser is logged in. Creating a new workspace."
   terra workspace create --id=my-workspace-$RANDOM
   terra auth status
-  # Polling for GCP permissions is difficult as the test user may not have gcloud credentials available,
-  # so instead this is a static wait to compensate for the delay in syncing IAM permissions in GCP.
-  sleep 600
 else
   echo "No user is logged in. Skipping creating a new workspace."
 fi

--- a/src/test/resources/testscripts/NextflowRnaseqSetup.sh
+++ b/src/test/resources/testscripts/NextflowRnaseqSetup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+## This script runs a demo Nextflow workflow on the GLS Pipelines API. The inline comments are talking notes for a demo.
+# Expected usage: NextflowRnaseqSetup.sh {resourceName}
+resourceName=$1
+if [[ -z "$resourceName" ]]; then
+  echo "Expected usage: NextflowRnaseqSetup.sh {resourceName}"
+  return 1
+fi
+
+# [Before demo]
+#   - Run through commands once
+#       - Do this at least 10 minutes beforehand, so the Nextflow workflow has time to complete
+#       - Keep the directory and terminal tab open, so we can switch back to it at the end of the demo, to show a completed workflow
+#   - Open the following pages in a browser:
+#       - https://github.com/DataBiosphere/terra-cli/releases
+#       - https://github.com/nextflow-io/rnaseq-nf
+#       - https://cloud.google.com/life-sciences/docs/tutorials/nextflow
+#       - file:///Users/marikomedlock/Desktop/working-terra-cli/demo6/results/multiqc_report.html
+
+# Check the status to see the current workspace id and backing GCP project.
+
+terra status
+
+# Nextflow requires a bucket to store temporary files. We can create a controlled resource for this, which means a cloud resource (a bucket in this case) within the backing GCP project.
+# Bucket names must be globally unique, so use a random UUID with the dashes removed for the bucket name.
+# Terra resource names must only be unique within the workspace, so use a fixed string for the resource name.
+
+bucketName=$(uuidgen | tr "[:upper:]" "[:lower:]" | sed -e 's/-//g')
+echo "resourceName: $resourceName, bucketName: $bucketName"
+terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
+terra resource describe --name=$resourceName
+
+# I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
+
+git clone https://github.com/nextflow-io/rnaseq-nf.git
+cd rnaseq-nf
+git checkout v2.0
+cd ..

--- a/src/test/resources/testscripts/NextflowRnaseqWorkflow.sh
+++ b/src/test/resources/testscripts/NextflowRnaseqWorkflow.sh
@@ -1,39 +1,9 @@
-#!/bin/bash
-set -e
-## This script runs a demo Nextflow workflow on the GLS Pipelines API. The inline comments are talking notes for a demo.
-
-# [Before demo]
-#   - Run through commands once
-#       - Do this at least 10 minutes beforehand, so the Nextflow workflow has time to complete
-#       - Keep the directory and terminal tab open, so we can switch back to it at the end of the demo, to show a completed workflow
-#   - Open the following pages in a browser:
-#       - https://github.com/DataBiosphere/terra-cli/releases
-#       - https://github.com/nextflow-io/rnaseq-nf
-#       - https://cloud.google.com/life-sciences/docs/tutorials/nextflow
-#       - file:///Users/marikomedlock/Desktop/working-terra-cli/demo6/results/multiqc_report.html
-
-# Check the status to see the current workspace id and backing GCP project.
-
-terra status
-
-# Nextflow requires a bucket to store temporary files. We can create a controlled resource for this, which means a cloud resource (a bucket in this case) within the backing GCP project.
-# Bucket names must be globally unique, so use a random UUID with the dashes removed for the bucket name.
-# Terra resource names must only be unique within the workspace, so use a fixed string for the resource name.
-
-resourceName="terraclitesting"
-bucketName=$(uuidgen | tr "[:upper:]" "[:lower:]" | sed -e 's/-//g')
-echo "resourceName: $resourceName, bucketName: $bucketName"
-terra resource create gcs-bucket --name=$resourceName --bucket-name=$bucketName
-terra resource list
-# Wait for permissions to propagate on the new bucket before attempting to use it
-sleep 900
-
-# I will use an example Nextflow workflow from a GitHub repository [show webpage], and checkout a tag that I have tested beforehand. This is the same example workflow that is used on the GCP + Nextflow tutorial [show webpage].
-
-git clone https://github.com/nextflow-io/rnaseq-nf.git
-cd rnaseq-nf
-git checkout v2.0
-cd ..
+# Expected usage: NextflowRnaseqSetup.sh {resourceName}
+resourceName=$1
+if [[ -z "$resourceName" ]]; then
+  echo "Expected usage: NextflowRnaseqSetup.sh {resourceName}"
+  return 1
+fi
 
 # Nextflow users modify the nextflow.config file to specify where to run the batch jobs. I will modify the gls section because I will run against the Google Life Sciences Pipelines API.
 terra nextflow -version


### PR DESCRIPTION
Problem statement - No support to run tests by a single tag. i.e. Cannot run only GCP-specific tests. Only option would be to run both GCP-specific (unit-gcp) + platform agnostic (unit) tests. This can both make testing cumbersome and unnecessarily duplicate test runs

Fix - add support to run tests by specific tag. 
Changes are backward compatible

Sample test runs

```
./gradlew runTestsWithTag -PtestTag=unit -Pplatform=aws -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: unit / testTag: unit / platform: aws --> allTestTags: [unit, unit-aws]

./gradlew runTestsWithTag -PtestTag=unit-aws -Pplatform=aws -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: unit / testTag: unit-aws / platform: aws --> allTestTags: [unit-aws]

./gradlew runTestsWithTag -PtestTag=unit-aws -Pplatform=gcp -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: unit / testTag: unit-aws / platform: gcp --> allTestTags: []

./gradlew runTestsWithTag -PtestTag=unit -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: unit / testTag: unit / platform: null --> allTestTags: [unit, unit-gcp, unit-aws, unit-azure]

./gradlew runTestsWithTag -PtestTag=unit-aws -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: unit / testTag: unit-aws / platform: null --> allTestTags: [unit-aws]

./gradlew runTestsWithTag -PtestTag=integration -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: integration / testTag: integration / platform: null --> allTestTags: [integration, integration-gcp, integration-aws, integration-azure]

./gradlew runTestsWithTag -PtestTag=integration-azure -Pplatform=gcp -Pserver=verily-mc-feature-dev -PtestConfig=verily
> testType: integration / testTag: integration-azure / platform: gcp --> allTestTags: []
```
