### PR TITLE
Revert "Revert "PF-2817: When auth0 enabled, use access token and not refresh…"

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -339,7 +339,6 @@ public class User {
    * configured Server instance.
    */
   public AccessToken getTerraToken() {
-    // google oauth has an opaque access token so we are using id token for google oauth2 login.
     return Context.getServer().getSupportsIdToken() ? getUserIdToken() : getUserAccessToken();
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -309,16 +309,7 @@ public class User {
     if (terraCredentials == null) {
       return true;
     }
-    // check if the token is expired
-    Date cutOffDate = new Date();
-    cutOffDate.setTime(cutOffDate.getTime() + CREDENTIAL_EXPIRATION_OFFSET_MS);
-
-    if (Context.getServer().getAuth0Enabled()) {
-      Date accessTokenExpiration = getTerraToken().getExpirationTime();
-      return accessTokenExpiration.before(cutOffDate);
-    }
     // NOTE: getUserAccessToken called to induce side effect of refreshing the token if expired
-
     Date accessTokenExpiration = getUserAccessToken().getExpirationTime();
     logger.debug("Access token expiration date: {}", accessTokenExpiration);
     Date idTokenExipration = terraCredentials.getIdToken().getExpirationTime();
@@ -326,6 +317,9 @@ public class User {
     Date earliestExpiration =
         accessTokenExpiration.before(idTokenExipration) ? accessTokenExpiration : idTokenExipration;
 
+    // check if the token is expired
+    Date cutOffDate = new Date();
+    cutOffDate.setTime(cutOffDate.getTime() + CREDENTIAL_EXPIRATION_OFFSET_MS);
     // If either token expires before the cutoff, return true to trigger a re-authentication.
     return (earliestExpiration.before(cutOffDate));
   }
@@ -346,11 +340,6 @@ public class User {
    */
   public AccessToken getTerraToken() {
     // google oauth has an opaque access token so we are using id token for google oauth2 login.
-    // But for auth0, access token is a jwt token and it is discouraged to use id token for calling
-    // API. To be consistent with the UI, we are using access token when auth0 is enabled.
-    if (Context.getServer().getAuth0Enabled()) {
-      return getUserAccessToken();
-    }
     return Context.getServer().getSupportsIdToken() ? getUserIdToken() : getUserAccessToken();
   }
 

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -309,7 +309,14 @@ public class User {
     if (terraCredentials == null) {
       return true;
     }
+    // check if the token is expired
+    Date cutOffDate = new Date();
+    cutOffDate.setTime(cutOffDate.getTime() + CREDENTIAL_EXPIRATION_OFFSET_MS);
 
+    if (Context.getServer().getAuth0Enabled()) {
+      Date accessTokenExpiration = getTerraToken().getExpirationTime();
+      return accessTokenExpiration.before(cutOffDate);
+    }
     // NOTE: getUserAccessToken called to induce side effect of refreshing the token if expired
 
     Date accessTokenExpiration = getUserAccessToken().getExpirationTime();
@@ -318,10 +325,6 @@ public class User {
     logger.debug("ID token expiration date: {}", idTokenExipration);
     Date earliestExpiration =
         accessTokenExpiration.before(idTokenExipration) ? accessTokenExpiration : idTokenExipration;
-
-    // check if the token is expired
-    Date cutOffDate = new Date();
-    cutOffDate.setTime(cutOffDate.getTime() + CREDENTIAL_EXPIRATION_OFFSET_MS);
 
     // If either token expires before the cutoff, return true to trigger a re-authentication.
     return (earliestExpiration.before(cutOffDate));
@@ -342,6 +345,12 @@ public class User {
    * configured Server instance.
    */
   public AccessToken getTerraToken() {
+    // google oauth has an opaque access token so we are using id token for google oauth2 login.
+    // But for auth0, access token is a jwt token and it is discouraged to use id token for calling
+    // API. To be consistent with the UI, we are using access token when auth0 is enabled.
+    if (Context.getServer().getAuth0Enabled()) {
+      return getUserAccessToken();
+    }
     return Context.getServer().getSupportsIdToken() ? getUserIdToken() : getUserAccessToken();
   }
 

--- a/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
+++ b/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
@@ -136,8 +136,7 @@ public final class Oauth {
             .authorize(CREDENTIAL_STORE_KEY);
 
     if (credential.getRefreshToken() == null || credential.getRefreshToken().isEmpty()) {
-      logger.info(
-          "Refresh token is not set. This is expected when testing, not during normal operation.");
+      logger.info("Refresh token is not set. This is expected when testing or auth0 is enabled.");
     } else {
       credential.refreshToken();
     }
@@ -232,7 +231,6 @@ public final class Oauth {
     if (storedCredential == null) {
       return null; // there is no credential, return here
     } else {
-
       // now turn the stored credential into a regular OAuth2 Credentials representing a user's
       // identity and consent
       credentials =
@@ -279,6 +277,9 @@ public final class Oauth {
    * @return access token
    */
   public static AccessToken getAccessToken(TerraCredentials credential) {
+    if (Context.getServer().getAuth0Enabled()) {
+      return credential.getGoogleCredentials().getAccessToken();
+    }
     try {
       credential.getGoogleCredentials().refreshIfExpired();
     } catch (IOException ioEx) {
@@ -494,7 +495,7 @@ public final class Oauth {
         String url =
             auth.authorizeUrl(
                     /*redirectUrl=*/ "https://github.com/DataBiosphere/terra-cli/blob/main/README.md")
-                .withResponseType("code token id_token")
+                .withResponseType("code")
                 .build();
         authorizationCodeFlow =
             new AuthorizationCodeFlow.Builder(


### PR DESCRIPTION
Reverts DataBiosphere/terra-cli#511

Cannot use access token for ADC login so I reverted the change to use access token when auth0 is enabled. 

kept the change to not refresh when getting access token.  