### PR TITLE
Add optional concurrent-job-limit flag to terra cromwell generate-config

### DIFF
--- a/src/main/java/bio/terra/cli/command/cromwell/GenerateConfig.java
+++ b/src/main/java/bio/terra/cli/command/cromwell/GenerateConfig.java
@@ -30,6 +30,13 @@ public class GenerateConfig extends BaseCommand {
       description = "Directory to put generated cromwell.conf in. Defaults to current directory.")
   public String dir;
 
+  @CommandLine.Option(
+      names = "--concurrent-job-limit",
+      defaultValue = "10",
+      required = false,
+      description = "Optional limits on the number of concurrent jobs. Defaults to 10.")
+  public String concurrent_job_limit;
+
   // We create an exclusive ArgGroup because we require one of either
   // workspace_bucket_name or google_bucket_name.
   @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
@@ -92,7 +99,8 @@ public class GenerateConfig extends BaseCommand {
                 org.apache.commons.io.FilenameUtils.concat(dir, "cromwell.conf"),
                 googleProjectId,
                 petSaEmail,
-                googleBucket));
+                googleBucket,
+                concurrent_job_limit));
     try {
       Files.deleteIfExists(Paths.get(absolutePath));
     } catch (IOException e) {

--- a/src/main/resources/configs/generate-cromwell-config.sh
+++ b/src/main/resources/configs/generate-cromwell-config.sh
@@ -2,10 +2,18 @@
 
 # Initialize a default Cromwell config. Don't overwrite in case the user has
 # customized their Cromwell config file on their PD.
-echo "CROMWELL_CONFIG_PATH" : $1
-echo "GOOGLE_PROJECT": $2
-echo "PET_SA_EMAIL": $3
-echo "GOOGLE_BUCKET": $4
+CROMWELL_CONFIG_PATH=$1
+GOOGLE_PROJECT=$2
+PET_SA_EMAIL=$3
+GOOGLE_BUCKET=$4
+CONCURRENT_JOB_LIMIT=$5
+
+echo "CROMWELL_CONFIG_PATH" : "${CROMWELL_CONFIG_PATH}"
+echo "GOOGLE_PROJECT": "${GOOGLE_PROJECT}"
+echo "PET_SA_EMAIL": "${PET_SA_EMAIL}"
+echo "GOOGLE_BUCKET": "${GOOGLE_BUCKET}"
+echo "CONCURRENT_JOB_LIMIT": "${CONCURRENT_JOB_LIMIT}"
+
 if [[ ! -f "$1" ]]; then
   cat <<EOF | tee "$1"
 
@@ -28,9 +36,9 @@ backend {
       actor-factory = "cromwell.backend.google.pipelines.v2beta.PipelinesApiLifecycleActorFactory"
 
       config {
-        project = "$2"
-        concurrent-job-limit = 10
-        root = "$4/workflows/cromwell-executions"
+        project = "$GOOGLE_PROJECT"
+        concurrent-job-limit = $CONCURRENT_JOB_LIMIT
+        root = "$GOOGLE_BUCKET/workflows/cromwell-executions"
 
         virtual-private-cloud {
           network-label-key = "vpc-network-name"
@@ -40,7 +48,7 @@ backend {
 
         genomics {
           auth = "application_default"
-          compute-service-account = "$3"
+          compute-service-account = "$PET_SA_EMAIL"
           endpoint-url = "https://lifesciences.googleapis.com/"
           location = "us-central1"
         }

--- a/src/test/java/unit/CromwellConfig.java
+++ b/src/test/java/unit/CromwellConfig.java
@@ -36,16 +36,21 @@ public class CromwellConfig extends SingleWorkspaceUnit {
   }
 
   @Test
-  @DisplayName("cromwell generate-config with custom dir")
+  @DisplayName("cromwell generate-config with custom dir and custom concurrent-job-limit")
   void cromwellGenerateConfigCustomDir() throws IOException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
-    // `terra cromwell generate-config --dir=build --google-bucket-name=foo`
+    // `terra cromwell generate-config --dir=build --concurrent-job-limit=1337
+    // --google-bucket-name=foo`
     TestCommand.runCommandExpectSuccess(
-        "cromwell", "generate-config", "--dir=build", "--google-bucket-name=foo");
+        "cromwell",
+        "generate-config",
+        "--dir=build",
+        "--concurrent-job-limit=1337",
+        "--google-bucket-name=foo");
 
     // New cromwell.conf file generate successfully.
     assertTrue(


### PR DESCRIPTION
Previously, concurrent-job-limit was hard coded to 10. This means larger workflows are bottlenecked by only having 10 VMs up at a time. 

This PR adds an optional `concurrent-job-limit` to configure this value. I have it default to 10, but I'm open to opinions to change it. Cromwell by default does not set this value, so it's technically unlimited. I think 10 is a fine default, as it would give time for newer users to cancel an accidentally massive workflow.