### PR TITLE
Add SageMaker notebook resource to generated AWS config, use UUID for filename.

### DIFF
--- a/src/main/java/bio/terra/cli/command/workspace/ConfigureAws.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ConfigureAws.java
@@ -53,12 +53,11 @@ public class ConfigureAws extends WsmBaseCommand {
 
   private static Path getAwsContextDir() {
     return Context.getContextDir()
-        .resolve(AWS_CONTEXT_SUBDIRECTORY_NAME)
-        .resolve(Context.getServer().getName());
+        .resolve(AWS_CONTEXT_SUBDIRECTORY_NAME);
   }
 
   private static Path getConfigFilePath(Workspace workspace) {
-    return getAwsContextDir().resolve(String.format("%s.conf", workspace.getUserFacingId()));
+    return getAwsContextDir().resolve(String.format("%s.conf", workspace.getUuid()));
   }
 
   @Override
@@ -72,7 +71,7 @@ public class ConfigureAws extends WsmBaseCommand {
 
     for (Resource resource : resourceList) {
       switch (resource.getResourceType()) {
-        case AWS_S3_STORAGE_FOLDER -> generateAwsResourceProfiles(builder, resource);
+        case AWS_S3_STORAGE_FOLDER, AWS_SAGEMAKER_NOTEBOOK -> generateAwsResourceProfiles(builder, resource);
       }
     }
 


### PR DESCRIPTION
* `workspace configure-aws` generates configs for SageMaker notebook resources.
* Notebook config file uses UUID instead of workspace name to work better with automation, no longer needs namespacing by server name.

Result:
```
$ eval $(terra workspace configure-aws)

$ echo ${AWS_CONFIG_FILE}
/Users/jczerk/.terra/aws/3d83d56b-adde-4243-9b9d-xxxxxxxxxxxx.conf

$ aws --profile notebook-xxxxxxxxxx sagemaker describe-notebook-instance --notebook-instance-name notebook-xxxxxxxxxx
{
    "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:000000000000:notebook-instance/notebook-xxxxxxxxxx",
    "NotebookInstanceName": "notebook-xxxxxxxxxx",
    "NotebookInstanceStatus": "Stopped",
...
```