### PR TITLE
POC demonstrating how to use guest attributes to improve notebook VM startup output.

### DIFF
--- a/src/main/java/bio/terra/cli/app/utils/LocalProcessLauncher.java
+++ b/src/main/java/bio/terra/cli/app/utils/LocalProcessLauncher.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -95,5 +96,17 @@ public class LocalProcessLauncher {
     } catch (InterruptedException intEx) {
       throw new SystemException("Error waiting for child process to terminate", intEx);
     }
+  }
+
+  public InputStream getErrorStream() {
+    return process.getErrorStream();
+  }
+
+  public InputStream getInputStream() {
+    return process.getInputStream();
+  }
+
+  public OutputStream getOutputStream() {
+    return process.getOutputStream();
   }
 }


### PR DESCRIPTION
Note intended as-is for commit. Intended as POC.

A good implementation would probably include getting attributes through the GCP API (through a wrapper in the
terra-cloud-resource-lib).

Would anticipate having command-line flags for people to choose whether they want to fire and forget or wait for completion.