### PR TITLE
Fetch verily client secret in for render_config (broad script) for local dev

### DIFF
--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -82,3 +82,13 @@ clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCK
                 vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
                 jq -r '.data."broad-client-secret"')
 ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "$clientId" "$clientSecret"
+
+echo "Fetching Verily client id and client secrets"
+clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+            jq -r '.data."verily-client-id"')
+clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+                vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+                jq -r '.data."verily-client-secret"')
+./tools/client-credentials.sh "src/main/resources/verily_secret.json" "$clientId" "$clientSecret"
+


### PR DESCRIPTION
Local dev needs verily client_creds, fetch it in the render_config script, that is called from local_dev script