### PR TITLE
[PF-2783] Add read only file permission bits

### DIFF
--- a/src/main/java/bio/terra/cli/utils/mount/handlers/GcsFuseMountHandler.java
+++ b/src/main/java/bio/terra/cli/utils/mount/handlers/GcsFuseMountHandler.java
@@ -43,7 +43,7 @@ public class GcsFuseMountHandler extends BaseMountHandler {
       command.addAll(List.of("--only-dir", subDir));
     }
     if (readOnly) {
-      command.addAll(List.of("-o", "ro"));
+      command.addAll(List.of("-o", "ro", "--file-mode", "444", "--dir-mode", "555"));
     }
     command.addAll(List.of(bucketName, mountPoint.toString()));
 


### PR DESCRIPTION
Currently, when a user mounts a bucket as read only and runs `ls -l` inside the mounted bucket, the files will have incorrect permission bits set. The default 644 (rx-r--r--) set by `gscfuse`. @mbookman proposed using the `--file-mode` and `--dir-mode` flags in `gcsfuse` to set the correct read only file permissions on files and directories. This PR does just that!