### PR TITLE
[TERRA-495], [PF-2631] Remove client_id and client_secret

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -71,7 +71,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         RELEASE_VERSION: ${{ steps.bump_tag.outputs.tag }}
-        BROAD_CLIENT_ID: ${{ secrets.BROAD_CLIENT_ID }}
-        BROAD_CLIENT_SECRET: ${{ secrets.BROAD_CLIENT_SECRET }}
-        VERILY_CLIENT_ID: ${{ secrets.VERILY_CLIENT_ID }}
-        VERILY_CLIENT_SECRET: ${{ secrets.VERILY_CLIENT_SECRET }}

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -62,3 +62,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         RELEASE_VERSION: ${{ steps.bump_tag.outputs.tag }}
+        BROAD_CLIENT_ID: ${{ secrets.BROAD_CLIENT_ID }}
+        BROAD_CLIENT_SECRET: ${{ secrets.BROAD_CLIENT_SECRET }}
+        VERILY_CLIENT_ID: ${{ secrets.VERILY_CLIENT_ID }}
+        VERILY_CLIENT_SECRET: ${{ secrets.VERILY_CLIENT_SECRET }}

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -16,12 +16,13 @@ jobs:
       with:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         ref: main
-    # publish-release runs Java code so ensure we're using 17 instead of 11    
+
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 17
+
     - name: Bump tag and build version
       id: bump_tag
       uses: databiosphere/github-actions/actions/bumper@bumper-0.1.0
@@ -31,12 +32,14 @@ jobs:
         RELEASE_BRANCHES: main
         VERSION_FILE_PATH: settings.gradle
         VERSION_LINE_MATCH: "^\\s*gradle.ext.cliVersion\\s*=\\s*'.*'"
+
     - name: Updating code to get the version bump changes
       id: update_code_post_version_bump
       run: |
         git pull
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+
     - name: Render config
       id: render_config
       run: |
@@ -55,6 +58,12 @@ jobs:
         DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}
         EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}
         JANITOR_CLIENT_SA_KEY: ${{ secrets.JANITOR_CLIENT_SA_KEY }}
+
+    - name: Update client credentials
+      run: |
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/verily_secret.json" ${{ secrets.VERILY_CLIENT_ID }} ${{ secrets.VERILY_CLIENT_SECRET }}
+
     - name: Publish a release
       id: publish_release
       run: |

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -11,18 +11,21 @@ jobs:
         testServer: [ "broad-dev" ]
       fail-fast: false
     runs-on: ubuntu-latest
+
     steps:
     - name: Checkout current code
       id: checkout_code
       uses: actions/checkout@v3
       with:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+
     - name: Set up JDK 17
       id: setup_jdk
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 17
+
     - name: Cache Gradle packages
       id: cache_gradle
       uses: actions/cache@v3
@@ -32,6 +35,7 @@ jobs:
           ~/.gradle/wrapper
         key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
         restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
     - name: Render config
       id: render_config
       run: |
@@ -61,12 +65,11 @@ jobs:
         LILY_SHADOWMOON: ${{ secrets.LILY_SHADOWMOON }}
         NOAH_FROSTWOLF: ${{ secrets.NOAH_FROSTWOLF }}
         PENELOPE_TWILIGHTSHAMMER: ${{ secrets.PENELOPE_TWILIGHTSHAMMER }}
+
     - name: Update client credentials
-      id: client-credentials
       run: |
-        ./tools/client-credentials.sh \
-          "src/main/resources/broad_secret.json" \
-          ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+
     - name: Run unit tests
       id: run_unit_tests
       if: always()
@@ -74,6 +77,7 @@ jobs:
         echo "Running unit tests for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-unit
         ./gradlew runTestsWithTag -PtestTag=unit --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit -PquietConsole
+
     - name: Run integration tests against source code
       id: run_integration_tests_against_source_code
       if: always()
@@ -81,6 +85,7 @@ jobs:
         echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-source
         ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source -PquietConsole
+
     - name: Run integration tests against release
       id: run_integration_tests_against_release
       if: always()
@@ -88,6 +93,7 @@ jobs:
         echo "Running integration tests against release for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-release
         ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release -PquietConsole
+
     - name: Compile logs and context files for all test runs
       id: compile_logs_and_context_files
       if: always()
@@ -108,6 +114,7 @@ jobs:
           cp -R ~/logs-unit/$N/.terra/logs/ ~/to-archive/unit/$N/logs/
           cp -R ~/logs-unit/$N/.terra/context.json ~/to-archive/unit/$N/context.json
         done
+
     - name: Archive logs and context file for all test runs
       id: archive_logs_and_context
       if: always()
@@ -116,6 +123,7 @@ jobs:
         name: logs-and-context-${{ matrix.testServer }}
         path: |
           ~/to-archive/
+
     - name: Compose status message
       id: compose_status_message
       if: always()
@@ -134,6 +142,7 @@ jobs:
         echo "status-title=$title" >> $GITHUB_OUTPUT
         echo "status-bold=$bold" >> $GITHUB_OUTPUT
         echo "status-text=$text" >> $GITHUB_OUTPUT
+
     - name: Notify PF alerts slack channel
       # don't notify manually triggered runs
       if: always() && github.event_name != 'workflow_dispatch'

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -61,6 +61,12 @@ jobs:
         LILY_SHADOWMOON: ${{ secrets.LILY_SHADOWMOON }}
         NOAH_FROSTWOLF: ${{ secrets.NOAH_FROSTWOLF }}
         PENELOPE_TWILIGHTSHAMMER: ${{ secrets.PENELOPE_TWILIGHTSHAMMER }}
+    - name: Update client credentials
+      id: client-credentials
+      run: |
+        ./tools/client-credentials.sh \
+          "src/main/resources/broad_secret.json" \
+          ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
     - name: Run unit tests
       id: run_unit_tests
       if: always()

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -93,6 +93,7 @@ jobs:
         jq --arg CLIENT_ID "$CLIENT_ID" --arg CLIENT_SECRET "$CLIENT_SECRET" \
           '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
           "$SECRETS_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$SECRETS_FILE"
+        cat "$SECRETS_FILE"
       env:
         CLIENT_ID: ${{ secrets.BROAD_CLIENT_ID }}
         CLIENT_SECRET: ${{ secrets.BROAD_CLIENT_SECRET }}

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -84,6 +84,19 @@ jobs:
         LILY_SHADOWMOON: ${{ secrets.LILY_SHADOWMOON }}
         NOAH_FROSTWOLF: ${{ secrets.NOAH_FROSTWOLF }}
         PENELOPE_TWILIGHTSHAMMER: ${{ secrets.PENELOPE_TWILIGHTSHAMMER }}
+
+    - name: Update client credentials
+      id: client-credentials
+      run: |
+        SECRETS_FILE="src/main/resources/broad_secret.json"
+        TEMP_FILE="$SECRETS_FILE"+".tmp"
+        jq --arg CLIENT_ID "$CLIENT_ID" --arg CLIENT_SECRET "$CLIENT_SECRET" \
+          '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
+          "$SECRETS_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$SECRETS_FILE"
+      env:
+        CLIENT_ID: ${{ secrets.BROAD_CLIENT_ID }}
+        CLIENT_SECRET: ${{ secrets.BROAD_CLIENT_SECRET }}
+
     - name: Build Docker image
       id: build_docker_image
       run: |
@@ -102,13 +115,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         GHA_EVENT_NAME: ${{ github.event_name }}
-    - name: Update client credentials
-      id: client-credentials
-      run: |
-        ./tools/client-credentials.sh \
-          "src/main/resources/broad_secret.json" \
-          ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
-        cat "src/main/resources/broad_secret.json"
     - name: Run tests
       id: run_tests
       run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -108,6 +108,7 @@ jobs:
         ./tools/client-credentials.sh \
           "src/main/resources/broad_secret.json" \
           ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        cat "src/main/resources/broad_secret.json"
     - name: Run tests
       id: run_tests
       run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -27,6 +27,7 @@ jobs:
       id: run_static_analysis
       run: |
         ./gradlew spotbugsMain spotbugsTest
+
   tests-against-source-code:
     strategy:
       matrix:
@@ -40,12 +41,14 @@ jobs:
       uses: actions/checkout@v3
       with:
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+
     - name: Set up JDK 17
       id: setup_jdk
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 17
+
     - name: Cache Gradle packages
       id: cache_gradle
       uses: actions/cache@v3
@@ -55,6 +58,7 @@ jobs:
           ~/.gradle/wrapper
         key: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}
         restore-keys: v1-${{ runner.os }}-gradle-${{ hashfiles('**/gradle-wrapper.properties') }}
+
     - name: Render config
       id: render_config
       run: |
@@ -86,17 +90,8 @@ jobs:
         PENELOPE_TWILIGHTSHAMMER: ${{ secrets.PENELOPE_TWILIGHTSHAMMER }}
 
     - name: Update client credentials
-      id: client-credentials
       run: |
-        SECRETS_FILE="src/main/resources/broad_secret.json"
-        TEMP_FILE="$SECRETS_FILE"+".tmp"
-        jq --arg CLIENT_ID "$CLIENT_ID" --arg CLIENT_SECRET "$CLIENT_SECRET" \
-          '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
-          "$SECRETS_FILE" > "$TEMP_FILE" && mv "$TEMP_FILE" "$SECRETS_FILE"
-        cat "$SECRETS_FILE"
-      env:
-        CLIENT_ID: ${{ secrets.BROAD_CLIENT_ID }}
-        CLIENT_SECRET: ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
 
     - name: Build Docker image
       id: build_docker_image
@@ -116,6 +111,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         GHA_EVENT_NAME: ${{ github.event_name }}
+
     - name: Run tests
       id: run_tests
       run: |
@@ -125,6 +121,7 @@ jobs:
         ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} --scan $TEST_DOCKER_IMAGE -PquietConsole
       env:
         TEST_DOCKER_IMAGE: ${{ steps.build_docker_image.outputs.test_docker_image }}
+
     - name: Archive logs and context file
       id: archive_logs_and_context
       if: always()

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -102,6 +102,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
         GHA_EVENT_NAME: ${{ github.event_name }}
+    - name: Update client credentials
+      id: client-credentials
+      run: |
+        ./tools/client-credentials.sh \
+          "src/main/resources/broad_secret.json" \
+          ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
     - name: Run tests
       id: run_tests
       run: |

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'terra-cli'
 
-gradle.ext.cliVersion = 'dex-test-release'
+gradle.ext.cliVersion = '0.324.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'terra-cli'
 
-gradle.ext.cliVersion = '0.324.0'
+gradle.ext.cliVersion = 'dex-test-release'

--- a/src/main/resources/broad_secret.json
+++ b/src/main/resources/broad_secret.json
@@ -7,8 +7,6 @@
     "redirect_uris": [
       "urn:ietf:wg:oauth:2.0:oob",
       "http://localhost"
-    ],
-    "client_id": "436986732241-nvjfkarirkhmcq7m3r1uemdau518uvdo.apps.googleusercontent.com",
-    "client_secret": "w7TLNFm2fog61d2cFNC_fO5L"
+    ]
   }
 }

--- a/src/main/resources/broad_secret.json
+++ b/src/main/resources/broad_secret.json
@@ -7,6 +7,8 @@
     "redirect_uris": [
       "urn:ietf:wg:oauth:2.0:oob",
       "http://localhost"
-    ]
+    ],
+    "client_id": "436986732241-nvjfkarirkhmcq7m3r1uemdau518uvdo.apps.googleusercontent.com",
+    "client_secret": "w7TLNFm2fog61d2cFNC_fO5L"
   }
 }

--- a/src/main/resources/broad_secret.json
+++ b/src/main/resources/broad_secret.json
@@ -1,11 +1,9 @@
 {
   "installed": {
-    "client_id": "436986732241-nvjfkarirkhmcq7m3r1uemdau518uvdo.apps.googleusercontent.com",
     "project_id": "terra-cli-dev",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "w7TLNFm2fog61d2cFNC_fO5L",
     "redirect_uris": [
       "urn:ietf:wg:oauth:2.0:oob",
       "http://localhost"

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -6,8 +6,6 @@
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "redirect_uris": [
       "https://terra.verily.com/authcode"
-    ],
-    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
-    "client_secret": "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"
+    ]
   }
 }

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -1,11 +1,9 @@
 {
   "installed": {
-    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
     "project_id": "terra-ots0-prod",
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "client_secret": "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",
     "redirect_uris": ["https://terra.verily.com/authcode"]
   }
 }

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -4,6 +4,10 @@
     "auth_uri": "https://accounts.google.com/o/oauth2/auth",
     "token_uri": "https://oauth2.googleapis.com/token",
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-    "redirect_uris": ["https://terra.verily.com/authcode"]
+    "redirect_uris": [
+      "https://terra.verily.com/authcode"
+    ],
+    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
+    "client_secret": "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"
   }
 }

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -33,7 +33,14 @@ function packageAppSecrets() {
     return
   fi
 
+  echo "********* start file before"
+  cat "$secretsFile"
+  echo "********* end file before"
+
   jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
     '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
     "$secretsFile" > "$tmpFile" && mv "$tmpFile" "$secretsFile"
+  echo "********* start file"
+  cat "$secretsFile"
+  echo "********* end file"
 }

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -21,26 +21,18 @@ fi
 secretsFile=$1
 clientId=$2
 clientSecret=$3
-function packageAppSecrets() {
-  if [ -f "$secretsFile" ]; then
-    echo "$secretsFile not available, skipping"
-    return
-  fi
-  tmpFile=$1+".tmp"
 
-  if [ -z "$clientId" ] || [ -z "$clientSecret" ]; then
-    echo "client_id & client_secret not available for $secretsFile, skipping"
-    return
-  fi
+if [ ! -f "$secretsFile" ]; then
+  echo "$secretsFile not available, skipping"
+  exit 0
+fi
+tmpFile=$1+".tmp"
 
-  echo "********* start file before"
-  cat "$secretsFile"
-  echo "********* end file before"
+if [ -z "$clientId" ] || [ -z "$clientSecret" ]; then
+  echo "client_id & client_secret not available for $secretsFile, skipping"
+  exit 0
+fi
 
-  jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
-    '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
-    "$secretsFile" > "$tmpFile" && mv "$tmpFile" "$secretsFile"
-  echo "********* start file"
-  cat "$secretsFile"
-  echo "********* end file"
-}
+jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
+  '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
+  "$secretsFile" > "$tmpFile" && mv "$tmpFile" "$secretsFile"

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+## This script package client id and secrets into relevant files
+## The GitHub release includes an install package and a download + install script.
+## Note that a pre-release does not affect the "Latest release" tag, but a regular release does.
+## The release version number argument to this script must match the version number in the settings.gradle
+# file (i.e. version = '0.0.0' line).
+#
+## Dependencies: jq
+## Inputs: secretsFile (arg, required) path to the secrets file (valid format)
+##         clientId (arg, required) client id
+##         clientSecret (arg, required) client secret
+## Usage: ./client-credentials.sh <file> <id> <secret> --> adds client_id and client_secret to file
+
+## The script assumes that it is being run from the top-level directory "terra-cli/".
+if [[ $(basename "$PWD") != 'terra-cli' ]]; then
+  >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
+  exit 1
+fi
+
+secretsFile=$1
+clientId=$2
+clientSecret=$3
+function packageAppSecrets() {
+  if [ -f "$secretsFile" ]; then
+    echo "$secretsFile not available, skipping"
+    return
+  fi
+  tmpFile=$1+".tmp"
+
+  if [ -z "$clientId" ] || [ -z "$clientSecret" ]; then
+    echo "client_id & client_secret not available for $secretsFile, skipping"
+    return
+  fi
+
+  jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
+    '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
+    "$secretsFile" > "$tmpFile" && mv "$tmpFile" "$secretsFile"
+}

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -70,8 +70,8 @@ echo "-- Building the distribution archive"
 distributionArchivePath=$(ls build/distributions/*tar)
 
 echo "-- Packaging client id and client secrets in the release"
-client-credentials.sh "src/main/resources/broad_secret.json" "$BROAD_CLIENT_ID" "$BROAD_CLIENT_SECRET"
-client-credentials.sh "src/main/resources/verily_secret.json" "$VERILY_CLIENT_ID" "$VERILY_CLIENT_SECRET"
+./tools/client-credentials.sh "src/main/resources/broad_secret.json" "$BROAD_CLIENT_ID" "$BROAD_CLIENT_SECRET"
+./tools/client-credentials.sh "src/main/resources/verily_secret.json" "$VERILY_CLIENT_ID" "$VERILY_CLIENT_SECRET"
 
 echo "-- Creating a new GitHub release with the install archive and download script"
 gh config set prompt disabled

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -6,7 +6,7 @@ set -e
 ## The release version number argument to this script must match the version number in the settings.gradle
 # file (i.e. version = '0.0.0' line).
 #
-## Dependencies: docker, gh, sed, jq
+## Dependencies: docker, gh, sed
 ## Inputs: releaseVersion (arg, required) determines the git tag to use for creating the release
 ##         isRegularRelease (arg, optional) 'false' for a pre-release (default), 'true' for a regular release
 ## Usage: ./publish-release.sh  0.0.0        --> publishes version 0.0.0 as a pre-release
@@ -68,10 +68,6 @@ dockerImageTag=$(./gradlew --quiet getDockerImageTag) # e.g. stable
 echo "-- Building the distribution archive"
 ./gradlew clean distTar -PforRelease
 distributionArchivePath=$(ls build/distributions/*tar)
-
-echo "-- Packaging client id and client secrets in the release"
-./tools/client-credentials.sh "src/main/resources/broad_secret.json" "$BROAD_CLIENT_ID" "$BROAD_CLIENT_SECRET"
-./tools/client-credentials.sh "src/main/resources/verily_secret.json" "$VERILY_CLIENT_ID" "$VERILY_CLIENT_SECRET"
 
 echo "-- Creating a new GitHub release with the install archive and download script"
 gh config set prompt disabled

--- a/tools/publish-release.sh
+++ b/tools/publish-release.sh
@@ -69,30 +69,9 @@ echo "-- Building the distribution archive"
 ./gradlew clean distTar -PforRelease
 distributionArchivePath=$(ls build/distributions/*tar)
 
-# Function to package client id and secrets into relevant files
-# params: $1: secretsFile
-#         $2: client_id
-#         $3: client_secret
-function packageAppSecrets() {
-  if [ -f "$1" ]; then
-    echo "$1 not available, skipping"
-    return
-  fi
-  tmpFile=$1+".tmp"
-
-  if [ -z "$2" ] || [ -z "$3" ]; then
-    echo "client_id & client_secret not available for $1, skipping"
-    return
-  fi
-
-  jq --arg CLIENT_ID "$2" --arg CLIENT_SECRET "$3" \
-    '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
-    "$1" > "$tmpFile" && mv "$tmpFile" "$1"
-}
-
 echo "-- Packaging client id and client secrets in the release"
-packageAppSecrets "src/main/resources/broad_secret.json" "$BROAD_CLIENT_ID" "$BROAD_CLIENT_SECRET"
-packageAppSecrets "src/main/resources/verily_secret.json" "$VERILY_CLIENT_ID" "$VERILY_CLIENT_SECRET"
+client-credentials.sh "src/main/resources/broad_secret.json" "$BROAD_CLIENT_ID" "$BROAD_CLIENT_SECRET"
+client-credentials.sh "src/main/resources/verily_secret.json" "$VERILY_CLIENT_ID" "$VERILY_CLIENT_SECRET"
 
 echo "-- Creating a new GitHub release with the install archive and download script"
 gh config set prompt disabled


### PR DESCRIPTION
- Remove client_id and client_secret from secrets file
- Fetch these values from env during release publish and insert into secrets file


```
# export variables BROAD_CLIENT_ID BROAD_CLIENT_SECRET VERILY_CLIENT_ID VERILY_CLIENT_SECRET
>>  ./tools/client-credentials.sh "src/main/resources/broad_secret.json" $BROAD_CLIENT_ID $BROAD_CLIENT_SECRET
# verified that files have the client id / secret updated

>> terra-cli (dexamundsen/terra-495) >> ./tools/publish-release.sh dex-test-release
# pre-release created successfully
Downloaded the prerelease and verified that json files include client credentials.

>> ./tools/render-config
# verified files have the client id / secret updated
```

- Credentials are needed in PR tests, a successful PR check implies this is reflected in CI/CD runs
