### PR TITLE
[PF-2113] Fix test tag error

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         echo "Running unit tests for server: ${{ matrix.testServer }}"
         mkdir -p ~/logs-unit
-        ./gradlew runTestsWithTag -PtestTag=unit -Pplatform=GCP -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit -PquietConsole --scan
+        ./gradlew runTestsWithTag -PtestTag=unit -Pplatform=gcp -Pserver=${{ matrix.testServer }} -PcontextDir=$HOME/logs-unit -PquietConsole --scan
 
     - name: Run integration tests against source code
       id: run_integration_tests_against_source_code

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -119,7 +119,7 @@ jobs:
         echo "Running tests with tag: ${{ matrix.testTag }}"
         echo "Using docker image (uses default if blank): $TEST_DOCKER_IMAGE"
         # Run "unit" and "unit-gcp" tags, but not "unit-aws"
-        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} -Pplatform=GCP --scan $TEST_DOCKER_IMAGE -PquietConsole
+        ./gradlew runTestsWithTag -PtestTag=${{ matrix.testTag }} -Pplatform=gcp --scan $TEST_DOCKER_IMAGE -PquietConsole
       env:
         TEST_DOCKER_IMAGE: ${{ steps.build_docker_image.outputs.test_docker_image }}
 


### PR DESCRIPTION
In #478, I added the wrong platform tag, as it's actually case-sensitive. The GHA is currently skipping tests tagged with `unit-gcp`