### PR TITLE
PF-2836: cleanupTestUserWorkspaces requires version info

### DIFF
--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -194,6 +194,14 @@ task cleanupTestUserWorkspaces(type: JavaExec) {
     classpath sourceSets.test.runtimeClasspath
     mainClass = 'harness.utils.CleanupTestUserWorkspaces'
 
+    // specify the implementation version that's set in the JAR manifest. cleanupTestUserWorkspaces
+    // run against the code directly, and so there is no JAR manifest. this implementation version is
+    // used to get the default docker image id.
+    systemProperty('TERRA_JAR_IMPLEMENTATION_VERSION',
+            "${project.properties['dockerRepoPath']}/${project.properties['dockerImageName']}/${gradle.cliVersion}:${project.properties['dockerImageTag']}")
+    // Normally CLI version comes from jar. For unit tests, there is no jar, so pass version this way.
+    systemProperty('TERRA_CLI_VERSION', "${gradle.cliVersion}")
+
     // override the default global context directory with a sub-directory of the gradle build directory
     // this is so that the tests don't overwrite any context that exists on this same machine.
     environment 'TERRA_CONTEXT_PARENT_DIR', "${buildDir}/test-context/"


### PR DESCRIPTION
Test user cleanup gradle task currently failing due to missing version info.