### PR TITLE
PF-2913: Distinguish an auth0 token based on whether auth0 is enabled and it is a browser login

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -306,7 +306,7 @@ public class User {
 
   /** Return true if the user credentials are expired or do not exist on disk. */
   public boolean requiresReauthentication() {
-    if (terraCredentials == null) {
+    if (terraCredentials == null || getUserAccessToken() == null) {
       return true;
     }
     // NOTE: getUserAccessToken called to induce side effect of refreshing the token if expired

--- a/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
+++ b/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
@@ -1,6 +1,7 @@
 package bio.terra.cli.cloud.auth;
 
 import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.command.auth.Login.LogInMode;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.utils.HttpUtils;
@@ -277,7 +278,9 @@ public final class Oauth {
    * @return access token
    */
   public static AccessToken getAccessToken(TerraCredentials credential) {
-    if (Context.getServer().getAuth0Enabled()) {
+    if (Context.getServer().getAuth0Enabled()
+        && LogInMode.BROWSER == Context.requireUser().getLogInMode()) {
+      // Auth0 login doesn't support token refresh.
       return credential.getGoogleCredentials().getAccessToken();
     }
     try {


### PR DESCRIPTION
Even when auth0 is enabled, we use ADC to login to vertex ai notebook so in that case it is still a google credentials. 

currently when opening a vertex ai notebook on startup, we can do all the normal terra operation with the id token. but it will throw NPE when claling terra auth status because the access token is not there. This is because we assume that it is an auth0 login when calling getAccessToken but in the case of vertex ai notebook env, it is actually an ADC id token