### PR TITLE
PF-2910: add support for folder in cli command

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -214,9 +214,8 @@ public class Workspace {
   }
 
   public Folder updateFolderProperties(UUID folderId, Map<String, String> properties) {
-   return WorkspaceManagerService.fromContext().updateFolderProperties(uuid, folderId, properties);
+    return WorkspaceManagerService.fromContext().updateFolderProperties(uuid, folderId, properties);
   }
-
 
   /** Delete the current workspace. */
   public void delete() {

--- a/src/main/java/bio/terra/cli/businessobject/Workspace.java
+++ b/src/main/java/bio/terra/cli/businessobject/Workspace.java
@@ -11,8 +11,6 @@ import bio.terra.workspace.model.CloneWorkspaceResult;
 import bio.terra.workspace.model.ClonedWorkspace;
 import bio.terra.workspace.model.CloudPlatform;
 import bio.terra.workspace.model.Folder;
-import bio.terra.workspace.model.Properties;
-import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.ResourceDescription;
 import bio.terra.workspace.model.WorkspaceDescription;
 import com.google.api.services.cloudresourcemanager.v3.model.Binding;
@@ -171,18 +169,6 @@ public class Workspace {
     return WorkspaceManagerService.fromContext().listWorkspaces(offset, limit).getWorkspaces();
   }
 
-  public static Properties stringMapToProperties(@Nullable Map<String, String> map) {
-    Properties properties = new Properties();
-    if (map == null) {
-      return properties;
-    }
-    for (Map.Entry<String, String> entry : map.entrySet()) {
-      Property property = new Property().key(entry.getKey()).value(entry.getValue());
-      properties.add(property);
-    }
-    return properties;
-  }
-
   /**
    * Update the mutable properties of the current workspace.
    *
@@ -226,6 +212,11 @@ public class Workspace {
     Context.setWorkspace(workspace);
     return workspace;
   }
+
+  public Folder updateFolderProperties(UUID folderId, Map<String, String> properties) {
+   return WorkspaceManagerService.fromContext().updateFolderProperties(uuid, folderId, properties);
+  }
+
 
   /** Delete the current workspace. */
   public void delete() {

--- a/src/main/java/bio/terra/cli/command/Folder.java
+++ b/src/main/java/bio/terra/cli/command/Folder.java
@@ -1,0 +1,11 @@
+package bio.terra.cli.command;
+
+import bio.terra.cli.command.folder.SetProperty;
+import bio.terra.cli.command.folder.Tree;
+import picocli.CommandLine.Command;
+
+@Command(
+    name = "folder",
+    description = "Commands related to folder.",
+    subcommands = {Tree.class, SetProperty.class})
+public class Folder {}

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -80,7 +80,8 @@ import picocli.CommandLine.ParseResult;
       Status.class,
       User.class,
       Version.class,
-      Workspace.class
+      Workspace.class,
+      Folder.class
     })
 public class Main implements Runnable {
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Main.class);

--- a/src/main/java/bio/terra/cli/command/Main.java
+++ b/src/main/java/bio/terra/cli/command/Main.java
@@ -66,6 +66,7 @@ import picocli.CommandLine.ParseResult;
       Bq.class,
       Config.class,
       Cromwell.class,
+      Folder.class,
       Gcloud.class,
       GenerateCompletion.class,
       Git.class,
@@ -80,8 +81,7 @@ import picocli.CommandLine.ParseResult;
       Status.class,
       User.class,
       Version.class,
-      Workspace.class,
-      Folder.class
+      Workspace.class
     })
 public class Main implements Runnable {
   private static final org.slf4j.Logger logger = LoggerFactory.getLogger(Main.class);

--- a/src/main/java/bio/terra/cli/command/folder/SetProperty.java
+++ b/src/main/java/bio/terra/cli/command/folder/SetProperty.java
@@ -1,14 +1,11 @@
 package bio.terra.cli.command.folder;
 
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
 import bio.terra.cli.serialization.userfacing.UFFolder;
-import bio.terra.cli.serialization.userfacing.UFWorkspace;
 import bio.terra.workspace.model.Folder;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.UUID;
 import picocli.CommandLine;
@@ -33,15 +30,15 @@ public class SetProperty extends WsmBaseCommand {
   @CommandLine.Option(
       names = "--id",
       required = true,
-      description = "Id of the folder. Hint: Obtain the id by running terra folder tree first."
-  )
+      description = "Id of the folder. Hint: Obtain the id by running terra folder tree first.")
   public UUID folderId;
 
   /** Set folder properties. */
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
-    Folder updatedFolder = Context.requireWorkspace().updateFolderProperties(folderId, folderProperties);
+    Folder updatedFolder =
+        Context.requireWorkspace().updateFolderProperties(folderId, folderProperties);
     System.out.println(new UFFolder(updatedFolder));
     formatOption.printReturnValue(new UFFolder(updatedFolder), this::printText);
   }

--- a/src/main/java/bio/terra/cli/command/folder/SetProperty.java
+++ b/src/main/java/bio/terra/cli/command/folder/SetProperty.java
@@ -39,7 +39,6 @@ public class SetProperty extends WsmBaseCommand {
     workspaceOption.overrideIfSpecified();
     Folder updatedFolder =
         Context.requireWorkspace().updateFolderProperties(folderId, folderProperties);
-    System.out.println(new UFFolder(updatedFolder));
     formatOption.printReturnValue(new UFFolder(updatedFolder), this::printText);
   }
 

--- a/src/main/java/bio/terra/cli/command/folder/SetProperty.java
+++ b/src/main/java/bio/terra/cli/command/folder/SetProperty.java
@@ -1,0 +1,54 @@
+package bio.terra.cli.command.folder;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.command.shared.WsmBaseCommand;
+import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.serialization.userfacing.UFFolder;
+import bio.terra.cli.serialization.userfacing.UFWorkspace;
+import bio.terra.workspace.model.Folder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.UUID;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra folder set-property" command. */
+// This is set-property instead of add-property because this can be used to 1) Add property 2)
+// Update existing property.
+@Command(name = "set-property", description = "Set the folder properties.")
+public class SetProperty extends WsmBaseCommand {
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+  @CommandLine.Mixin Format formatOption;
+
+  @CommandLine.Option(
+      names = "--properties",
+      required = true,
+      split = ",",
+      description =
+          "Folder properties. Example: --properties=key=value. For multiple properties, use \",\": --properties=key1=value1,key2=value2")
+  public Map<String, String> folderProperties;
+
+  @CommandLine.Option(
+      names = "--id",
+      required = true,
+      description = "Id of the folder. Hint: Obtain the id by running terra folder tree first."
+  )
+  public UUID folderId;
+
+  /** Set folder properties. */
+  @Override
+  protected void execute() {
+    workspaceOption.overrideIfSpecified();
+    Folder updatedFolder = Context.requireWorkspace().updateFolderProperties(folderId, folderProperties);
+    System.out.println(new UFFolder(updatedFolder));
+    formatOption.printReturnValue(new UFFolder(updatedFolder), this::printText);
+  }
+
+  /** Print this command's output in text format. */
+  private void printText(UFFolder folder) {
+    OUT.println("Folder properties successfully updated.");
+    folder.print();
+  }
+}

--- a/src/main/java/bio/terra/cli/command/folder/Tree.java
+++ b/src/main/java/bio/terra/cli/command/folder/Tree.java
@@ -60,7 +60,7 @@ public class Tree extends WsmBaseCommand {
         StringBuilder sb = new StringBuilder(prefix);
         sb.append(isLast ? "└── " : "├── ");
         sb.append(childFolder.getDisplayName());
-        sb.append("(");
+        sb.append(" (");
         sb.append(childFolder.getId());
         sb.append(")");
         System.out.println(sb);

--- a/src/main/java/bio/terra/cli/command/folder/Tree.java
+++ b/src/main/java/bio/terra/cli/command/folder/Tree.java
@@ -3,12 +3,9 @@ package bio.terra.cli.command.folder;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
-import bio.terra.workspace.api.FolderApi;
 import bio.terra.workspace.model.Folder;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import picocli.CommandLine;
@@ -18,21 +15,15 @@ import picocli.CommandLine.Command;
 @Command(name = "tree", description = "show the folder hierarchy.")
 public class Tree extends WsmBaseCommand {
 
-  /**
-   * Map for folder id to folder.
-   */
+  /** Map for folder id to folder. */
   private static final Map<UUID, Folder> ID_TO_FOLDER = new HashMap<>();
-  /**
-   * Map for folder to all of its children folders.
-   */
+  /** Map for folder to all of its children folders. */
   private static final Map<Folder, ArrayList<Folder>> EDGES = new HashMap<>();
 
-  /**
-   * An imaginary root folder of a workspace.
-   */
+  /** An imaginary root folder of a workspace. */
   private static final Folder ROOT = new Folder().id(UUID.randomUUID()).displayName("root");
-  @CommandLine.Mixin
-  WorkspaceOverride workspaceOption;
+
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   /** List the resources and folders in the workspace. */
   @Override
@@ -49,7 +40,9 @@ public class Tree extends WsmBaseCommand {
     for (Folder folder : ID_TO_FOLDER.values()) {
       EDGES
           .computeIfAbsent(
-              folder.getParentFolderId() != null ? ID_TO_FOLDER.get(folder.getParentFolderId()) : ROOT,
+              folder.getParentFolderId() != null
+                  ? ID_TO_FOLDER.get(folder.getParentFolderId())
+                  : ROOT,
               k -> new ArrayList<>())
           .add(folder);
     }

--- a/src/main/java/bio/terra/cli/command/folder/Tree.java
+++ b/src/main/java/bio/terra/cli/command/folder/Tree.java
@@ -1,0 +1,78 @@
+package bio.terra.cli.command.folder;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.command.shared.WsmBaseCommand;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.workspace.api.FolderApi;
+import bio.terra.workspace.model.Folder;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+/** This class corresponds to the third-level "terra folder tree" command. */
+@Command(name = "tree", description = "show the folder hierarchy.")
+public class Tree extends WsmBaseCommand {
+
+  /**
+   * Map for folder id to folder.
+   */
+  private static final Map<UUID, Folder> ID_TO_FOLDER = new HashMap<>();
+  /**
+   * Map for folder to all of its children folders.
+   */
+  private static final Map<Folder, ArrayList<Folder>> EDGES = new HashMap<>();
+
+  /**
+   * An imaginary root folder of a workspace.
+   */
+  private static final Folder ROOT = new Folder().id(UUID.randomUUID()).displayName("root");
+  @CommandLine.Mixin
+  WorkspaceOverride workspaceOption;
+
+  /** List the resources and folders in the workspace. */
+  @Override
+  protected void execute() {
+    workspaceOption.overrideIfSpecified();
+
+    // Get folders in the workspace and sort by name
+    Context.requireWorkspace().listFolders().forEach(f -> ID_TO_FOLDER.put(f.getId(), f));
+
+    // Create edges map for DFS and store name for each id. Display the folder before the resource.
+    // Note: The intuitive algorithm doesn't handle drawing lines correctly, so use this algorithm
+    // from GNU Tree utility implementation: https://github.com/kddnewton/tree/blob/main/Tree.java
+    // See https://github.com/DataBiosphere/terra-cli/pull/329/files#r982639897
+    for (Folder folder : ID_TO_FOLDER.values()) {
+      EDGES
+          .computeIfAbsent(
+              folder.getParentFolderId() != null ? ID_TO_FOLDER.get(folder.getParentFolderId()) : ROOT,
+              k -> new ArrayList<>())
+          .add(folder);
+    }
+
+    dfsWalk(ROOT, "");
+  }
+
+  // A DFS walk helper function to print out a tree view graph.
+  private static void dfsWalk(Folder parentFolder, String prefix) {
+    if (EDGES.containsKey(parentFolder)) {
+      ArrayList<Folder> edgeList = EDGES.get(parentFolder);
+      for (int index = 0; index < edgeList.size(); index++) {
+        Folder childFolder = edgeList.get(index);
+        boolean isLast = index == edgeList.size() - 1;
+        StringBuilder sb = new StringBuilder(prefix);
+        sb.append(isLast ? "└── " : "├── ");
+        sb.append(childFolder.getDisplayName());
+        sb.append("(");
+        sb.append(childFolder.getId());
+        sb.append(")");
+        System.out.println(sb);
+        dfsWalk(childFolder, prefix + (isLast ? "    " : "│   "));
+      }
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/command/shared/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/Format.java
@@ -35,6 +35,7 @@ public class Format {
     // use Jackson to map the object to a JSON-formatted text block
     ObjectWriter objectWriter = JacksonMapper.getMapper().writerWithDefaultPrettyPrinter();
     try {
+      System.out.println(objectWriter.writeValueAsString(returnValue));
       UserIO.getOut().println(objectWriter.writeValueAsString(returnValue));
     } catch (JsonProcessingException jsonEx) {
       throw new SystemException("Error JSON-formatting the command return value.", jsonEx);

--- a/src/main/java/bio/terra/cli/command/shared/options/Format.java
+++ b/src/main/java/bio/terra/cli/command/shared/options/Format.java
@@ -35,7 +35,6 @@ public class Format {
     // use Jackson to map the object to a JSON-formatted text block
     ObjectWriter objectWriter = JacksonMapper.getMapper().writerWithDefaultPrettyPrinter();
     try {
-      System.out.println(objectWriter.writeValueAsString(returnValue));
       UserIO.getOut().println(objectWriter.writeValueAsString(returnValue));
     } catch (JsonProcessingException jsonEx) {
       throw new SystemException("Error JSON-formatting the command return value.", jsonEx);

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
@@ -1,0 +1,93 @@
+package bio.terra.cli.serialization.userfacing;
+
+import bio.terra.cli.utils.PropertiesUtils;
+import bio.terra.cli.utils.UserIO;
+import bio.terra.workspace.model.Folder;
+import bio.terra.workspace.model.Properties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import java.io.PrintStream;
+import java.util.UUID;
+
+@JsonDeserialize(builder = UFFolder.Builder.class)
+public class UFFolder {
+  public final UUID id;
+  public final String displayName;
+  public final String description;
+  public final UUID parentId;
+
+  public final Properties properties;
+
+  public UFFolder(Folder folder) {
+    id = folder.getId();
+    displayName = folder.getDisplayName();
+    description = folder.getDescription();
+    parentId = folder.getParentFolderId();
+    properties = folder.getProperties();
+  }
+
+  public UFFolder(Builder builder) {
+    id = builder.id;
+    displayName = builder.displayName;
+    description = builder.description;
+    parentId = builder.parentId;
+    properties = builder.properties;
+  }
+
+  public void print() {
+    PrintStream OUT = UserIO.getOut();
+    OUT.println("ID:                " + id);
+    OUT.println("Name:              " + displayName);
+    OUT.println("Description:       " + description);
+    OUT.println("Parent folder ID:  " + parentId);
+    if (properties != null){
+      OUT.println("Properties:");
+      PropertiesUtils.propertiesToStringMap(properties).forEach((key, value) -> OUT.println("  " + key + ": " + value));
+    }
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class Builder {
+
+    private UUID id;
+    private String displayName;
+    private String description;
+    private UUID parentId;
+
+    private Properties properties;
+
+    /** Default constructor for Jackson. */
+    public Builder() {}
+
+    public UFFolder.Builder id(UUID id) {
+      this.id = id;
+      return this;
+    }
+
+    public UFFolder.Builder displayName(String displayName) {
+      this.displayName = displayName;
+      return this;
+    }
+
+    public UFFolder.Builder description(String description) {
+      this.description = description;
+      return this;
+    }
+
+    public UFFolder.Builder parentId(UUID parentId) {
+      this.parentId = parentId;
+      return this;
+    }
+
+    public UFFolder.Builder properties(Properties properties) {
+      this.properties = properties;
+      return this;
+    }
+
+
+    /** Call the private constructor. */
+    public UFFolder build() {
+      return new UFFolder(this);
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
@@ -36,10 +36,10 @@ public class UFFolder {
 
   public void print() {
     PrintStream OUT = UserIO.getOut();
-    OUT.println("ID:                " + id);
-    OUT.println("Name:              " + displayName);
-    OUT.println("Description:       " + description);
-    OUT.println("Parent ID:  " + parentId);
+    OUT.println("ID:          " + id);
+    OUT.println("Name:        " + displayName);
+    OUT.println("Description: " + description);
+    OUT.println("Parent ID:   " + parentId);
     if (properties != null) {
       OUT.println("Properties:");
       PropertiesUtils.propertiesToStringMap(properties)

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
@@ -39,7 +39,7 @@ public class UFFolder {
     OUT.println("ID:                " + id);
     OUT.println("Name:              " + displayName);
     OUT.println("Description:       " + description);
-    OUT.println("Parent folder ID:  " + parentId);
+    OUT.println("Parent ID:  " + parentId);
     if (properties != null) {
       OUT.println("Properties:");
       PropertiesUtils.propertiesToStringMap(properties)

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFFolder.java
@@ -40,9 +40,10 @@ public class UFFolder {
     OUT.println("Name:              " + displayName);
     OUT.println("Description:       " + description);
     OUT.println("Parent folder ID:  " + parentId);
-    if (properties != null){
+    if (properties != null) {
       OUT.println("Properties:");
-      PropertiesUtils.propertiesToStringMap(properties).forEach((key, value) -> OUT.println("  " + key + ": " + value));
+      PropertiesUtils.propertiesToStringMap(properties)
+          .forEach((key, value) -> OUT.println("  " + key + ": " + value));
     }
   }
 
@@ -83,7 +84,6 @@ public class UFFolder {
       this.properties = properties;
       return this;
     }
-
 
     /** Call the private constructor. */
     public UFFolder build() {

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -292,5 +292,4 @@ public class UFWorkspaceLight {
       return new UFWorkspaceLight(this);
     }
   }
-
 }

--- a/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/UFWorkspaceLight.java
@@ -2,11 +2,10 @@ package bio.terra.cli.serialization.userfacing;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
+import bio.terra.cli.utils.PropertiesUtils;
 import bio.terra.cli.utils.UserIO;
 import bio.terra.workspace.model.AwsContext;
 import bio.terra.workspace.model.CloudPlatform;
-import bio.terra.workspace.model.Properties;
-import bio.terra.workspace.model.Property;
 import bio.terra.workspace.model.WorkspaceDescription;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import java.io.PrintStream;
@@ -14,7 +13,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /** This is used instead of UFWorkspace, if workspace resources aren't needed. */
 public class UFWorkspaceLight {
@@ -62,7 +60,7 @@ public class UFWorkspaceLight {
     WorkspaceDescription workspaceDescription = internalObj.getWorkspaceDescription();
     this.name = workspaceDescription.getDisplayName();
     this.description = workspaceDescription.getDescription();
-    this.properties = propertiesToStringMap(workspaceDescription.getProperties());
+    this.properties = PropertiesUtils.propertiesToStringMap(workspaceDescription.getProperties());
     this.userEmail = Context.requireUser().getEmail();
     this.serverName = Context.getServer().getName();
     this.createdDate = workspaceDescription.getCreatedDate();
@@ -99,7 +97,7 @@ public class UFWorkspaceLight {
 
     this.name = workspaceDescription.getDisplayName();
     this.description = workspaceDescription.getDescription();
-    this.properties = propertiesToStringMap(workspaceDescription.getProperties());
+    this.properties = PropertiesUtils.propertiesToStringMap(workspaceDescription.getProperties());
     this.userEmail = Context.requireUser().getEmail();
     this.serverName = Context.getServer().getName();
     this.createdDate = workspaceDescription.getCreatedDate();
@@ -295,7 +293,4 @@ public class UFWorkspaceLight {
     }
   }
 
-  private static Map<String, String> propertiesToStringMap(Properties properties) {
-    return properties.stream().collect(Collectors.toMap(Property::getKey, Property::getValue));
-  }
 }

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -2,7 +2,6 @@ package bio.terra.cli.service;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Server;
-import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.userfacing.input.AddGitRepoParams;
@@ -11,6 +10,7 @@ import bio.terra.cli.serialization.userfacing.input.UpdateReferencedGitRepoParam
 import bio.terra.cli.service.utils.HttpUtils;
 import bio.terra.cli.utils.HttpClients;
 import bio.terra.cli.utils.JacksonMapper;
+import bio.terra.cli.utils.PropertiesUtils;
 import bio.terra.workspace.api.FolderApi;
 import bio.terra.workspace.api.ReferencedGcpResourceApi;
 import bio.terra.workspace.api.ResourceApi;
@@ -184,7 +184,7 @@ public class WorkspaceManagerService {
                             .displayName(name)
                             .description(description)
                             .stage(WorkspaceStageModel.MC_WORKSPACE)
-                            .properties(Workspace.stringMapToProperties(properties))
+                            .properties(PropertiesUtils.stringMapToProperties(properties))
                             .cloudPlatform(cloudPlatform)
                             .spendProfile(spendProfile)
                             .jobControl(new JobControl().id(jobId))),
@@ -355,6 +355,18 @@ public class WorkspaceManagerService {
     return callWithRetries(
         () -> new WorkspaceApi(apiClient).getWorkspace(workspaceId, /*minimumHighestRole=*/ null),
         "Error getting the workspace after updating properties");
+  }
+
+
+  public Folder updateFolderProperties(UUID workspaceId, UUID folderId, Map<String, String> folderProperties) {
+    callWithRetries(
+        () ->
+            new FolderApi(apiClient).updateFolderProperties(buildProperties(folderProperties), workspaceId, folderId),
+        "Error updating folder properties"
+    );
+    return callWithRetries(
+        () -> new FolderApi(apiClient).getFolder(workspaceId, folderId),
+        "Error getting the folder after updating properties");
   }
 
   /**

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerService.java
@@ -357,13 +357,13 @@ public class WorkspaceManagerService {
         "Error getting the workspace after updating properties");
   }
 
-
-  public Folder updateFolderProperties(UUID workspaceId, UUID folderId, Map<String, String> folderProperties) {
+  public Folder updateFolderProperties(
+      UUID workspaceId, UUID folderId, Map<String, String> folderProperties) {
     callWithRetries(
         () ->
-            new FolderApi(apiClient).updateFolderProperties(buildProperties(folderProperties), workspaceId, folderId),
-        "Error updating folder properties"
-    );
+            new FolderApi(apiClient)
+                .updateFolderProperties(buildProperties(folderProperties), workspaceId, folderId),
+        "Error updating folder properties");
     return callWithRetries(
         () -> new FolderApi(apiClient).getFolder(workspaceId, folderId),
         "Error getting the folder after updating properties");

--- a/src/main/java/bio/terra/cli/utils/PropertiesUtils.java
+++ b/src/main/java/bio/terra/cli/utils/PropertiesUtils.java
@@ -1,0 +1,30 @@
+package bio.terra.cli.utils;
+
+import bio.terra.workspace.model.Properties;
+import bio.terra.workspace.model.Property;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+public class PropertiesUtils {
+
+  public static Map<String, String> propertiesToStringMap(@Nullable Properties properties) {
+    if (properties == null) {
+      return new HashMap<>();
+    }
+    return properties.stream().collect(Collectors.toMap(Property::getKey, Property::getValue));
+  }
+
+  public static Properties stringMapToProperties(@Nullable Map<String, String> map) {
+    Properties properties = new Properties();
+    if (map == null) {
+      return properties;
+    }
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      Property property = new Property().key(entry.getKey()).value(entry.getValue());
+      properties.add(property);
+    }
+    return properties;
+  }
+}

--- a/src/main/java/bio/terra/cli/utils/PropertiesUtils.java
+++ b/src/main/java/bio/terra/cli/utils/PropertiesUtils.java
@@ -21,10 +21,7 @@ public class PropertiesUtils {
     if (map == null) {
       return properties;
     }
-    for (Map.Entry<String, String> entry : map.entrySet()) {
-      Property property = new Property().key(entry.getKey()).value(entry.getValue());
-      properties.add(property);
-    }
+    map.forEach((key, value) -> properties.add(new Property().key(key).value(value)));
     return properties;
   }
 }


### PR DESCRIPTION
```
yuhuyoyo-macbookpro2:terra-cli yuhuyoyo$ terra folder tree
└── Data from 1000 Genomes Phase 3(175b1f73-a868-457e-b2ff-4bf95cdc5fa7)
    ├── BigQuery tables(33d08e65-68df-4d6a-8baa-2567388789db)
    └── GCS folders(df48c9b2-820d-49ac-a53e-65a18c0c68c7)
        └── Synthetic phenotypes(aa951c12-0051-493f-bf4f-2f8b8de1be02)
yuhuyoyo-macbookpro2:terra-cli yuhuyoyo$ terra folder set-property --id=aa951c12-0051-493f-bf4f-2f8b8de1be02 --properties=foo=bar,k=v
bio.terra.cli.serialization.userfacing.UFFolder@3d24420b
Folder properties successfully updated.
ID:                aa951c12-0051-493f-bf4f-2f8b8de1be02
Name:              Synthetic phenotypes
Description:       null
Parent folder ID:  df48c9b2-820d-49ac-a53e-65a18c0c68c7
Properties:
  foo: bar
  k: v
```