### PR TITLE
TERRA-575: Allow 'set workspace' by UUID, expose workspace UUID in JSON.

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -119,10 +119,7 @@ public class Workspace {
     return workspace;
   }
 
-  /** Load an existing workspace and set it as the current workspace. */
-  public static Workspace load(String userFacingId) {
-    Workspace workspace = Workspace.getByUserFacingId(userFacingId);
-
+  private static Workspace load(Workspace workspace) {
     // update the global context with the current workspace
     Context.setWorkspace(workspace);
 
@@ -133,6 +130,16 @@ public class Workspace {
     Context.requireUser().fetchPetSaEmail();
 
     return workspace;
+  }
+
+  /** Load an existing workspace and set it as the current workspace. */
+  public static Workspace load(String userFacingId) {
+    return load(Workspace.getByUserFacingId(userFacingId));
+  }
+
+  /** Load an existing workspace and set it as the current workspace. */
+  public static Workspace load(UUID id) {
+    return load(Workspace.get(id));
   }
 
   /** Fetch an existing workspace by uuid, with resources populated */

--- a/src/main/java/bio/terra/cli/command/workspace/Set.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Set.java
@@ -4,6 +4,7 @@ import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import java.util.UUID;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -12,14 +13,14 @@ import picocli.CommandLine.Command;
 public class Set extends WsmBaseCommand {
   @CommandLine.Mixin Format formatOption;
 
-  @CommandLine.Option(names = "--id", required = true, description = "Workspace id.")
-  // Variable is `id` instead of `userFacingId` because user sees it with `terra workspace set`
-  private String id;
+  @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+  WorkspaceIdArgGroup argGroup;
 
   /** Load an existing workspace. */
   @Override
   protected void execute() {
-    Workspace workspace = Workspace.load(id);
+    Workspace workspace =
+        argGroup.id != null ? Workspace.load(argGroup.id) : Workspace.load(argGroup.uuid);
     formatOption.printReturnValue(new UFWorkspace(workspace), this::printText);
   }
 
@@ -27,5 +28,14 @@ public class Set extends WsmBaseCommand {
   private void printText(UFWorkspace returnValue) {
     OUT.println("Workspace successfully loaded.");
     returnValue.print();
+  }
+
+  static class WorkspaceIdArgGroup {
+    @CommandLine.Option(names = "--id", description = "Workspace id.")
+    // Variable is `id` instead of `userFacingId` because user sees it with `terra workspace set`
+    private String id;
+
+    @CommandLine.Option(names = "--uuid", description = "Workspace UUID.")
+    private UUID uuid;
   }
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -13,6 +13,7 @@ import java.io.PrintStream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /** This is used instead of UFWorkspace, if workspace resources aren't needed. */
@@ -20,6 +21,7 @@ public class UFWorkspaceLight {
   // "id" instead of "userFacingId" because user sees this with "terra workspace describe
   // --format=json"
   public String id;
+  public UUID uuid;
   public CloudPlatform cloudPlatform;
 
   // GCP
@@ -48,6 +50,7 @@ public class UFWorkspaceLight {
    */
   public UFWorkspaceLight(Workspace internalObj) {
     this.id = internalObj.getUserFacingId();
+    this.uuid = internalObj.getUuid();
     this.cloudPlatform = internalObj.getCloudPlatform();
     this.googleProjectId = internalObj.getGoogleProjectId().orElse(null);
     this.awsMajorVersion = internalObj.getAwsMajorVersion().orElse(null);
@@ -74,6 +77,7 @@ public class UFWorkspaceLight {
    */
   public UFWorkspaceLight(WorkspaceDescription workspaceDescription) {
     this.id = workspaceDescription.getUserFacingId();
+    this.uuid = workspaceDescription.getId();
 
     if (workspaceDescription.getGcpContext() != null) {
       this.cloudPlatform = CloudPlatform.GCP;
@@ -105,6 +109,7 @@ public class UFWorkspaceLight {
   /** Constructor for Jackson deserialization during testing. */
   protected UFWorkspaceLight(Builder builder) {
     this.id = builder.id;
+    this.uuid = builder.uuid;
     this.cloudPlatform = builder.cloudPlatform;
     this.googleProjectId = builder.googleProjectId;
     this.awsMajorVersion = builder.awsMajorVersion;
@@ -125,6 +130,7 @@ public class UFWorkspaceLight {
   /** Default constructor for subclass Builder constructor */
   protected UFWorkspaceLight() {
     this.id = null;
+    this.uuid = null;
     this.cloudPlatform = null;
     this.googleProjectId = null;
     this.awsMajorVersion = null;
@@ -179,6 +185,7 @@ public class UFWorkspaceLight {
     // "id" instead of "userFacingId" because user sees this with "terra workspace describe
     // --format=json"
     protected String id;
+    protected UUID uuid;
     protected CloudPlatform cloudPlatform;
 
     // GCP
@@ -204,6 +211,11 @@ public class UFWorkspaceLight {
 
     public Builder id(String id) {
       this.id = id;
+      return this;
+    }
+
+    public Builder uuid(UUID uuid) {
+      this.uuid = uuid;
       return this;
     }
 

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -267,10 +267,14 @@ public class Workspace extends ClearContextUnit {
     assertEquals(
         createdWorkspace1.id, describedWorkspace.id, "describe matches set workspace id (1)");
 
-    // set current workspace = workspace 2
+    // check the workspace describe reflects the workspace set
+    assertEquals(
+        createdWorkspace1.uuid, describedWorkspace.uuid, "describe matches set workspace uuid (1)");
+
+    // set current workspace = workspace 2 (use --uuid this time)
     UFWorkspace setWorkspace2 =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFWorkspace.class, "workspace", "set", "--id=" + createdWorkspace2.id);
+            UFWorkspace.class, "workspace", "set", "--uuid=" + createdWorkspace2.uuid);
     assertEquals(createdWorkspace2.id, setWorkspace2.id, "set returned the expected workspace (2)");
 
     // `terra status --format=json`
@@ -286,6 +290,10 @@ public class Workspace extends ClearContextUnit {
     // check the workspace describe reflects the workspace set
     assertEquals(
         createdWorkspace2.id, describedWorkspace.id, "describe matches set workspace id (2)");
+
+    // check the workspace describe reflects the workspace set
+    assertEquals(
+        createdWorkspace2.uuid, describedWorkspace.uuid, "describe matches set workspace uuid (2)");
 
     // `terra workspace delete` (workspace 2)
     TestCommand.runCommandExpectSuccess("workspace", "delete", "--quiet");


### PR DESCRIPTION
I've recently found several scenarios where I needed to resort to using direct WSM calls (Swagger UI by port-forwarding or curl) to get Workspace UUID's.

Issue [TERRA-575](https://verily.atlassian.net/browse/TERRA-575) exposes a specific case where not being able to resolve a workspace UUID to a workspace user-facing ID causes an issue.  

In AWS, we tag resources with the workspace UUID, for IAM, grouping, and (eventually) billing purposes.  In the SageMaker notebook instance controlled resource use case, we want to use this tag to automate configuration of the Terra CLI in the startup script.  This is currently not possible with the `terra set workspace` command.

This PR addresses these issues by:
* Adding `uuid` to the JSON output of `terra workspace [list|describe]`.  This is already present in the "persistent" serialized resource types, so should not cause issues with current user context.
* Add a `--uuid` option (mutually exclusive with the `--id` option, and one or the other is required) to allow setting workspace by UUID.

I'd propose that we probably want to extend this UUID option to commands with `--workspace` overrides, and to controlled resource commands (alternative to `--name`), but my immediate concern in with resolving TERRA-575.  I can add a Jira ticket for this follow-on effort if it seems worthwhile.