### PR TITLE
[PF-2837] Remove access and cloning flags for aws-notebook creation

### DIFF
--- a/src/main/java/bio/terra/cli/command/resource/create/AwsSageMakerNotebook.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/AwsSageMakerNotebook.java
@@ -1,14 +1,14 @@
 package bio.terra.cli.command.resource.create;
 
 import bio.terra.cli.command.shared.WsmBaseCommand;
-import bio.terra.cli.command.shared.options.ControlledResourceCreation;
 import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.ResourceCreation;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.input.CreateAwsSageMakerNotebookParams;
 import bio.terra.cli.serialization.userfacing.input.CreateResourceParams;
-import bio.terra.cli.serialization.userfacing.resource.UFAwsSageMakerNotebook;
 import bio.terra.cli.utils.CommandUtils;
 import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
 import bio.terra.workspace.model.CloudPlatform;
 import bio.terra.workspace.model.StewardshipType;
 import picocli.CommandLine;
@@ -22,7 +22,7 @@ import picocli.CommandLine;
     showDefaultValues = true,
     sortOptions = false)
 public class AwsSageMakerNotebook extends WsmBaseCommand {
-  @CommandLine.Mixin ControlledResourceCreation controlledResourceCreationOptions;
+  @CommandLine.Mixin ResourceCreation resourceCreationOption;
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
   @CommandLine.Mixin Format formatOption;
 
@@ -46,12 +46,6 @@ public class AwsSageMakerNotebook extends WsmBaseCommand {
           "The AWS region of the SageMaker Notebook instance (https://docs.aws.amazon.com/general/latest/gr/sagemaker.html).")
   private String region;
 
-  /** Print this command's output in text format. */
-  private static void printText(UFAwsSageMakerNotebook returnValue) {
-    OUT.println("Successfully added controlled AWS SageMaker Notebook.");
-    returnValue.print();
-  }
-
   /** Add a controlled AWS SageMaker Notebook to the workspace. */
   @Override
   protected void execute() {
@@ -60,10 +54,11 @@ public class AwsSageMakerNotebook extends WsmBaseCommand {
 
     // build the resource object to create. force the resource to be private
     CreateResourceParams createResourceParams =
-        controlledResourceCreationOptions
+        resourceCreationOption
             .populateMetadataFields()
             .stewardshipType(StewardshipType.CONTROLLED)
             .accessScope(AccessScope.PRIVATE_ACCESS)
+            .cloningInstructions(CloningInstructionsEnum.NOTHING)
             .build();
 
     CreateAwsSageMakerNotebookParams.Builder createParams =

--- a/src/test/java/unit/AwsS3StorageFolderControlledTest.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlledTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 /** Tests for the `terra resource` commands that handle controlled AWS S3 Storage Folders. */
 @Tag("unit-aws")
-public class AwsS3StorageFolderControlled extends SingleWorkspaceUnitAws {
+public class AwsS3StorageFolderControlledTest extends SingleWorkspaceUnitAws {
   private static boolean verifyS3Path(String s3Path, String prefix, boolean includesS3Prefix) {
     return s3Path.matches(
         String.format("^%s[a-zA-Z0-9_-]+/%s/?$", (includesS3Prefix ? "[sS]3://" : ""), prefix));

--- a/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
@@ -101,7 +101,7 @@ public class AwsSageMakerNotebookControlledTest extends SingleWorkspaceUnitAws {
     assertEquals(
         CloningInstructionsEnum.NOTHING,
         createdResource.cloningInstructions,
-        "created resource matches access");
+        "created resource matches cloning instruction");
 
     // check that the notebook is in the resource list
     UFAwsSageMakerNotebook matchedResource =

--- a/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
@@ -12,6 +12,7 @@ import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.businessobject.resource.AwsSageMakerNotebook;
 import bio.terra.cli.serialization.userfacing.resource.UFAwsSageMakerNotebook;
 import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnitAws;
 import harness.utils.ResourceUtils;
@@ -28,7 +29,7 @@ import software.amazon.awssdk.services.sagemaker.model.NotebookInstanceStatus;
 
 /** Tests for the `terra resource` commands that handle controlled AWS SageMaker Notebooks. */
 @Tag("unit-aws")
-public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
+public class AwsSageMakerNotebookControlledTest extends SingleWorkspaceUnitAws {
   private static boolean verifySageMakerPath(
       String SageMakerPath, String instanceName, String region) {
     return SageMakerPath.equals(
@@ -90,13 +91,17 @@ public class AwsSageMakerNotebookControlled extends SingleWorkspaceUnitAws {
     assertNotNull(createdResource.instanceType, "created resource returned instance type");
     assertNotNull(createdResource.instanceStatus, "created resource returned instance status");
 
-    // sagemaker notebooks are always private
+    // sagemaker notebooks are always private, no clone support
     assertEquals(
         AccessScope.PRIVATE_ACCESS, createdResource.accessScope, "created resource matches access");
     assertEquals(
         workspaceCreator.email.toLowerCase(),
         createdResource.privateUserName.toLowerCase(),
         "created resource matches private user name");
+    assertEquals(
+        CloningInstructionsEnum.NOTHING,
+        createdResource.cloningInstructions,
+        "created resource matches access");
 
     // check that the notebook is in the resource list
     UFAwsSageMakerNotebook matchedResource =

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.cli.serialization.userfacing.resource.UFGcpNotebook;
 import bio.terra.cli.service.utils.CrlUtils;
 import bio.terra.workspace.model.AccessScope;
+import bio.terra.workspace.model.CloningInstructionsEnum;
 import harness.TestCommand;
 import harness.baseclasses.SingleWorkspaceUnitGcp;
 import harness.utils.GcpNotebookUtils;
@@ -158,13 +159,17 @@ public class GcpNotebookControlled extends SingleWorkspaceUnitGcp {
     assertEquals(location, createdNotebook.location, "create output matches location");
     assertEquals(instanceId, createdNotebook.instanceId, "create output matches instance id");
 
-    // gcp notebooks are always private
+    // gcp notebooks are always private, no clone support
     assertEquals(
         AccessScope.PRIVATE_ACCESS, createdNotebook.accessScope, "create output matches access");
     assertEquals(
         workspaceCreator.email.toLowerCase(),
         createdNotebook.privateUserName.toLowerCase(),
         "create output matches private user name");
+    assertEquals(
+        CloningInstructionsEnum.NOTHING,
+        createdNotebook.cloningInstructions,
+        "created resource matches cloning instruction");
 
     // `terra resource describe --name=$name --format=json`
     UFGcpNotebook describeResource =

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -169,7 +169,7 @@ public class GcpNotebookControlled extends SingleWorkspaceUnitGcp {
     assertEquals(
         CloningInstructionsEnum.NOTHING,
         createdNotebook.cloningInstructions,
-        "created resource matches cloning instruction");
+        "create output matches cloning instruction");
 
     // `terra resource describe --name=$name --format=json`
     UFGcpNotebook describeResource =

--- a/src/test/java/unit/WorkspaceAwsTest.java
+++ b/src/test/java/unit/WorkspaceAwsTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 /** Tests for the `terra workspace` commands specific to CloudPlatform.AWS. */
 @Tag("unit-aws")
-public class WorkspaceAws extends ClearContextUnit {
+public class WorkspaceAwsTest extends ClearContextUnit {
   @BeforeAll
   protected void setupOnce() throws Exception {
     setCloudPlatform(CloudPlatform.AWS);


### PR DESCRIPTION
- Same as https://github.com/DataBiosphere/terra-cli/pull/513, for AWS notebooks
- remove unused functions
- rename test classes to have suffix 'Test'