### PR TITLE
[PF-2629] - Use resource name as the cloned repo directory name

### DIFF
--- a/src/main/java/bio/terra/cli/command/app/passthrough/Git.java
+++ b/src/main/java/bio/terra/cli/command/app/passthrough/Git.java
@@ -87,13 +87,15 @@ public class Git extends ToolCommand {
                         resource.getResourceType(), resource.getName()));
               }
               return new Repo(resource.getName(), resource.resolve());
-            }).toList();
+            })
+        .toList();
   }
 
   private void clone(List<Repo> gitRepos) {
     gitRepos.forEach(
         gitRepo -> {
-          List<String> cloneCommands = ImmutableList.of("git", "clone", gitRepo.url, gitRepo.resourceName);
+          List<String> cloneCommands =
+              ImmutableList.of("git", "clone", gitRepo.url, gitRepo.resourceName);
           try {
             Context.getConfig().getCommandRunnerOption().getRunner().runToolCommand(cloneCommands);
           } catch (PassthroughException e) {

--- a/src/test/java/unit/GcpPassthroughApps.java
+++ b/src/test/java/unit/GcpPassthroughApps.java
@@ -300,11 +300,10 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
     // `terra git clone --all`
     TestCommand.runCommandExpectSuccess("git", "clone", "--all");
 
-    assertTrue(
-        Files.exists(Paths.get(System.getProperty("user.dir"), "terra-example-notebooks", ".git")));
-    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), "terra", ".git")));
-    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/terra-example-notebooks"));
-    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/terra"));
+    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), resource1Name, ".git")));
+    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), resource2Name, ".git")));
+    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/" + resource1Name));
+    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/" + resource2Name));
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + resource1Name, "--quiet");
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + resource2Name, "--quiet");
   }
@@ -343,13 +342,12 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
     // `terra git clone --resource=$bucketResourceName`
     TestCommand.runCommandExpectExitCode(1, "git", "clone", "--resource=" + bucketResourceName);
 
-    assertTrue(
-        Files.exists(Paths.get(System.getProperty("user.dir"), "terra-example-notebooks", ".git")));
-    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), "terra", ".git")));
+    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), repo1, ".git")));
+    assertTrue(Files.exists(Paths.get(System.getProperty("user.dir"), repo2, ".git")));
 
     // cleanup
-    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/terra-example-notebooks"));
-    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + "/terra"));
+    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + repo1));
+    FileUtils.deleteQuietly(new File(System.getProperty("user.dir") + repo2));
   }
 
   @Test


### PR DESCRIPTION
Instead of the git repo name itself.