### PR TITLE
fix typo, make the ssh-key command descriptive text more consistent

### DIFF
--- a/src/main/java/bio/terra/cli/command/SshKey.java
+++ b/src/main/java/bio/terra/cli/command/SshKey.java
@@ -7,6 +7,6 @@ import picocli.CommandLine.Command;
 
 @Command(
     name = "ssh-key",
-    description = "Get and generate an terra managed ssh key pair.",
+    description = "Get and generate a Terra-managed SSH key pair.",
     subcommands = {Get.class, Generate.class, Add.class})
 public class SshKey {}

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Add.java
@@ -17,7 +17,7 @@ import java.util.List;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "add", description = "Save your Terra SSH key to ~/.ssh and add it to ssh agent.")
+@Command(name = "add", description = "Save your Terra SSH key to ~/.ssh and add it to ssh-agent.")
 public class Add extends BaseCommand {
 
   @CommandLine.Mixin Format formatOption;

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Generate.java
@@ -10,13 +10,13 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra user ssh-key generate" command. */
-@Command(name = "generate", description = "Generate a terra managed ssh key.")
+@Command(name = "generate", description = "Generate a Terra-managed SSH key.")
 public class Generate extends BaseCommand {
   @CommandLine.Mixin Format formatOption;
 
   @CommandLine.Option(
       names = "--save-to-file",
-      description = "Save the terra ssh key pair as file, skip printing out the key")
+      description = "Save the Terra SSH key pair as a file, skip printing out the key")
   boolean saveToFile;
 
   @CommandLine.Mixin ConfirmationPrompt confirmationPrompt;

--- a/src/main/java/bio/terra/cli/command/user/sshkey/Get.java
+++ b/src/main/java/bio/terra/cli/command/user/sshkey/Get.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 /** This class corresponds to the fourth-level "terra user ssh-key get" command. */
-@Command(name = "get", description = "Get a terra-generated and -managed ssh key.")
+@Command(name = "get", description = "Get a Terra-generated and -managed SSH key.")
 public class Get extends BaseCommand {
   @CommandLine.Mixin Format formatOption;
 


### PR DESCRIPTION
I created the PR to fix a typo in a description, but while I was in there I thought I would make the descriptive text a bit more consistent as well.