### PR TITLE
[draft] Fixes

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -61,11 +61,8 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
-                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
-        mkdir -p rendered/verily
-        ./tools/client-credentials.sh "src/main/resources/verily_secret.json" "rendered/verily/verily_secret.json" \
-                                      ${{ secrets.VERILY_CLIENT_ID }} ${{ secrets.VERILY_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/verily_secret.json" ${{ secrets.VERILY_CLIENT_ID }} ${{ secrets.VERILY_CLIENT_SECRET }}
 
     - name: Publish a release
       id: publish_release

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -68,8 +68,8 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
-                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }} \
+                                      "rendered/broad/broad_secret.json"
 
     - name: Run unit tests
       id: run_unit_tests

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -91,8 +91,8 @@ jobs:
 
     - name: Update client credentials
       run: |
-        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" "rendered/broad/broad_secret.json" \
-                                      ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }}
+        ./tools/client-credentials.sh "src/main/resources/broad_secret.json" ${{ secrets.BROAD_CLIENT_ID }} ${{ secrets.BROAD_CLIENT_SECRET }} \
+                                      "rendered/broad/broad_secret.json"
 
     - name: Build Docker image
       id: build_docker_image

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'terra-cli'
 
-gradle.ext.cliVersion = '0.353.0'
+gradle.ext.cliVersion = 'dexamundsen-530-fix'

--- a/tools/client-credentials.sh
+++ b/tools/client-credentials.sh
@@ -13,14 +13,9 @@ set -o pipefail
 ## Usage: ./client-credentials.sh <file> <renderedFile> <id> <secret> --> rendered client_id & client_secret to file saving it as renderedFile
 
 readonly secretsFile="$1"
-readonly renderedSecretsFile="$2"
-readonly clientId="$3"
-readonly clientSecret="$4"
-
-if [[ "${secretsFile}" == "${renderedSecretsFile}" ]]; then
-  echo "secretsFile & renderedSecretsFile paths must be different"
-  exit 1
-fi
+readonly clientId="$2"
+readonly clientSecret="$3"
+readonly renderedSecretsFile="${4:-${1}}"
 
 if [[ ! -f "${secretsFile}" ]]; then
   echo "secretsFile ${secretsFile} not available"

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -31,7 +31,7 @@ CLIENT_CRED_VAULT_PATH=secret/dsde/terra/cli/oauth-client-credentials
 readFromVault () {
   vaultPath="$1"
   fileName="$2"
-  decodeBase64="$3"
+  decodeBase64="${3:-}" # empty string if $3 not set
   if [[ -z "${vaultPath}" ]] || [[ -z "${fileName}" ]]; then
     >&2 echo "ERROR: Two arguments required for readFromVault function"
     exit 1


### PR DESCRIPTION
Test that render config puts secrets under rendered folder
```
>> ls rendered/broad/broad_secret.json rendered/verily/verily_secret.json
ls: rendered/broad/broad_secret.json: No such file or directory
ls: rendered/verily/verily_secret.json: No such file or directory

>> ./tools/render-config.sh 
…
Fetching Broad client id and client secrets
Fetching Verily client id and client secrets

>> ls -l rendered/broad/broad_secret.json rendered/verily/verily_secret.json
-rw-r--r--  1 dexamundsen  primarygroup  592 May 31 21:20 rendered/broad/broad_secret.json
-rw-r--r--  1 dexamundsen  primarygroup  589 May 31 21:20 rendered/verily/verily_secret.json
```

Test that client credentials script writes secrets to src file under resources if dot is not specified
```
>> rm rendered/broad/broad_secret.json rendered/verily/verily_secret.json

>> ./tools/client-credentials.sh "src/main/resources/verily_secret.json" testId testSecret
>> ./tools/client-credentials.sh "src/main/resources/broad_secret.json" testId testSecret

>> ls -l rendered/broad/broad_secret.json rendered/verily/verily_secret.json
ls: rendered/broad/broad_secret.json: No such file or directory
ls: rendered/verily/verily_secret.json: No such file or directory

>> cat src/main/resources/broad_secret.json;_secret.json 
{…
    "client_id": "testId",
    "client_secret": "testSecret"
…}
```

Create a test release
```
>> git tag dexamundsen-530-fix

>> git push origin dexamundsen-530-fix
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/DataBiosphere/terra-cli.git
 * [new tag]           dexamundsen-530-fix -> dexamundsen-530-fix

>> ./tools/publish-release.sh dexamundsen-530-fix
…
Creating pre-release
https://github.com/DataBiosphere/terra-cli/releases/tag/dexamundsen-530-fix
```