### PR TITLE
[BENCH-530] Render client id / secrets to files in rendered folder

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -61,8 +61,10 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
-        ./tools/client-credentials.sh "src/main/resources/verily_secret.json" ${{ secrets.VERILY_CLIENT_ID }} ${{ secrets.VERILY_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
+                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" \
+                                      ${{ secrets.VERILY_CLIENT_ID }} ${{ secrets.VERILY_CLIENT_SECRET }}
 
     - name: Publish a release
       id: publish_release

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -68,7 +68,8 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
+                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
 
     - name: Run unit tests
       id: run_unit_tests

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -91,7 +91,8 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
+                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
 
     - name: Build Docker image
       id: build_docker_image

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'terra-cli'
 
-gradle.ext.cliVersion = '0.350.0'
+gradle.ext.cliVersion = '0.351.0'

--- a/src/main/java/bio/terra/cli/cloud/gcp/GoogleOauth.java
+++ b/src/main/java/bio/terra/cli/cloud/gcp/GoogleOauth.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,16 +59,17 @@ public final class GoogleOauth {
 
   /** Load the client secrets file to pass to oauth API's. */
   private static GoogleClientSecrets readRenderedClientSecrets() {
-    String clientCredentialsFileName =
-        StringUtils.isEmpty(Context.getServer().getClientCredentialsFile())
-            ? "rendered/broad/broad_secret.json"
-            : Context.getServer().getClientCredentialsFile();
+    String clientCredentialsFileName = Context.getServer().getClientCredentialsFile();
 
     try {
+      // Path clientCredentialsFilePath = Path.of(System.getProperty("user.dir"), "rendered",
+      // clientCredentialsFileName);
       return GoogleClientSecrets.load(
           GsonFactory.getDefaultInstance(),
           new InputStreamReader(
               new FileInputStream(clientCredentialsFileName), StandardCharsets.UTF_8));
+      // new FileInputStream(clientCredentialsFilePath.toAbsolutePath().toFile()),
+      // StandardCharsets.UTF_8));
 
     } catch (IOException ioException) {
       throw new SystemException(

--- a/src/main/resources/broad_secret.json
+++ b/src/main/resources/broad_secret.json
@@ -8,5 +8,6 @@
       "urn:ietf:wg:oauth:2.0:oob",
       "http://localhost"
     ]
-  }
+  },
+  "description": "Secrets file. Client id & secrets are rendered to rendered/broad/broad_secret.json"
 }

--- a/src/main/resources/servers/broad-dev-cli-testing.json
+++ b/src/main/resources/servers/broad-dev-cli-testing.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev-cli-testing",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Broad development environment for CLI testing. More stable and updated less frequently than the main development environment.",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev-local-sam.json
+++ b/src/main/resources/servers/broad-dev-local-sam.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev-local-sam",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Local SAM and Broad development environment for other services.",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev-local-wsm.json
+++ b/src/main/resources/servers/broad-dev-local-wsm.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev-local-wsm",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Local WSM and Broad development environment for other services.",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev-mmedlock.json
+++ b/src/main/resources/servers/broad-dev-mmedlock.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev-mmedlock",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Broad developer environment (mmedlock)",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev-zloery.json
+++ b/src/main/resources/servers/broad-dev-zloery.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev-zloery",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Broad developer environment (zloery)",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-dev.json
+++ b/src/main/resources/servers/broad-dev.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-dev",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Broad main development environment",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/broad-wsmtest.json
+++ b/src/main/resources/servers/broad-wsmtest.json
@@ -1,6 +1,6 @@
 {
   "name": "broad-wsmtest",
-  "clientCredentialsFile": "broad_secret.json",
+  "clientCredentialsFile": "rendered/broad/broad_secret.json",
   "cloudBuildEnabled": false,
   "description": "Broad WSM test server and Broad development environment for other services.",
   "dataRepoUri": "https://jade.datarepo-dev.broadinstitute.org",

--- a/src/main/resources/servers/verily-autopush.json
+++ b/src/main/resources/servers/verily-autopush.json
@@ -1,6 +1,6 @@
 {
   "name": "verily-autopush",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "cloudBuildEnabled": true,
   "description": "Verily auto-push environment",
   "samUri": "https://terra-autopush-sam.api.verily.com",

--- a/src/main/resources/servers/verily-devel.json
+++ b/src/main/resources/servers/verily-devel.json
@@ -1,6 +1,6 @@
 {
   "name": "verily-devel",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "cloudBuildEnabled": true,
   "description": "Verily devel environment",
   "samUri": "https://terra-devel-sam.api.verily.com",

--- a/src/main/resources/servers/verily-mc-feature-dev.json
+++ b/src/main/resources/servers/verily-mc-feature-dev.json
@@ -1,6 +1,6 @@
 {
   "name": "verily-mc-feature-dev",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "description": "Verily mc-feature-dev environment",
   "samUri": "https://terra-mc-feature-dev-sam.api.verily.com",
   "samInviteRequiresAdmin": true,

--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -1,6 +1,6 @@
 {
   "name": "verily-preprod",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "cloudBuildEnabled": true,
   "description": "Verily pre-prod environment",
   "samUri": "https://terra-preprod-sam.api.verily.com",

--- a/src/main/resources/servers/verily-staging.json
+++ b/src/main/resources/servers/verily-staging.json
@@ -1,6 +1,6 @@
 {
   "name": "verily-staging",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "cloudBuildEnabled": true,
   "description": "Verily staging environment",
   "samUri": "https://terra-staging-sam.api.verily.com",

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -1,6 +1,6 @@
 {
   "name": "verily",
-  "clientCredentialsFile": "verily_secret.json",
+  "clientCredentialsFile": "rendered/verily/verily_secret.json",
   "cloudBuildEnabled": true,
   "description": "Verily production environment",
   "samUri": "https://terra-sam.api.verily.com",

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -7,5 +7,6 @@
     "redirect_uris": [
       "https://terra.verily.com/authcode"
     ]
-  }
+  },
+  "description": "Secrets file. Client id & secrets are rendered to rendered/verily/verily_secret.json"
 }

--- a/src/test/java/harness/TestBashScript.java
+++ b/src/test/java/harness/TestBashScript.java
@@ -72,11 +72,13 @@ public class TestBashScript {
     Path workingDirectory = Path.of(System.getProperty("TERRA_WORKING_DIR"));
 
     // copy client credential files
-    File sourceFile =
-        Path.of("rendered", TestConfig.getTestConfigName(), "broad_secret.json")
-            .toFile(); // TODO-Dex
+    String clientCredentialsFileName =
+        String.format(
+            "rendered/%s/%s_secret.json",
+            TestConfig.getTestConfigName(), TestConfig.getTestConfigName());
+    File sourceFile = new File(clientCredentialsFileName);
     File destinationFile =
-        Path.of(System.getProperty("TERRA_WORKING_DIR"), "rendered", "broad_secret.json").toFile();
+        new File(System.getProperty("TERRA_WORKING_DIR") + "/", clientCredentialsFileName);
     FileUtils.copyFile(sourceFile, destinationFile);
 
     // run the commands in a child process

--- a/src/test/java/harness/baseclasses/ClearContextIntegration.java
+++ b/src/test/java/harness/baseclasses/ClearContextIntegration.java
@@ -29,7 +29,7 @@ public class ClearContextIntegration {
   }
 
   @AfterEach
-  protected void cleanupEachTime() {
+  protected void cleanupEachTime() throws IOException {
     // run a script that deletes the current workspace, but don't fail the test for any errors
     // during cleanup
     TestBashScript.runScript("DeleteWorkspace.sh");

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -14,21 +14,24 @@ renderedSecretsFile=$2
 clientId=$3
 clientSecret=$4
 
-if [ -z "$secretsFile" ] || [ -z "$renderedSecretsFile" ] || [ "$secretsFile" = "$renderedSecretsFile" ]; then
+if [[ -z "${secretsFile}" ]] || \
+   [[ -z "${renderedSecretsFile}" ]] || \
+   [[ "${secretsFile}" == "${renderedSecretsFile}" ]]; then
   echo "secretsFile & renderedSecretsFile paths are required and must be different"
   exit 1
 fi
 
-if [ ! -f "$secretsFile" ]; then
+if [[ ! -f "${secretsFile}" ]]; then
   echo "secrets file $secretsFile not available"
   exit 1
 fi
 
-if [ -z "$clientId" ] || [ -z "$clientSecret" ]; then
+if [[ -z "${clientId}" ]] || \
+   [[ -z "${clientSecret}" ]]; then
   echo "client_id & client_secret not available for $secretsFile"
   exit 1
 fi
 
-jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
+jq --arg CLIENT_ID "${clientId}" --arg CLIENT_SECRET "${clientSecret}" \
   '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
-  "$secretsFile" > "$renderedSecretsFile"
+  "${secretsFile}" > "${renderedSecretsFile}"

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
+
 ## This script adds client id and secrets into relevant files
 #
 ## Dependencies: jq
@@ -9,10 +12,10 @@ set -e
 ##         clientSecret (arg, required) client secret
 ## Usage: ./client-credentials.sh <file> <renderedFile> <id> <secret> --> rendered client_id & client_secret to file saving it as renderedFile
 
-secretsFile=$1
-renderedSecretsFile=$2
-clientId=$3
-clientSecret=$4
+readonly secretsFile="$1"
+readonly renderedSecretsFile="$2"
+readonly clientId="$3"
+readonly clientSecret="$4"
 
 if [[ -z "${secretsFile}" ]] || \
    [[ -z "${renderedSecretsFile}" ]] || \
@@ -22,13 +25,13 @@ if [[ -z "${secretsFile}" ]] || \
 fi
 
 if [[ ! -f "${secretsFile}" ]]; then
-  echo "secrets file $secretsFile not available"
+  echo "secrets file ${secretsFile} not available"
   exit 1
 fi
 
 if [[ -z "${clientId}" ]] || \
    [[ -z "${clientSecret}" ]]; then
-  echo "client_id & client_secret not available for $secretsFile"
+  echo "client_id & client_secret not available for ${secretsFile}"
   exit 1
 fi
 

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -1,32 +1,34 @@
 #!/bin/bash
 set -e
-## This script package client id and secrets into relevant files
-## The GitHub release includes an install package and a download + install script.
-## Note that a pre-release does not affect the "Latest release" tag, but a regular release does.
-## The release version number argument to this script must match the version number in the settings.gradle
-# file (i.e. version = '0.0.0' line).
+## This script adds client id and secrets into relevant files
 #
 ## Dependencies: jq
 ## Inputs: secretsFile (arg, required) path to the secrets file (valid format)
+##         renderedSecretsFile (arg, required) path to rendered secrets file.
 ##         clientId (arg, required) client id
 ##         clientSecret (arg, required) client secret
-## Usage: ./client-credentials.sh <file> <id> <secret> --> adds client_id and client_secret to file
+## Usage: ./client-credentials.sh <file> <renderedFile> <id> <secret> --> rendered client_id & client_secret to file saving it as renderedFile
 
 secretsFile=$1
-clientId=$2
-clientSecret=$3
+renderedSecretsFile=$2
+clientId=$3
+clientSecret=$4
+
+if [ -z "$secretsFile" ] || [ -z "$renderedSecretsFile" ] || [ "$secretsFile" = "$renderedSecretsFile" ]; then
+  echo "secretsFile & renderedSecretsFile paths are required and must be different"
+  exit 1
+fi
 
 if [ ! -f "$secretsFile" ]; then
-  echo "$secretsFile not available, skipping"
-  exit 0
+  echo "secrets file $secretsFile not available"
+  exit 1
 fi
-tmpFile=$1+".tmp"
 
 if [ -z "$clientId" ] || [ -z "$clientSecret" ]; then
-  echo "client_id & client_secret not available for $secretsFile, skipping"
-  exit 0
+  echo "client_id & client_secret not available for $secretsFile"
+  exit 1
 fi
 
 jq --arg CLIENT_ID "$clientId" --arg CLIENT_SECRET "$clientSecret" \
   '.installed.client_id = $CLIENT_ID | .installed.client_secret = $CLIENT_SECRET' \
-  "$secretsFile" > "$tmpFile" && mv "$tmpFile" "$secretsFile"
+  "$secretsFile" > "$renderedSecretsFile"

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -75,20 +75,20 @@ while IFS= read -r line; do
 done <<< "${testUsers}"
 
 echo "Fetching Broad client id and client secrets"
-clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
             vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
             jq -r '.data."broad-client-id"')
-clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
                 vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
                 jq -r '.data."broad-client-secret"')
 ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
                               "${clientId}" "${clientSecret}"
 
 echo "Fetching Verily client id and client secrets"
-clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
             vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
             jq -r '.data."verily-client-id"')
-clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
                 vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
                 jq -r '.data."verily-client-secret"')
 ./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" \

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -81,7 +81,7 @@ clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_I
 clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
                 vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
                 jq -r '.data."broad-client-secret"')
-./tools/client-credentials.sh "src/main/resources/broad_secret.json" "$clientId" "$clientSecret"
+./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" "$clientId" "$clientSecret"
 
 echo "Fetching Verily client id and client secrets"
 clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
@@ -90,5 +90,5 @@ clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_I
 clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
                 vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
                 jq -r '.data."verily-client-secret"')
-./tools/client-credentials.sh "src/main/resources/verily_secret.json" "$clientId" "$clientSecret"
+./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" "$clientId" "$clientSecret"
 

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
 
 ## This script renders configuration files needed for development and CI/CD.
 ## Dependencies: vault
@@ -26,19 +29,19 @@ CLIENT_CRED_VAULT_PATH=secret/dsde/terra/cli/oauth-client-credentials
 # Usage: readFromVault $CI_SA_VAULT_PATH ci-account.json
 #        readFromValue $JANITOR_CLIENT_SA_VAULT_PATH janitor-client.json base64
 readFromVault () {
-  vaultPath=$1
-  fileName=$2
-  decodeBase64=$3
+  vaultPath="$1"
+  fileName="$2"
+  decodeBase64="$3"
   if [[ -z "${vaultPath}" ]] || [[ -z "${fileName}" ]]; then
     >&2 echo "ERROR: Two arguments required for readFromVault function"
     exit 1
   fi
   if [[ -z "${decodeBase64}" ]]; then
-    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
               vault read -format json "${vaultPath}" \
               | jq -r .data > "rendered/broad/${fileName}"
   else
-    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
               vault read -format json "${vaultPath}" \
               | jq -r .data.key | base64 -d > "rendered/broad/${fileName}"
   fi

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -6,12 +6,12 @@
 ## Usage: ./tools/render-config.sh
 
 ## The script assumes that it is being run from the top-level directory "terra-cli/".
-if [[ $(basename $PWD) != 'terra-cli' ]]; then
+if [[ $(basename "${PWD}") != 'terra-cli' ]]; then
   >&2 echo "ERROR: Script must be run from top-level directory 'terra-cli/'"
   exit 1
 fi
 
-VAULT_TOKEN=${1:-$(cat $HOME/.vault-token)}
+VAULT_TOKEN=${1:-$(cat "${HOME}"/.vault-token)}
 DSDE_TOOLBOX_DOCKER_IMAGE=broadinstitute/dsde-toolbox:dev
 CI_SA_VAULT_PATH=secret/dsde/terra/kernel/dev/common/ci/ci-account.json
 TEST_USER_SA_VAULT_PATH=secret/dsde/firecloud/dev/common/firecloud-account.json
@@ -29,18 +29,18 @@ readFromVault () {
   vaultPath=$1
   fileName=$2
   decodeBase64=$3
-  if [[ -z "$vaultPath" ]] || [[ -z "$fileName" ]]; then
+  if [[ -z "${vaultPath}" ]] || [[ -z "${fileName}" ]]; then
     >&2 echo "ERROR: Two arguments required for readFromVault function"
     exit 1
   fi
-  if [[ -z "$decodeBase64" ]]; then
-    docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-              vault read -format json $vaultPath \
-              | jq -r .data > "rendered/broad/$fileName"
+  if [[ -z "${decodeBase64}" ]]; then
+    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+              vault read -format json "${vaultPath}" \
+              | jq -r .data > "rendered/broad/${fileName}"
   else
-    docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-              vault read -format json $vaultPath \
-              | jq -r .data.key | base64 -d > "rendered/broad/$fileName"
+    docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+              vault read -format json "${vaultPath}" \
+              | jq -r .data.key | base64 -d > "rendered/broad/${fileName}"
   fi
   return 0
 }
@@ -49,46 +49,47 @@ mkdir -p rendered/broad
 
 # used for publishing Docker images to GCR in the terra-cli-dev project
 echo "Reading the CI service account key file from Vault"
-readFromVault "$CI_SA_VAULT_PATH" "ci-account.json"
+readFromVault "${CI_SA_VAULT_PATH}" "ci-account.json"
 
 # used for generating domain-wide delegated credentials for test users
 echo "Reading the domain-wide delegated test users service account key file from Vault"
-readFromVault "$TEST_USER_SA_VAULT_PATH" "test-user-account.json"
+readFromVault "${TEST_USER_SA_VAULT_PATH}" "test-user-account.json"
 
 # used for creating external cloud resources in the terra-cli-test project for tests
 echo "Reading the external project service account key file from Vault"
-readFromVault "$EXT_PROJECT_SA_VAULT_PATH" "external-project-account.json"
+readFromVault "${EXT_PROJECT_SA_VAULT_PATH}" "external-project-account.json"
 
 # used for cleaning up external (to WSM) test resources with Janitor
 echo "Reading the Janitor client service account key file from Vault"
-readFromVault "$JANITOR_CLIENT_SA_VAULT_PATH" "janitor-client.json" "base64"
+readFromVault "${JANITOR_CLIENT_SA_VAULT_PATH}" "janitor-client.json" "base64"
 
 # used for granting break-glass access to a workspace in the verilycli deployment
 echo "Reading the WSM app service account key file for the verilycli deployment from Vault"
-readFromVault "$VERILYCLI_WSM_SA_VAULT_PATH" "verilycli-wsm-sa.json" "base64"
+readFromVault "${VERILYCLI_WSM_SA_VAULT_PATH}" "verilycli-wsm-sa.json" "base64"
 
 # Read test user refresh tokens
 echo "Reading test user refresh tokens from Vault"
 testUsers=$(cat "src/test/resources/testconfigs/broad.json" | jq -r '.testUsers[] | {email} | join (" ")')
 while IFS= read -r line; do
-  readFromVault "$TEST_USERS_VAULT_PATH/${line}" "${line}.json"
-done <<< "$testUsers"
+  readFromVault "${TEST_USERS_VAULT_PATH}/${line}" "${line}.json"
+done <<< "${testUsers}"
 
 echo "Fetching Broad client id and client secrets"
-clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
             jq -r '.data."broad-client-id"')
-clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-                vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+                vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
                 jq -r '.data."broad-client-secret"')
-./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" "$clientId" "$clientSecret"
+./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
+                              "${clientId}" "${clientSecret}"
 
 echo "Fetching Verily client id and client secrets"
-clientId=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-            vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+clientId=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+            vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
             jq -r '.data."verily-client-id"')
-clientSecret=$(docker run --rm -e VAULT_TOKEN="$VAULT_TOKEN" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
-                vault read -format json "$CLIENT_CRED_VAULT_PATH" | \
+clientSecret=$(docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" ${DSDE_TOOLBOX_DOCKER_IMAGE} \
+                vault read -format json "${CLIENT_CRED_VAULT_PATH}" | \
                 jq -r '.data."verily-client-secret"')
-./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" "$clientId" "$clientSecret"
-
+./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" \
+                              "${clientId}" "${clientSecret}"


### PR DESCRIPTION
Test with published version 

```
temp >> curl -L https://github.com/DataBiosphere/terra-cli/releases/download/dexamundsen-bench-530/download-install.sh | bash && export SUPPRESS_GCLOUD_CREDS_WARNING=true
….

temp >> ./terra server status
Current server: broad-dev-cli-testing (Broad development environment for CLI testing. More stable and updated less frequently than the main development environment.)
Server status: OKAY

temp >> ./terra auth status
NO USER LOGGED IN

temp >> ./terra auth login
Please open the following address in your browser:
  …
Attempting to open that address in the default browser now...
Login successful: dexamundsen@google.com

temp >> ./terra server set --name=verily-devel
Switching the server will clear the current login credentials and workspace. Are you sure you want to proceed (y/N)? y
Terra server is set to verily-devel (CHANGED).

temp >> ./terra auth status
NO USER LOGGED IN
temp >> ./terra auth login
Please open the following address in your browser:
  …
Attempting to open that address in the default browser now...
Login successful: dexamundsen@google.com

```

@mbookman  fyi (https://github.com/DataBiosphere/terra-cli/pull/491#discussion_r1205895522)