### PR TITLE
[BENCH-655], [BENCH-660] Open console link in browser if supported, update start o/p message

### DIFF
--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -23,6 +23,11 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 17
+    - name: Run linter
+      id: run_linter
+      run: |
+        cd terra-cli
+        ./gradlew spotlessCheck
     - name: Run static analysis
       id: run_static_analysis
       run: |

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Run linter
       id: run_linter
       run: |
-        cd terra-cli
         ./gradlew spotlessCheck
     - name: Run static analysis
       id: run_static_analysis

--- a/src/main/java/bio/terra/cli/command/notebook/Start.java
+++ b/src/main/java/bio/terra/cli/command/notebook/Start.java
@@ -11,6 +11,7 @@ import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.WorkspaceManagerServiceAws;
 import bio.terra.cloudres.google.notebooks.InstanceName;
 import bio.terra.workspace.model.CloudPlatform;
+import java.util.Optional;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra notebook start" command. */
@@ -34,8 +35,13 @@ public class Start extends BaseCommand {
 
     } else if (workspace.getCloudPlatform() == CloudPlatform.AWS) {
       AwsSageMakerNotebook awsNotebook = instanceOption.toAwsNotebookResource();
-      WorkspaceManagerServiceAws.fromContext()
-          .startSageMakerNotebook(workspace.getUuid(), awsNotebook);
+      Optional<Boolean> isSuccessful =
+          WorkspaceManagerServiceAws.fromContext()
+              .startSageMakerNotebook(workspace.getUuid(), awsNotebook);
+      if (isSuccessful.orElse(false)) {
+        OUT.println("Notebook instance started");
+        return;
+      }
 
     } else {
       throw new UserActionableException(

--- a/src/main/java/bio/terra/cli/command/resource/OpenConsole.java
+++ b/src/main/java/bio/terra/cli/command/resource/OpenConsole.java
@@ -3,7 +3,6 @@ package bio.terra.cli.command.resource;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.command.shared.WsmBaseCommand;
-import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.utils.UserIO;

--- a/src/main/java/bio/terra/cli/command/resource/OpenConsole.java
+++ b/src/main/java/bio/terra/cli/command/resource/OpenConsole.java
@@ -6,8 +6,7 @@ import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.ResourceName;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
-import java.net.URL;
-import org.json.JSONObject;
+import bio.terra.cli.utils.UserIO;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -30,7 +29,6 @@ public class OpenConsole extends WsmBaseCommand {
   private int duration;
 
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
-  @CommandLine.Mixin Format formatOption;
 
   /** Get an authenticated URL to directly access the resource in AWS console. */
   @Override
@@ -38,13 +36,6 @@ public class OpenConsole extends WsmBaseCommand {
     workspaceOption.overrideIfSpecified();
 
     Resource resource = Context.requireWorkspace().getResource(resourceNameOption.name);
-    URL consoleUrl = resource.getConsoleUrl(scope, duration);
-
-    JSONObject object = new JSONObject().put(resource.getName(), consoleUrl.toString());
-    formatOption.printReturnValue(object, this::printText, this::printJson);
-  }
-
-  private void printText(JSONObject object) {
-    OUT.println(object.getString(resourceNameOption.name));
+    UserIO.browse(resource.getConsoleUrl(scope, duration).toString());
   }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceAws.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.time.Duration;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -285,7 +286,6 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
    *
    * @param workspaceId the workspace to add the resource to
    * @param createParams creation parameters
-   * @return the AWS SageMaker Notebook resource object, if available
    */
   public void createControlledAwsSageMakerNotebook(
       UUID workspaceId, CreateAwsSageMakerNotebookParams createParams) {
@@ -480,7 +480,8 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
     }
   }
 
-  public void startSageMakerNotebook(UUID workspaceId, AwsSageMakerNotebook awsNotebook) {
+  public Optional<Boolean> startSageMakerNotebook(
+      UUID workspaceId, AwsSageMakerNotebook awsNotebook) {
     SageMakerClient sageMakerClient =
         getSageMakerClient(
             getControlledAwsSageMakerNotebookCredential(
@@ -494,7 +495,7 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
       NotebookInstanceStatus currentStatus =
           getSageMakerNotebookInstanceStatus(awsNotebook, sageMakerClient);
       if (currentStatus == NotebookInstanceStatus.IN_SERVICE) {
-        return;
+        return Optional.of(true); // successful, complete
       }
       checkNotebookStatus(
           notebookStatusSetCanStart, currentStatus, "Cannot start notebook instance");
@@ -511,6 +512,7 @@ public class WorkspaceManagerServiceAws extends WorkspaceManagerService {
             "Error starting notebook instance, "
                 + httpResponse.statusText().orElse(String.valueOf(httpResponse.statusCode())));
       }
+      return Optional.empty(); // successful, no completion status
 
     } catch (SdkException e) {
       checkException(e);

--- a/src/main/java/bio/terra/cli/utils/UserIO.java
+++ b/src/main/java/bio/terra/cli/utils/UserIO.java
@@ -1,8 +1,14 @@
 package bio.terra.cli.utils;
 
+import bio.terra.cli.businessobject.Config;
+import bio.terra.cli.businessobject.Context;
+import com.google.api.client.util.Preconditions;
+import java.awt.Desktop;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.List;
@@ -121,5 +127,29 @@ public class UserIO {
   public static <F, T> List<T> sortAndMap(
       List<F> fromList, Comparator<F> sorter, Function<F, T> mapper) {
     return fromList.stream().sorted(sorter).map(mapper).collect(Collectors.toList());
+  }
+
+  /**
+   * Open a browser at the given URL using {@link Desktop} if available, or alternatively output the
+   * URL to {@link System#out} for command-line applications. (copied from google-oauth-client-java)
+   *
+   * @param url URL to browse
+   */
+  public static void browse(String url) {
+    Preconditions.checkNotNull(url);
+    try {
+      if ((Context.getConfig().getBrowserLaunchOption().equals(Config.BrowserLaunchOption.AUTO))
+          && Desktop.isDesktopSupported()) {
+        Desktop desktop = Desktop.getDesktop();
+        if (desktop.isSupported(Desktop.Action.BROWSE)) {
+          System.out.println("Attempting to open that address in the default browser now...");
+          desktop.browse(URI.create(url));
+        }
+      } else {
+        getOut().println(url);
+      }
+    } catch (IOException | InternalError e) {
+      logger.warn("Unable to open browser", e);
+    }
   }
 }

--- a/src/main/java/bio/terra/cli/utils/UserIO.java
+++ b/src/main/java/bio/terra/cli/utils/UserIO.java
@@ -137,16 +137,14 @@ public class UserIO {
    */
   public static void browse(String url) {
     Preconditions.checkNotNull(url);
+    getOut().println("Please open the following address in your browser:");
+    getOut().println("  " + url);
     try {
       if ((Context.getConfig().getBrowserLaunchOption().equals(Config.BrowserLaunchOption.AUTO))
-          && Desktop.isDesktopSupported()) {
-        Desktop desktop = Desktop.getDesktop();
-        if (desktop.isSupported(Desktop.Action.BROWSE)) {
-          System.out.println("Attempting to open that address in the default browser now...");
-          desktop.browse(URI.create(url));
-        }
-      } else {
-        getOut().println(url);
+          && Desktop.isDesktopSupported()
+          && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+        getOut().println("Attempting to open that address in the default browser now...");
+        Desktop.getDesktop().browse(URI.create(url));
       }
     } catch (IOException | InternalError e) {
       logger.warn("Unable to open browser", e);

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -6,7 +6,9 @@
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "redirect_uris": [
       "https://terra.verily.com/authcode"
-    ]
+    ],
+    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
+    "client_secret": "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"
   },
   "description": "Secrets file. Client id & secrets are rendered to rendered/verily_secret.json"
 }

--- a/src/main/resources/verily_secret.json
+++ b/src/main/resources/verily_secret.json
@@ -6,9 +6,7 @@
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "redirect_uris": [
       "https://terra.verily.com/authcode"
-    ],
-    "client_id": "590500654757-l8ripukp65bpdr7kc7nq0o4bv8kmtku0.apps.googleusercontent.com",
-    "client_secret": "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"
+    ]
   },
   "description": "Secrets file. Client id & secrets are rendered to rendered/verily_secret.json"
 }

--- a/src/test/java/unit/AwsS3StorageFolderControlled.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlled.java
@@ -129,14 +129,19 @@ public class AwsS3StorageFolderControlled extends SingleWorkspaceUnitAws {
             "--name=" + name,
             "--scope=" + Resource.CredentialsAccessScope.READ_ONLY,
             "--duration=" + 1500);
-    assertThat(result.stdOut, containsString("Please open the following address in your browser"));
     assertThat(
+        "console link is displayed",
+        result.stdOut,
+        containsString("Please open the following address in your browser"));
+    assertThat(
+        "console link is opened in the browser",
         result.stdOut,
         containsString("Attempting to open that address in the default browser now..."));
 
     TestCommand.runCommandExpectSuccess("config", "set", "browser", "MANUAL");
     result = TestCommand.runCommandExpectSuccess("resource", "open-console", "--name=" + name);
     assertThat(
+        "console link is not opened in the browser",
         result.stdOut,
         not(containsString("Attempting to open that address in the default browser now...")));
 

--- a/src/test/java/unit/AwsS3StorageFolderControlled.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlled.java
@@ -2,6 +2,8 @@ package unit;
 
 import static bio.terra.cli.businessobject.Resource.CredentialsAccessScope.READ_ONLY;
 import static bio.terra.cli.businessobject.Resource.Type.AWS_S3_STORAGE_FOLDER;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,7 +18,6 @@ import harness.utils.TestUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
@@ -120,16 +121,24 @@ public class AwsS3StorageFolderControlled extends SingleWorkspaceUnitAws {
     assertNotNull(
         resolvedCredentials.get("Expiration"), "get credentials returned expiration date time");
 
-    // `terra resource open-console --name=$name --scope=READ_ONLY --duration=1500 --format=json`
-    JSONObject consoleUrl =
-        TestCommand.runAndGetJsonObjectExpectSuccess(
+    // `terra resource open-console --name=$name --scope=READ_ONLY --duration=1500`
+    TestCommand.Result result =
+        TestCommand.runCommandExpectSuccess(
             "resource",
             "open-console",
             "--name=" + name,
             "--scope=" + Resource.CredentialsAccessScope.READ_ONLY,
-            "--duration=" + 900);
-    String url = consoleUrl.getString(name);
-    assertTrue(StringUtils.isNotBlank(url), "open console returned console url");
+            "--duration=" + 1500);
+    assertThat(result.stdOut, containsString("Please open the following address in your browser"));
+    assertThat(
+        result.stdOut,
+        containsString("Attempting to open that address in the default browser now..."));
+
+    TestCommand.runCommandExpectSuccess("config", "set", "browser", "MANUAL");
+    result = TestCommand.runCommandExpectSuccess("resource", "open-console", "--name=" + name);
+    assertThat(
+        result.stdOut,
+        not(containsString("Attempting to open that address in the default browser now...")));
 
     // `terra resources check-access --name=$name`
     String stdErr =

--- a/src/test/java/unit/AwsSageMakerNotebookControlled.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlled.java
@@ -1,6 +1,8 @@
 package unit;
 
 import static bio.terra.cli.businessobject.Resource.Type.AWS_SAGEMAKER_NOTEBOOK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,7 +18,6 @@ import harness.utils.ResourceUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.json.JSONObject;
@@ -126,21 +127,29 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     assertNotNull(
         resolvedCredentials.get("Expiration"), "get credentials returned expiration date time");
 
-    // `terra resource open-console --name=$name --scope=READ_ONLY --duration=1500 --format=json`
-    JSONObject consoleUrl =
-        TestCommand.runAndGetJsonObjectExpectSuccess(
+    // `terra resource open-console --name=$name --scope=READ_ONLY --duration=1500`
+    TestCommand.Result result =
+        TestCommand.runCommandExpectSuccess(
             "resource",
             "open-console",
             "--name=" + name,
             "--scope=" + Resource.CredentialsAccessScope.READ_ONLY,
-            "--duration=" + 900);
-    String url = consoleUrl.getString(name);
-    assertTrue(StringUtils.isNotBlank(url), "open console returned console url");
+            "--duration=" + 1500);
+    assertThat(result.stdOut, containsString("Please open the following address in your browser"));
+    assertThat(
+        result.stdOut,
+        containsString("Attempting to open that address in the default browser now..."));
+
+    TestCommand.runCommandExpectSuccess("config", "set", "browser", "MANUAL");
+    result = TestCommand.runCommandExpectSuccess("resource", "open-console", "--name=" + name);
+    assertThat(
+        result.stdOut,
+        not(containsString("Attempting to open that address in the default browser now...")));
 
     // `terra notebook launch --name=$name --format=json` // lab view
     JSONObject proxyUrl =
         TestCommand.runAndGetJsonObjectExpectSuccess("notebook", "launch", "--name=" + name);
-    url = proxyUrl.getString(name);
+    String url = proxyUrl.getString(name);
     assertNotNull(url, "launch notebook returned proxy url for lab view");
     assertTrue(
         url.endsWith(AwsSageMakerNotebook.ProxyView.JUPYTERLAB.toParam()), "proxy url view is lab");


### PR DESCRIPTION
[BENCH-655] Open console link in browser if supported
Testing - 
```
>> terra config set browser AUTO
Browser launch mode for login is AUTO (UNCHANGED).

>> terra resource open-console --name=dex-s3-519-1 
Please open the following address in your browser:
  <url>
Attempting to open that address in the default browser now...
<verified that link opened in default browser>

>> terra config set browser MANUAL
Browser launch mode for login is MANUAL (CHANGED).

>> terra resource open-console --name=dex-s3-519-1 
Please open the following address in your browser:
<url>
<no browser window opened>
```

[BENCH-660] - display message that notebook is started if start is requested when notebook is already in service

AWS tests local run successful

![image](https://github.com/DataBiosphere/terra-cli/assets/2914285/ab5dca3a-c28f-4f6b-8937-7e471656e3ff)

