### PR TITLE
[TERRA-564] Add subcommand to get Notebook proxyUrl

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -84,7 +84,7 @@ jobs:
       run: |
         echo "Running integration tests against source code for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-source
-        ./gradlew runTestsWithTag -PtestTag=integration --scan -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source -PquietConsole
+        ./gradlew runTestsWithTag -PtestTag=integration -Pplatform=gcp -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-source -PquietConsole --scan
 
     - name: Run integration tests against release
       id: run_integration_tests_against_release
@@ -92,7 +92,7 @@ jobs:
       run: |
         echo "Running integration tests against release for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-integration-release
-        ./gradlew runTestsWithTag -PtestTag=integration --scan -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release -PquietConsole
+        ./gradlew runTestsWithTag -PtestTag=integration -Pplatform=gcp -PtestInstallFromGitHub -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-integration-release -PquietConsole --scan
 
     - name: Compile logs and context files for all test runs
       id: compile_logs_and_context_files

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -118,8 +118,7 @@ jobs:
         # runs against the default server: broad-dev
         echo "Running tests with tag: ${{ matrix.testTag }}"
         echo "Using docker image (uses default if blank): $TEST_DOCKER_IMAGE"
-        # Run "unit" and "unit-gcp" tags, but not "unit-aws"
-        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} -Pplatform=gcp --scan $TEST_DOCKER_IMAGE -PquietConsole
+        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} -Pplatform=gcp $TEST_DOCKER_IMAGE -PquietConsole --scan
       env:
         TEST_DOCKER_IMAGE: ${{ steps.build_docker_image.outputs.test_docker_image }}
 

--- a/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
@@ -141,8 +141,7 @@ public class AwsSageMakerNotebook extends Resource {
     JUPYTER,
     JUPYTERLAB;
 
-    @Override
-    public String toString() {
+    public String toParam() {
       return (this == ProxyView.JUPYTERLAB) ? "lab" : "classic";
     }
   }

--- a/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
@@ -136,4 +136,14 @@ public class AwsSageMakerNotebook extends Resource {
   public String getInstanceType() {
     return instanceType;
   }
+
+  public enum ProxyView {
+    JUPYTER,
+    JUPYTERLAB;
+
+    @Override
+    public String toString() {
+      return (this == ProxyView.JUPYTERLAB) ? "lab" : "classic";
+    }
+  }
 }

--- a/src/main/java/bio/terra/cli/command/Notebook.java
+++ b/src/main/java/bio/terra/cli/command/Notebook.java
@@ -1,5 +1,6 @@
 package bio.terra.cli.command;
 
+import bio.terra.cli.command.notebook.Launch;
 import bio.terra.cli.command.notebook.Start;
 import bio.terra.cli.command.notebook.Stop;
 import picocli.CommandLine;
@@ -12,9 +13,10 @@ import picocli.CommandLine;
     name = "notebook",
     header = "Use GCP Notebooks in the workspace.",
     description =
-        "Commands to create and manage GCP Notebook resources within the workspace. \n\n"
-            + "You can create a https://cloud.google.com/vertex-ai/docs/workbench/notebook-solution[GCP Notebook] controlled resource "
-            + "with `terra resource create gcp-notebook`. The `stop`, `start` commands are provided for convenience. \n\n"
-            + "You can also stop and start the notebook using the `gcloud notebooks instances start/stop` commands.",
-    subcommands = {Start.class, Stop.class})
+        "Commands to manage Notebook resources within the workspace. \n\n"
+            + "You can create a GCP Notebook controlled resource [https://cloud.google.com/vertex-ai/docs/workbench/notebook-solution]"
+            + "with `terra resource create gcp-notebook`, and a AWS Notebook controlled resource [https://aws.amazon.com/sagemaker] "
+            + "with `terra resource create sagemaker-notebook`. The `stop`, `start` and `launch` commands are provided for convenience. \n\n"
+            + "You can also stop and start the gcp-notebook using the `gcloud notebooks instances start/stop` commands.",
+    subcommands = {Start.class, Stop.class, Launch.class})
 public class Notebook {}

--- a/src/main/java/bio/terra/cli/command/Notebook.java
+++ b/src/main/java/bio/terra/cli/command/Notebook.java
@@ -11,7 +11,7 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
     name = "notebook",
-    header = "Use GCP Notebooks in the workspace.",
+    header = "Use Notebooks in the workspace.",
     description =
         "Commands to manage Notebook resources within the workspace. \n\n"
             + "You can create a GCP Notebook controlled resource [https://cloud.google.com/vertex-ai/docs/workbench/notebook-solution]"

--- a/src/main/java/bio/terra/cli/command/notebook/Launch.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Launch.java
@@ -1,0 +1,62 @@
+package bio.terra.cli.command.notebook;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.businessobject.resource.AwsSageMakerNotebook;
+import bio.terra.cli.command.shared.BaseCommand;
+import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.NotebookInstance;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.exception.UserActionableException;
+import bio.terra.cli.service.WorkspaceManagerServiceAws;
+import bio.terra.workspace.model.CloudPlatform;
+import java.net.URL;
+import org.json.JSONObject;
+import picocli.CommandLine;
+
+/** This class corresponds to the third-level "terra notebook launch" command. */
+@CommandLine.Command(
+    name = "launch",
+    description = "Launch a running Notebook instance within your workspace.",
+    showDefaultValues = true)
+public class Launch extends BaseCommand {
+  private static final String PROXY_URL = "proxy_url";
+  @CommandLine.Mixin NotebookInstance instanceOption;
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+  @CommandLine.Mixin Format formatOption;
+
+  @CommandLine.Option(
+      names = "--proxy-view",
+      description = "AWS Sagemaker Notebook view to be launched: ${COMPLETION-CANDIDATES}.",
+      defaultValue = "JUPYTER",
+      showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
+  private AwsSageMakerNotebook.ProxyView proxyView;
+
+  @Override
+  protected void execute() {
+    workspaceOption.overrideIfSpecified();
+    Workspace workspace = Context.requireWorkspace();
+
+    if (workspace.getCloudPlatform() == CloudPlatform.GCP) {
+      throw new UserActionableException("Launch notebooks not implemented for GCP Notebooks");
+
+    } else if (workspace.getCloudPlatform() == CloudPlatform.AWS) {
+      AwsSageMakerNotebook awsNotebook = instanceOption.toAwsNotebookResource();
+      URL proxyUrl =
+          WorkspaceManagerServiceAws.fromContext()
+              .getSageMakerNotebookProxyUrl(workspace.getUuid(), awsNotebook, proxyView);
+
+      JSONObject object = new JSONObject();
+      object.put(PROXY_URL, proxyUrl.toString());
+      formatOption.printReturnValue(object, this::printText);
+
+    } else {
+      throw new UserActionableException(
+          "Notebooks not supported on workspace cloud platform " + workspace.getCloudPlatform());
+    }
+  }
+
+  private void printText(JSONObject object) {
+    OUT.println(object.get(PROXY_URL));
+  }
+}

--- a/src/main/java/bio/terra/cli/command/notebook/Launch.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Launch.java
@@ -28,7 +28,7 @@ public class Launch extends BaseCommand {
   @CommandLine.Option(
       names = "--proxy-view",
       description = "AWS Sagemaker Notebook view to be launched: ${COMPLETION-CANDIDATES}.",
-      defaultValue = "JUPYTER",
+      defaultValue = "JUPYTERLAB",
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
   private AwsSageMakerNotebook.ProxyView proxyView;
 

--- a/src/main/java/bio/terra/cli/command/notebook/Launch.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Launch.java
@@ -48,7 +48,7 @@ public class Launch extends BaseCommand {
 
       JSONObject object = new JSONObject();
       object.put(PROXY_URL, proxyUrl.toString());
-      formatOption.printReturnValue(object, this::printText);
+      formatOption.printReturnValue(object, this::printText, this::printJson);
 
     } else {
       throw new UserActionableException(
@@ -58,5 +58,9 @@ public class Launch extends BaseCommand {
 
   private void printText(JSONObject object) {
     OUT.println(object.get(PROXY_URL));
+  }
+
+  private void printJson(JSONObject object) {
+    OUT.println(object);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -58,14 +58,10 @@ public class Resolve extends WsmBaseCommand {
         };
     JSONObject object = new JSONObject();
     object.put(resource.getName(), cloudId);
-    formatOption.printReturnValue(object, this::printText, this::printJson);
+    formatOption.printReturnValue(object, this::printText);
   }
 
   private void printText(JSONObject object) {
     OUT.println(object.get(resourceNameOption.name));
-  }
-
-  private void printJson(JSONObject object) {
-    OUT.println(object);
   }
 }

--- a/src/main/java/bio/terra/cli/command/resource/Resolve.java
+++ b/src/main/java/bio/terra/cli/command/resource/Resolve.java
@@ -58,10 +58,14 @@ public class Resolve extends WsmBaseCommand {
         };
     JSONObject object = new JSONObject();
     object.put(resource.getName(), cloudId);
-    formatOption.printReturnValue(object, this::printText);
+    formatOption.printReturnValue(object, this::printText, this::printJson);
   }
 
   private void printText(JSONObject object) {
     OUT.println(object.get(resourceNameOption.name));
+  }
+
+  private void printJson(JSONObject object) {
+    OUT.println(object);
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
@@ -5,6 +5,7 @@ import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.Server;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.businessobject.resource.AwsSageMakerNotebook;
+import bio.terra.cli.businessobject.resource.AwsSageMakerNotebook.ProxyView;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.CreateAwsS3StorageFolderParams;
@@ -24,10 +25,12 @@ import bio.terra.workspace.model.DeleteControlledAwsResourceRequestBody;
 import bio.terra.workspace.model.DeleteControlledAwsResourceResult;
 import bio.terra.workspace.model.JobControl;
 import com.google.auth.oauth2.AccessToken;
+import java.net.URL;
 import java.time.Duration;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -39,6 +42,8 @@ import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sagemaker.SageMakerClient;
+import software.amazon.awssdk.services.sagemaker.model.CreatePresignedNotebookInstanceUrlRequest;
+import software.amazon.awssdk.services.sagemaker.model.CreatePresignedNotebookInstanceUrlResponse;
 import software.amazon.awssdk.services.sagemaker.model.DescribeNotebookInstanceRequest;
 import software.amazon.awssdk.services.sagemaker.model.DescribeNotebookInstanceResponse;
 import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
@@ -51,6 +56,7 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
   private static final Logger logger = LoggerFactory.getLogger(WorkspaceManagerServiceAws.class);
   private static final int CREDENTIAL_EXPIRATION_SECONDS_DEFAULT = 900;
   private static final Duration SAGEMAKER_CLIENT_WAITER_TIMEOUT = Duration.ofSeconds(1800);
+  private static final Integer SAGEMAKER_SESSION_DURATION_SECONDS_MAX = 43200; // 12 hours
   public static final Set<NotebookInstanceStatus> notebookStatusSetCanStart =
       Set.of(NotebookInstanceStatus.STOPPED, NotebookInstanceStatus.FAILED);
   public static final Set<NotebookInstanceStatus> notebookStatusSetCanStop =
@@ -261,7 +267,8 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
                 getControlledAwsSageMakerNotebookCredential(workspace.getUuid(), resourceId),
                 awsNotebook.getRegion()));
     if (notebookStatus != NotebookInstanceStatus.DELETING) {
-      checkNotebookStatus(notebookStatusSetCanDelete, notebookStatus);
+      checkNotebookStatus(
+          notebookStatusSetCanDelete, notebookStatus, "Cannot delete notebook instance");
     }
 
     String asyncJobId = UUID.randomUUID().toString();
@@ -420,7 +427,8 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
       if (currentStatus == NotebookInstanceStatus.IN_SERVICE) {
         return;
       }
-      checkNotebookStatus(notebookStatusSetCanStart, currentStatus);
+      checkNotebookStatus(
+          notebookStatusSetCanStart, currentStatus, "Cannot start notebook instance");
 
       SdkHttpResponse httpResponse =
           sageMakerClient
@@ -459,7 +467,7 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
       if (notebookStatusSetCanStart.contains(currentStatus)) {
         return;
       }
-      checkNotebookStatus(notebookStatusSetCanStop, currentStatus);
+      checkNotebookStatus(notebookStatusSetCanStop, currentStatus, "Cannot stop notebook instance");
 
       SdkHttpResponse httpResponse =
           sageMakerClient
@@ -481,14 +489,59 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
     }
   }
 
+  public URL getSageMakerNotebookProxyUrl(
+      UUID workspaceId, AwsSageMakerNotebook awsNotebook, ProxyView proxyView) {
+    SageMakerClient sageMakerClient =
+        getSageMakerClient(
+            getControlledAwsSageMakerNotebookCredential(
+                workspaceId,
+                awsNotebook.getId(),
+                AwsCredentialAccessScope.READ_ONLY,
+                CREDENTIAL_EXPIRATION_SECONDS_DEFAULT),
+            awsNotebook.getRegion());
+
+    try {
+      NotebookInstanceStatus currentStatus =
+          getSageMakerNotebookInstanceStatus(awsNotebook, sageMakerClient);
+      checkNotebookStatus(
+          Set.of(NotebookInstanceStatus.IN_SERVICE),
+          currentStatus,
+          "Cannot launch notebook instance");
+
+      CreatePresignedNotebookInstanceUrlResponse createPresignedUrlResponse =
+          sageMakerClient.createPresignedNotebookInstanceUrl(
+              CreatePresignedNotebookInstanceUrlRequest.builder()
+                  .notebookInstanceName(awsNotebook.getInstanceName())
+                  .sessionExpirationDurationInSeconds(SAGEMAKER_SESSION_DURATION_SECONDS_MAX)
+                  .build());
+      SdkHttpResponse httpResponse = createPresignedUrlResponse.sdkHttpResponse();
+      if (!httpResponse.isSuccessful()) {
+        throw new SystemException(
+            "Error creating presigned notebook instance url, "
+                + httpResponse.statusText().orElse(String.valueOf(httpResponse.statusCode())));
+      }
+      return new URIBuilder(createPresignedUrlResponse.authorizedUrl())
+          .addParameter("view", proxyView.toString())
+          .build()
+          .toURL();
+
+    } catch (Exception e) {
+      if (e instanceof SdkException sdkE) {
+        checkException(sdkE);
+      }
+      throw new SystemException("Error creating presigned notebook instance url", e);
+    }
+  }
+
   private void checkNotebookStatus(
-      Set<NotebookInstanceStatus> expectedStatusSet, NotebookInstanceStatus currentStatus) {
+      Set<NotebookInstanceStatus> expectedStatusSet,
+      NotebookInstanceStatus currentStatus,
+      String message) {
     if (!expectedStatusSet.contains(currentStatus)) {
       throw new UserActionableException(
-          "Expected notebook instance status is "
-              + expectedStatusSet
-              + " but current status is "
-              + currentStatus);
+          String.format(
+              "%s: Expected notebook instance status is %s but current status is %s",
+              message, expectedStatusSet, currentStatus));
     }
   }
 

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
@@ -25,6 +25,8 @@ import bio.terra.workspace.model.DeleteControlledAwsResourceRequestBody;
 import bio.terra.workspace.model.DeleteControlledAwsResourceResult;
 import bio.terra.workspace.model.JobControl;
 import com.google.auth.oauth2.AccessToken;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Set;
@@ -521,11 +523,11 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
                 + httpResponse.statusText().orElse(String.valueOf(httpResponse.statusCode())));
       }
       return new URIBuilder(createPresignedUrlResponse.authorizedUrl())
-          .addParameter("view", proxyView.toString())
+          .addParameter("view", proxyView.toParam())
           .build()
           .toURL();
 
-    } catch (Exception e) {
+    } catch (SdkException | URISyntaxException | MalformedURLException e) {
       if (e instanceof SdkException sdkE) {
         checkException(sdkE);
       }

--- a/src/test/java/unit/AwsSageMakerNotebookControlled.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlled.java
@@ -134,7 +134,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     Object url = proxyUrl.get("proxy_url");
     assertNotNull(url, "launch notebook returned proxy url for classic view");
     assertTrue(
-        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTER.toString()),
+        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTER.toParam()),
         "proxy url view is classic");
 
     // `terra notebook launch --name=$name --proxy-view=$proxyView` // lab view
@@ -147,7 +147,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     url = proxyUrl.get("proxy_url");
     assertNotNull(url, "launch notebook returned proxy url for lab view");
     assertTrue(
-        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTERLAB.toString()),
+        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTERLAB.toParam()),
         "proxy url view is lab");
 
     // `terra resources check-access --name=$name`
@@ -182,7 +182,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
         "error message includes expected and current statuses",
         stdErr,
         CoreMatchers.containsString(
-            "Expected notebook instance status is [InService] but current status is STOPPED"));
+            "Expected notebook instance status is [InService] but current status is Stopped"));
 
     // `terra resource delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");


### PR DESCRIPTION
- New  subcommand to get Notebook proxyUrl
- connected test

Manual test - 

```
terra-cli (dexamundsen/terra-564) >> terra notebook launch --name=dex-notebook-516-1
<verified classic view url>

terra-cli (dexamundsen/terra-564) >> terra notebook launch --name=dex-notebook-516-1 --proxy-view=JUPYTERLAB
<verified lab view url>

terra-cli (dexamundsen/terra-564) >> terra notebook stop --name=dex-notebook-516-1
Notebook instance stopped

terra-cli (dexamundsen/terra-564) >> terra notebook launch --name=dex-notebook-516-1
Cannot launch notebook instance: Expected notebook instance status is [InService] but current status is Stopped
```
![image](https://github.com/DataBiosphere/terra-cli/assets/2914285/493c5db0-01b1-4de3-9224-60ffd0c4b98b)
