### PR TITLE
(Do not submit) Fake change for CI comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,3 +119,4 @@ apply from: "$rootDir/gradle/spotbugs.gradle"
 apply from: "$rootDir/gradle/spotless.gradle"
 apply from: "$rootDir/gradle/tools.gradle"
 apply from: "$rootDir/gradle/test.gradle"
+


### PR DESCRIPTION
The PR tests for #448 ran in ~half the time I'd expect. I'd like to know if that's a WSM client change (less likely) or temporary grant code finally affecting CLI tests (more likely).