### PR TITLE
[PF-2478] Only run checks when PR targets 'main' branch

### DIFF
--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore: [ '**.md' ]
   pull_request:
     # Branch settings require status checks before merging, so don't add paths-ignore.
-    branches: [ '**' ]
+    branches: [ main ]
 
 jobs:
   lint-and-static-analysis:


### PR DESCRIPTION
Only run PR checks when the PR targets main/master branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.