### PR TITLE
[PF-2333] Client-side fix for connection reset issues

### DIFF
--- a/src/main/java/bio/terra/cli/service/DataRepoService.java
+++ b/src/main/java/bio/terra/cli/service/DataRepoService.java
@@ -3,6 +3,7 @@ package bio.terra.cli.service;
 import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.businessobject.User;
 import bio.terra.cli.exception.SystemException;
+import bio.terra.cli.utils.HttpClients;
 import bio.terra.datarepo.api.UnauthenticatedApi;
 import bio.terra.datarepo.client.ApiClient;
 import bio.terra.datarepo.client.ApiException;
@@ -25,7 +26,9 @@ public class DataRepoService {
   private DataRepoService(@Nullable User user, Server server) {
     this.apiClient = new ApiClient();
 
-    this.apiClient.setBasePath(server.getDataRepoUri());
+    this.apiClient
+        .setHttpClient(HttpClients.getDataRepoClient())
+        .setBasePath(server.getDataRepoUri());
     if (user != null) {
       this.apiClient.setAccessToken(user.getTerraToken().getTokenValue());
     }

--- a/src/main/java/bio/terra/cli/service/UserManagerService.java
+++ b/src/main/java/bio/terra/cli/service/UserManagerService.java
@@ -4,6 +4,7 @@ import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.service.utils.HttpUtils;
+import bio.terra.cli.utils.HttpClients;
 import bio.terra.user.api.ProfileApi;
 import bio.terra.user.api.PublicApi;
 import bio.terra.user.client.ApiClient;
@@ -32,7 +33,9 @@ public class UserManagerService {
   private UserManagerService(@Nullable AccessToken accessToken, Server server) {
     this.apiClient = new ApiClient();
 
-    this.apiClient.setBasePath(server.getUserManagerUri());
+    this.apiClient
+        .setHttpClient(HttpClients.getUserManagerClient())
+        .setBasePath(server.getUserManagerUri());
     if (accessToken != null) {
       this.apiClient.setAccessToken(accessToken.getTokenValue());
     }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -466,7 +466,7 @@ public class WorkspaceManagerService {
                   WorkspaceManagerService::isRetryable,
                   // Context creation will wait for cloud IAM permissions to sync, so poll for up to
                   // 30 minutes.
-                  /*maxCalls=*/ 4*30,
+                  /*maxCalls=*/ 4 * 30,
                   /*sleepDuration=*/ Duration.ofSeconds(15));
           logger.debug("create workspace context result: {}", createContextResult);
           StatusEnum status = createContextResult.getJobReport().getStatus();

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -466,8 +466,8 @@ public class WorkspaceManagerService {
                   WorkspaceManagerService::isRetryable,
                   // Context creation will wait for cloud IAM permissions to sync, so poll for up to
                   // 30 minutes.
-                  /*maxCalls=*/ 30,
-                  /*sleepDuration=*/ Duration.ofSeconds(60));
+                  /*maxCalls=*/ 4*30,
+                  /*sleepDuration=*/ Duration.ofSeconds(15));
           logger.debug("create workspace context result: {}", createContextResult);
           StatusEnum status = createContextResult.getJobReport().getStatus();
           if (StatusEnum.FAILED == status) {
@@ -666,8 +666,8 @@ public class WorkspaceManagerService {
                     (result) -> isDone(result.getJobReport()),
                     WorkspaceManagerService::isRetryable,
                     // Retry for 30 minutes, as this involves creating a new context
-                    /*maxCalls=*/ 30,
-                    /*sleepDuration=*/ Duration.ofSeconds(60)),
+                    /*maxCalls=*/ 4 * 30,
+                    /*sleepDuration=*/ Duration.ofSeconds(15)),
             "Error in cloning workspace.");
     logger.debug("clone workspace polling result: {}", cloneWorkspaceResult);
     throwIfJobNotCompleted(

--- a/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
+++ b/src/main/java/bio/terra/cli/service/utils/CrlUtils.java
@@ -19,8 +19,8 @@ import org.apache.http.HttpStatus;
 public class CrlUtils {
 
   // For GCP permissions propagation, retry for up to 30 minutes.
-  public static final int GCP_RETRY_COUNT = 30;
-  public static final Duration GCP_RETRY_SLEEP_DURATION = Duration.ofSeconds(60);
+  public static final int GCP_RETRY_COUNT = 120;
+  public static final Duration GCP_RETRY_SLEEP_DURATION = Duration.ofSeconds(15);
 
   private static final ClientConfig clientConfig =
       ClientConfig.Builder.newBuilder().setClient("terra-cli").build();

--- a/src/main/java/bio/terra/cli/utils/HttpClients.java
+++ b/src/main/java/bio/terra/cli/utils/HttpClients.java
@@ -12,10 +12,14 @@ import org.broadinstitute.dsde.workbench.client.sam.ApiClient;
 public class HttpClients {
   private static final OkHttpClient samClient;
   private static final Client wsmClient;
+  private static final Client dataRepoClient;
+  private static final Client userManagerClient;
 
   static {
     samClient = new ApiClient().getHttpClient();
     wsmClient = new bio.terra.workspace.client.ApiClient().getHttpClient();
+    dataRepoClient = new bio.terra.datarepo.client.ApiClient().getHttpClient();
+    userManagerClient = new bio.terra.user.client.ApiClient().getHttpClient();
   }
 
   private HttpClients() {}
@@ -26,5 +30,13 @@ public class HttpClients {
 
   public static Client getWsmClient() {
     return wsmClient;
+  }
+
+  public static Client getDataRepoClient() {
+    return dataRepoClient;
+  }
+
+  public static Client getUserManagerClient() {
+    return userManagerClient;
   }
 }

--- a/src/test/java/harness/utils/GcpNotebookUtils.java
+++ b/src/test/java/harness/utils/GcpNotebookUtils.java
@@ -42,8 +42,8 @@ public class GcpNotebookUtils {
                     "--workspace=" + workspaceUserFacingId),
         (result) -> notebookState.equals(result.state),
         (ex) -> false, // no retries
-        2 * 20, // up to 20 minutes
-        Duration.ofSeconds(30)); // every 30 seconds
+        4 * 20, // up to 20 minutes
+        Duration.ofSeconds(15)); // every 15 seconds
 
     assertNotebookState(resourceName, notebookState, workspaceUserFacingId);
   }


### PR DESCRIPTION
The cause of these `Connection Reset` issues appears to be the 30s default idle timeout in the JdkConnector inside WSM's client wrapper. The fix for this is removing all places where the CLI is polling WSM slower than once per 30s to prevent these idle connections from being closed.

It's also possible to change this timeout value, but for most polling patterns (especially now that IAM delay is generally mitigated) 30s seems reasonable.

Additionally, this switches the TDR and UserManager clients to use static HttpClients like WSM. This wasn't an issue as these don't get called nearly as much, but it's a small improvement.

