### PR TITLE
[TERRA-578] Return from create / start aws commands immediately

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/AwsSageMakerNotebook.java
@@ -70,23 +70,13 @@ public class AwsSageMakerNotebook extends Resource {
         "Referenced resources not supported for AWS SageMaker Notebook.");
   }
 
-  /**
-   * Create a AWS SageMaker Notebook as a controlled resource in the workspace.
-   *
-   * @return the resource that was created
-   */
-  public static AwsSageMakerNotebook createControlled(
-      CreateAwsSageMakerNotebookParams createParams) {
+  /** Create a AWS SageMaker Notebook as a controlled resource in the workspace. */
+  public static void createControlled(CreateAwsSageMakerNotebookParams createParams) {
     validateResourceName(createParams.resourceFields.name);
 
     // call WSM to create the resource
-    AwsSageMakerNotebookResource createdResource =
-        WorkspaceManagerServiceAws.fromContext()
-            .createControlledAwsSageMakerNotebook(
-                Context.requireWorkspace().getUuid(), createParams);
-    logger.info("Created AWS SageMaker Notebook: {}", createdResource);
-
-    return new AwsSageMakerNotebook(createdResource);
+    WorkspaceManagerServiceAws.fromContext()
+        .createControlledAwsSageMakerNotebook(Context.requireWorkspace().getUuid(), createParams);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/command/notebook/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Start.java
@@ -31,17 +31,17 @@ public class Start extends BaseCommand {
       InstanceName instanceName = instanceOption.toGcpNotebookInstanceName();
       GoogleNotebooks notebooks = new GoogleNotebooks(Context.requireUser().getPetSACredentials());
       notebooks.start(instanceName);
-      OUT.println("Notebook instance starting. It may take a few minutes before it is available");
 
     } else if (workspace.getCloudPlatform() == CloudPlatform.AWS) {
       AwsSageMakerNotebook awsNotebook = instanceOption.toAwsNotebookResource();
       WorkspaceManagerServiceAws.fromContext()
           .startSageMakerNotebook(workspace.getUuid(), awsNotebook);
-      OUT.println("Notebook instance started");
 
     } else {
       throw new UserActionableException(
           "Notebooks not supported on workspace cloud platform " + workspace.getCloudPlatform());
     }
+
+    OUT.println("Notebook instance starting. It may take a few minutes before it is available");
   }
 }

--- a/src/main/java/bio/terra/cli/command/resource/create/AwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/AwsSageMakerNotebook.java
@@ -70,10 +70,9 @@ public class AwsSageMakerNotebook extends WsmBaseCommand {
             .instanceType(instanceType)
             .region(region);
 
-    bio.terra.cli.businessobject.resource.AwsSageMakerNotebook createdResource =
-        bio.terra.cli.businessobject.resource.AwsSageMakerNotebook.createControlled(
-            createParams.build());
-    formatOption.printReturnValue(
-        new UFAwsSageMakerNotebook(createdResource), AwsSageMakerNotebook::printText);
+    bio.terra.cli.businessobject.resource.AwsSageMakerNotebook.createControlled(
+        createParams.build());
+
+    OUT.println("Creating notebook instance. It may take a few minutes before it is available");
   }
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFAwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFAwsSageMakerNotebook.java
@@ -66,15 +66,10 @@ public class UFAwsSageMakerNotebook extends UFResource {
   public void print(String prefix) {
     super.print(prefix);
     PrintStream OUT = UserIO.getOut();
-    OUT.println(prefix + "SageMaker Notebook instance name:   " + instanceName);
+    OUT.println(prefix + "Instance name:   " + instanceName);
+    OUT.println(prefix + "Instance type:   " + (instanceType == null ? "(unknown)" : instanceType));
     OUT.println(
-        prefix
-            + "SageMaker Notebook instance type:   "
-            + (instanceType == null ? "(unknown)" : instanceType));
-    OUT.println(
-        prefix
-            + "SageMaker Notebook instance status: "
-            + (instanceStatus == null ? "(unavailable)" : instanceStatus));
+        prefix + "Instance status: " + (instanceStatus == null ? "(unavailable)" : instanceStatus));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFAwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/resource/UFAwsSageMakerNotebook.java
@@ -74,7 +74,7 @@ public class UFAwsSageMakerNotebook extends UFResource {
     OUT.println(
         prefix
             + "SageMaker Notebook instance status: "
-            + (instanceStatus == null ? "(unknown)" : instanceStatus));
+            + (instanceStatus == null ? "(unavailable)" : instanceStatus));
   }
 
   @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -61,6 +61,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -795,6 +796,20 @@ public class WorkspaceManagerService {
       case FAILED -> throw new SystemException("Job failed: " + errorReport.getMessage());
       case RUNNING -> throw new UserActionableException(
           "CLI timed out waiting for the job to complete. It's still running on the server.");
+    }
+  }
+
+  /**
+   * Helper method that checks a JobReport's status and throws an exception if it's failed.
+   *
+   * <p>- Throws a {@link SystemException} if the job FAILED.
+   *
+   * @param jobReport WSM job report object
+   * @param errorReport WSM error report object
+   */
+  public static void throwIfJobFailed(JobReport jobReport, ErrorReport errorReport) {
+    if (Objects.requireNonNull(jobReport.getStatus()) == StatusEnum.FAILED) {
+      throw new SystemException("Job failed: " + errorReport.getMessage());
     }
   }
 

--- a/src/test/java/unit/AwsS3StorageFolderControlled.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlled.java
@@ -50,8 +50,9 @@ public class AwsS3StorageFolderControlled extends SingleWorkspaceUnitAws {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create s3-storage-folder --name=$name --folder-name=folderName`
-    String folderName = UUID.randomUUID().toString();
-    String name = "listDescribeResolveReflectCreateDelete-" + folderName;
+    UUID uuid = UUID.randomUUID();
+    String folderName = "cli-unit-aws-" + uuid;
+    String name = "listDescribeResolveReflectCreateDelete-" + uuid;
     UFAwsS3StorageFolder createdResource =
         TestCommand.runAndParseCommandExpectSuccess(
             UFAwsS3StorageFolder.class,

--- a/src/test/java/unit/AwsS3StorageFolderControlled.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlled.java
@@ -74,7 +74,7 @@ public class AwsS3StorageFolderControlled extends SingleWorkspaceUnitAws {
         ResourceUtils.listOneResourceWithName(name, AWS_S3_STORAGE_FOLDER);
     assertS3StorageFolderFields(createdResource, matchedResource, "list");
 
-    // `terra resource describe --name=$name --format=json`
+    // `terra resource describe --name=$name`
     UFAwsS3StorageFolder describedResource =
         TestCommand.runAndParseCommandExpectSuccess(
             UFAwsS3StorageFolder.class, "resource", "describe", "--name=" + name);

--- a/src/test/java/unit/AwsSageMakerNotebookControlled.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlled.java
@@ -160,8 +160,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     assertThat(
         "error message includes expected and current statuses",
         stdErr,
-        CoreMatchers.containsString(
-            "Expected notebook instance status is [Failed, Stopped] but current status is InService"));
+        CoreMatchers.containsString("Expected notebook instance status is"));
 
     // `terra notebook stop --name=$name`
     TestCommand.runCommandExpectSuccessWithRetries("notebook", "stop", "--name=" + name);
@@ -180,8 +179,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     assertThat(
         "error message includes expected and current statuses",
         stdErr,
-        CoreMatchers.containsString(
-            "Expected notebook instance status is [InService] but current status is Stopped"));
+        CoreMatchers.containsString("Expected notebook instance status is"));
 
     // `terra resource delete --name=$name`
     TestCommand.runCommandExpectSuccess("resource", "delete", "--name=" + name, "--quiet");

--- a/src/test/java/unit/AwsSageMakerNotebookControlled.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlled.java
@@ -61,8 +61,9 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create sagemaker-notebook --name=$name --folder-name=folderName`
-    String instanceName = UUID.randomUUID().toString();
-    String name = "listDescribeResolveReflectCreateDelete-" + instanceName;
+    UUID uuid = UUID.randomUUID();
+    String instanceName = "cli-unit-aws-" + uuid;
+    String name = "listDescribeResolveReflectCreateDelete-" + uuid;
     TestCommand.runCommandExpectSuccessWithRetries(
         "resource",
         "create",

--- a/src/test/java/unit/AwsSageMakerNotebookControlled.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlled.java
@@ -13,7 +13,6 @@ import bio.terra.workspace.model.AccessScope;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnitAws;
 import harness.utils.ResourceUtils;
-import harness.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +22,7 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
 /** Tests for the `terra resource` commands that handle controlled AWS SageMaker Notebooks. */
 @Tag("unit-aws")
@@ -54,7 +54,7 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
 
   @Test
   @DisplayName("list, describe and resolve reflect creating and deleting a controlled notebook")
-  void listDescribeResolveReflectCreateDelete() throws IOException {
+  void listDescribeResolveReflectCreateDelete() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
@@ -63,15 +63,21 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     // `terra resource create sagemaker-notebook --name=$name --folder-name=folderName`
     String instanceName = UUID.randomUUID().toString();
     String name = "listDescribeResolveReflectCreateDelete-" + instanceName;
+    TestCommand.runCommandExpectSuccessWithRetries(
+        "resource",
+        "create",
+        "sagemaker-notebook",
+        "--name=" + name,
+        "--instance-name=" + instanceName,
+        "--region=" + AWS_REGION);
+
+    ResourceUtils.pollDescribeForResourceField(
+        name, "instanceStatus", NotebookInstanceStatus.IN_SERVICE.toString());
+
+    // `terra resource describe --name=$name`
     UFAwsSageMakerNotebook createdResource =
         TestCommand.runAndParseCommandExpectSuccess(
-            UFAwsSageMakerNotebook.class,
-            "resource",
-            "create",
-            "sagemaker-notebook",
-            "--name=" + name,
-            "--instance-name=" + instanceName,
-            "--region=" + AWS_REGION);
+            UFAwsSageMakerNotebook.class, "resource", "describe", "--name=" + name);
 
     // check the created resource has required details
     assertEquals(name, createdResource.name, "created resource matches name");
@@ -93,15 +99,6 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     UFAwsSageMakerNotebook matchedResource =
         ResourceUtils.listOneResourceWithName(name, AWS_SAGEMAKER_NOTEBOOK);
     assertSageMakerNotebookFields(createdResource, matchedResource, "list");
-
-    // `terra resource describe --name=$name --format=json`
-    UFAwsSageMakerNotebook describedResource =
-        TestCommand.runAndParseCommandExpectSuccess(
-            UFAwsSageMakerNotebook.class, "resource", "describe", "--name=" + name);
-
-    // check the new notebook is returned by describe
-    TestUtils.assertResourceProperties(createdResource, describedResource, "describe");
-    assertSageMakerNotebookFields(createdResource, describedResource, "describe");
 
     // `terra resource resolve --name=$name --format=json`
     JSONObject resolved =
@@ -127,28 +124,27 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     assertNotNull(
         resolvedCredentials.get("Expiration"), "get credentials returned expiration date time");
 
-    // `terra notebook launch --name=$name` // classic view
-    TestCommand.runCommandExpectSuccessWithRetries("notebook", "launch", "--name=" + name);
+    // `terra notebook launch --name=$name --format=json` // lab view
     JSONObject proxyUrl =
         TestCommand.runAndGetJsonObjectExpectSuccess("notebook", "launch", "--name=" + name);
     Object url = proxyUrl.get("proxy_url");
-    assertNotNull(url, "launch notebook returned proxy url for classic view");
+    assertNotNull(url, "launch notebook returned proxy url for lab view");
     assertTrue(
-        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTER.toParam()),
-        "proxy url view is classic");
+        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTERLAB.toParam()),
+        "proxy url view is lab");
 
-    // `terra notebook launch --name=$name --proxy-view=$proxyView` // lab view
+    // `terra notebook launch --name=$name --proxy-view=$proxyView --format=json` // lab view
     proxyUrl =
         TestCommand.runAndGetJsonObjectExpectSuccess(
             "notebook",
             "launch",
             "--name=" + name,
-            "--proxy-view=" + AwsSageMakerNotebook.ProxyView.JUPYTERLAB);
+            "--proxy-view=" + AwsSageMakerNotebook.ProxyView.JUPYTER);
     url = proxyUrl.get("proxy_url");
-    assertNotNull(url, "launch notebook returned proxy url for lab view");
+    assertNotNull(url, "launch notebook returned proxy url for classic view");
     assertTrue(
-        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTERLAB.toParam()),
-        "proxy url view is lab");
+        url.toString().endsWith(AwsSageMakerNotebook.ProxyView.JUPYTER.toParam()),
+        "proxy url view is classic");
 
     // `terra resources check-access --name=$name`
     String stdErr =
@@ -172,6 +168,9 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
 
     // `terra notebook start --name=$name`
     TestCommand.runCommandExpectSuccessWithRetries("notebook", "start", "--name=" + name);
+
+    ResourceUtils.pollDescribeForResourceField(
+        name, "instanceStatus", NotebookInstanceStatus.IN_SERVICE.toString());
 
     // `terra notebook stop --name=$name`
     TestCommand.runCommandExpectSuccessWithRetries("notebook", "stop", "--name=" + name);


### PR DESCRIPTION
- Return from create / start aws commands immediately
- describe resource may be used to check status
- No changes at this time to delete, stop commands
- Start command behaviors are now consistent b/w AWS and GCP. These are fairly quick to complete (under 5 min). Further stop / delete confirmation is likely important for the user since it mat otherwise lead to user being charged
- Also included: minor UT fixes

locat test - 

```
terra-cli (dexamundsen/terra-578) >> terra resource create sagemaker-notebook --name=dex-notebook-517-5
Creating notebook instance. It may take a few minutes before it is available

terra-cli (dexamundsen/terra-578) >> terra resource list
NAME                            RESOURCE TYPE         STEWARDSHIP TYPE      DESCRIPTION                             
…                             
dex-notebook-517-5              AWS_SAGEMAKER_NOT...  CONTROLLED            (unset)     

// Resource creation not complete

terra-cli (dexamundsen/terra-578) >> terra resource describe --name=dex-notebook-517-5
Name:         dex-notebook-517-5
….
SageMaker Notebook instance name:   dex-notebook-517-5-dex-ws-513
SageMaker Notebook instance type:   ml.t2.medium
SageMaker Notebook instance status: (unavailable)

Logs:
2023-05-18 00:14:10.052 PDT [main] ERROR bio.terra.cli.service.WorkspaceManagerService - WSM exception status code: 409, response body: {"message":"Another operation is running on the resource; try again later","statusCode":409,"causes":[]}, message: {"message":"Another operation is running on the resource; try again later","statusCode":409,"causes":[]}
2023-05-18 00:14:10.060 PDT [main] ERROR bio.terra.cli.service.WorkspaceManagerService - WSM exception status code: 409, response body: {"message":"Another operation is running on the resource; try again later","statusCode":409,"causes":[]}, message: {"message":"Another operation is running on the resource; try again later","statusCode":409,"causes":[]}
2023-05-18 00:14:10.060 PDT [main] ERROR b.t.c.s.userfacing.resource.UFAwsSageMakerNotebook - bio.terra.cli.exception.SystemException: Error getting AWS SageMaker Notebook credential.: Another operation is running on the resource; try again later

// Creation complete 

terra-cli (dexamundsen/terra-578) >> terra resource describe --name=dex-notebook-517-5
Name:         dex-notebook-517-5
…
SageMaker Notebook instance status: InService



terra-cli (dexamundsen/terra-578) >> terra notebook stop --name=dex-notebook-517-5
Notebook instance stopped
terra-cli (dexamundsen/terra-578) >> terra resource describe --name=dex-notebook-517-5
Name:         dex-notebook-517-5
…
SageMaker Notebook instance status: Stopped

terra-cli (dexamundsen/terra-578) >> terra notebook start --name=dex-notebook-517-5
Notebook instance starting. It may take a few minutes before it is available
terra-cli (dexamundsen/terra-578) >> terra resource describe --name=dex-notebook-517-5
Name:         dex-notebook-517-5
..
SageMaker Notebook instance status: Pending

terra-cli (dexamundsen/terra-578) >> terra resource describe --name=dex-notebook-517-5
Name:         dex-notebook-517-5
..
SageMaker Notebook instance status: InService
```
<img width="872" alt="image" src="https://github.com/DataBiosphere/terra-cli/assets/2914285/86fe85c3-cd5a-4251-af8a-0f1416453d82">

