### PR TITLE
[PF-2661] - Omit unsupported resources from resource list

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -105,7 +105,8 @@ public abstract class Resource {
       case BIG_QUERY_DATA_TABLE -> new BqTable(wsmObject);
       case AI_NOTEBOOK -> new GcpNotebook(wsmObject);
       case GIT_REPO -> new GitRepo(wsmObject);
-      default -> throw new IllegalArgumentException("Unexpected resource type: " + wsmResourceType);
+        // Omit other resource types are not supported by the CLI.
+      default -> null;
     };
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -253,7 +254,10 @@ public class Workspace {
     List<ResourceDescription> wsmObjects =
         WorkspaceManagerService.fromContext()
             .enumerateAllResources(uuid, Context.getConfig().getResourcesCacheSize());
-    return wsmObjects.stream().map(Resource::deserializeFromWsm).collect(Collectors.toList());
+    return wsmObjects.stream()
+        .map(Resource::deserializeFromWsm)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 
   /** Fetch the list of folders for this workspace */


### PR DESCRIPTION
Flexible resources are breaking `terra resource list` for workspaces that contain them. Lets omit resources unsupported by CLI instead of throwing an error.

https://broadworkbench.atlassian.net/browse/PF-2661