### PR TITLE
[BENCH-781] User suitable prefix for test AWS resources

### DIFF
--- a/src/test/java/harness/utils/TestUtils.java
+++ b/src/test/java/harness/utils/TestUtils.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 public class TestUtils {
   // appendRandomNumber: definition copied from Workspace Manager
-  public static String appendRandomNumber(String prefix) {
+  public static String appendRandomString(String prefix) {
     // Can't have dash because BQ dataset names can't have dash.
     // Can't have underscore because for controlled buckets, GCP recommends not having underscore
     // in bucket name.

--- a/src/test/java/harness/utils/TestUtils.java
+++ b/src/test/java/harness/utils/TestUtils.java
@@ -3,14 +3,16 @@ package harness.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import bio.terra.cli.serialization.userfacing.UFResource;
-import java.util.Random;
+import java.util.UUID;
 
 public class TestUtils {
-  private static final Random RANDOM = new Random();
-
-  public static String appendRandomNumber(String string) {
-    // This might be used for BQ datasets, so can't have "-". (BQ dataset names can't have "-".)
-    return string + RANDOM.nextInt(10000);
+  // appendRandomNumber: definition copied from Workspace Manager
+  public static String appendRandomNumber(String prefix) {
+    // Can't have dash because BQ dataset names can't have dash.
+    // Can't have underscore because for controlled buckets, GCP recommends not having underscore
+    // in bucket name.
+    String randomString = prefix + UUID.randomUUID();
+    return randomString.replaceAll("[-_]", "");
   }
 
   public static <T extends UFResource, E extends UFResource> void assertResourceProperties(

--- a/src/test/java/unit/AwsS3StorageFolderControlledTest.java
+++ b/src/test/java/unit/AwsS3StorageFolderControlledTest.java
@@ -54,7 +54,7 @@ public class AwsS3StorageFolderControlledTest extends SingleWorkspaceUnitAws {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create s3-storage-folder --name=$name --folder-name=folderName`
-    String storageName = TestUtils.appendRandomNumber(namePrefix);
+    String storageName = TestUtils.appendRandomString(namePrefix);
     UFAwsS3StorageFolder createdResource =
         TestCommand.runAndParseCommandExpectSuccess(
             UFAwsS3StorageFolder.class,

--- a/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
+++ b/src/test/java/unit/AwsSageMakerNotebookControlledTest.java
@@ -66,7 +66,7 @@ public class AwsSageMakerNotebookControlledTest extends SingleWorkspaceUnitAws {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create sagemaker-notebook --name=$name --folder-name=folderName`
-    String notebookName = TestUtils.appendRandomNumber(namePrefix);
+    String notebookName = TestUtils.appendRandomString(namePrefix);
     TestCommand.runCommandExpectSuccessWithRetries(
         "resource",
         "create",

--- a/src/test/java/unit/DuplicateWorkspaceGcp.java
+++ b/src/test/java/unit/DuplicateWorkspaceGcp.java
@@ -189,7 +189,7 @@ public class DuplicateWorkspaceGcp extends ClearContextUnit {
             UFDuplicatedWorkspace.class,
             "workspace",
             "duplicate",
-            "--new-id=" + TestUtils.appendRandomNumber("duplicated-workspace-id"),
+            "--new-id=" + TestUtils.appendRandomString("duplicated-workspace-id"),
             "--name=duplicated_workspace",
             "--description=A duplicate.");
 

--- a/src/test/java/unit/GcpPassthroughApps.java
+++ b/src/test/java/unit/GcpPassthroughApps.java
@@ -225,7 +225,7 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
 
     // `terra resource create bq-dataset --name=$name --dataset-id=$datasetId --format=json`
-    String name = TestUtils.appendRandomNumber("bqShow");
+    String name = TestUtils.appendRandomString("bqShow");
     String datasetId = randomDatasetId();
     UFBqDataset dataset =
         TestCommand.runAndParseCommandExpectSuccess(
@@ -270,7 +270,7 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
   @Test
   @DisplayName("git clone --all")
   void gitCloneAll() throws IOException {
-    String resource1Name = TestUtils.appendRandomNumber("repo1");
+    String resource1Name = TestUtils.appendRandomString("repo1");
 
     workspaceCreator.login(/*writeGcloudAuthFiles=*/ true);
     // `terra workspace set --id=$id`
@@ -301,14 +301,14 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
 
     // `terra workspace set --id=$id`
     TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
-    String repo1 = TestUtils.appendRandomNumber("repo");
+    String repo1 = TestUtils.appendRandomString("repo");
     TestCommand.runCommandExpectSuccess(
         "resource",
         "add-ref",
         "git-repo",
         "--name=" + repo1,
         "--repo-url=https://github.com/DataBiosphere/terra-example-notebooks.git");
-    String repo2 = TestUtils.appendRandomNumber("repo2");
+    String repo2 = TestUtils.appendRandomString("repo2");
     TestCommand.runCommandExpectSuccess(
         "resource",
         "add-ref",
@@ -321,7 +321,7 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
         "add-ref",
         "gcs-bucket",
         "--name=" + bucketResourceName,
-        "--bucket-name=" + TestUtils.appendRandomNumber("bucket-name"));
+        "--bucket-name=" + TestUtils.appendRandomString("bucket-name"));
 
     // `terra git clone --resource=$repo1,repo2`
     TestCommand.runCommandExpectSuccess("git", "clone", "--resource=" + repo1 + "," + repo2);
@@ -471,7 +471,7 @@ public class GcpPassthroughApps extends SingleWorkspaceUnitGcp {
 
   /** This is to re-create a scenario when a resource is created through UI. */
   private String createAGitRepoReferenceByCallingWsmEndpoint() {
-    String gitResourceName = TestUtils.appendRandomNumber("git-referenced-url");
+    String gitResourceName = TestUtils.appendRandomString("git-referenced-url");
     UUID workspaceUuid =
         WorkspaceManagerService.fromContext().getWorkspaceByUserFacingId(getUserFacingId()).getId();
     WorkspaceManagerService.fromContext()

--- a/src/test/java/unit/WorkspaceAwsTest.java
+++ b/src/test/java/unit/WorkspaceAwsTest.java
@@ -130,7 +130,7 @@ public class WorkspaceAwsTest extends ClearContextUnit {
     assertEquals(0, createdWorkspace.numResources, "new workspace has 0 resources");
 
     // `terra resource create s3-storage-folder --name=$name`
-    String storageName = TestUtils.appendRandomNumber(namePrefix);
+    String storageName = TestUtils.appendRandomString(namePrefix);
     TestCommand.runCommandExpectSuccess(
         "resource", "create", "s3-storage-folder", "--name=" + storageName);
 
@@ -163,7 +163,7 @@ public class WorkspaceAwsTest extends ClearContextUnit {
     TestCommand.runCommandExpectExitCode(1, "workspace", "configure-aws");
 
     // `terra resource create s3-storage-folder --name=$name --region $region`
-    String firstStorageName = TestUtils.appendRandomNumber(namePrefix);
+    String firstStorageName = TestUtils.appendRandomString(namePrefix);
     TestCommand.runCommandExpectSuccess(
         "resource",
         "create",
@@ -172,7 +172,7 @@ public class WorkspaceAwsTest extends ClearContextUnit {
         "--region=" + folderRegion);
 
     // `terra resource create s3-storage-folder --name=$name --region $region`
-    String secondStorageName = TestUtils.appendRandomNumber(namePrefix);
+    String secondStorageName = TestUtils.appendRandomString(namePrefix);
     TestCommand.runCommandExpectSuccess(
         "resource",
         "create",

--- a/src/test/java/unit/WorkspaceAwsTest.java
+++ b/src/test/java/unit/WorkspaceAwsTest.java
@@ -14,13 +14,13 @@ import harness.TestCommand;
 import harness.TestUser;
 import harness.baseclasses.ClearContextUnit;
 import harness.utils.AwsConfigurationUtils;
+import harness.utils.TestUtils;
 import harness.utils.WorkspaceUtils;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 /** Tests for the `terra workspace` commands specific to CloudPlatform.AWS. */
 @Tag("unit-aws")
 public class WorkspaceAwsTest extends ClearContextUnit {
+  private static final String namePrefix = "cliTestWorkspaceResource";
+
   @BeforeAll
   protected void setupOnce() throws Exception {
     setCloudPlatform(CloudPlatform.AWS);
@@ -128,9 +130,9 @@ public class WorkspaceAwsTest extends ClearContextUnit {
     assertEquals(0, createdWorkspace.numResources, "new workspace has 0 resources");
 
     // `terra resource create s3-storage-folder --name=$name`
-    String name = "describeReflectsNumResources" + UUID.randomUUID();
+    String storageName = TestUtils.appendRandomNumber(namePrefix);
     TestCommand.runCommandExpectSuccess(
-        "resource", "create", "s3-storage-folder", "--name=" + name);
+        "resource", "create", "s3-storage-folder", "--name=" + storageName);
 
     // `terra workspace describe`
     UFWorkspace describedWorkspace =
@@ -161,27 +163,27 @@ public class WorkspaceAwsTest extends ClearContextUnit {
     TestCommand.runCommandExpectExitCode(1, "workspace", "configure-aws");
 
     // `terra resource create s3-storage-folder --name=$name --region $region`
-    String defaultResourceName = UUID.randomUUID().toString();
+    String firstStorageName = TestUtils.appendRandomNumber(namePrefix);
     TestCommand.runCommandExpectSuccess(
         "resource",
         "create",
         "s3-storage-folder",
-        "--name=" + defaultResourceName,
+        "--name=" + firstStorageName,
         "--region=" + folderRegion);
 
     // `terra resource create s3-storage-folder --name=$name --region $region`
-    String secondaryResourceName = UUID.randomUUID().toString();
+    String secondStorageName = TestUtils.appendRandomNumber(namePrefix);
     TestCommand.runCommandExpectSuccess(
         "resource",
         "create",
         "s3-storage-folder",
-        "--name=" + secondaryResourceName,
+        "--name=" + secondStorageName,
         "--region=" + folderRegion);
 
     String terraPath = "/fake/path/to/terra";
     String awsVaultPath = "/fake/path/to/aws-vault";
 
-    Collection<String> resourceNames = Set.of(defaultResourceName, secondaryResourceName);
+    Collection<String> resourceNames = Set.of(firstStorageName, secondStorageName);
 
     // 'terra workspace configure-aws'
     TestCommand.Result configureResult =
@@ -199,13 +201,13 @@ public class WorkspaceAwsTest extends ClearContextUnit {
     // 'terra workspace configure-aws --default-resource $name'
     configureResult =
         TestCommand.runCommandExpectSuccess(
-            "workspace", "configure-aws", "--default-resource", defaultResourceName);
+            "workspace", "configure-aws", "--default-resource", firstStorageName);
 
     AwsConfigurationUtils.validateConfiguration(
         configureResult.stdOut,
         folderRegion,
         resourceNames,
-        Optional.of(defaultResourceName),
+        Optional.of(firstStorageName),
         false,
         Optional.empty(),
         Optional.empty());
@@ -229,14 +231,14 @@ public class WorkspaceAwsTest extends ClearContextUnit {
             "workspace",
             "configure-aws",
             "--default-resource",
-            defaultResourceName,
+            firstStorageName,
             "--cache-with-aws-vault");
 
     AwsConfigurationUtils.validateConfiguration(
         configureResult.stdOut,
         folderRegion,
         resourceNames,
-        Optional.of(defaultResourceName),
+        Optional.of(firstStorageName),
         true,
         Optional.empty(),
         Optional.empty());


### PR DESCRIPTION
- add a suitable prefix to AWS resource identifiers created in test scripts
- This helps to separate out test script resources from user created resources for manual cleanup (if needed)
- This applies to - 
    - ResourceName (stored in sam)
    - for S3 - folderName
    - for SageMaker - instanceName
- To keep it easier in WSM tests same resource and folderName (or instanceName) is used. 

Rename util appendRandomNumber to appendRandomString

---

Reference in WSM - 

util function to append random number to a prefix - https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAwsResourceFixtures.java#L139

same resource and folderName used - https://github.com/DataBiosphere/terra-workspace-manager/blob/main/service/src/test/java/bio/terra/workspace/common/fixtures/ControlledAwsResourceFixtures.java#L148

Successful test run downstream

![image](https://github.com/DataBiosphere/terra-cli/assets/2914285/88f2cf13-9b8d-4bef-a61e-4ac745358bc6)
