### PR TITLE
[BENCH-863] Allow user to specific spend profile during workspace creation

### DIFF
--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -36,11 +36,20 @@ public class Create extends WsmBaseCommand {
       showDefaultValue = CommandLine.Help.Visibility.ALWAYS)
   private CloudPlatform cloudPlatform;
 
+  @CommandLine.Option(
+      names = "--spend-profile",
+      required = false,
+      description = "Spend profile to use for this workspace.")
+  public String spendProfile;
+
   /** Create a new workspace. */
   @Override
   protected void execute() {
-
     CommandUtils.checkServerSupport(cloudPlatform);
+
+    if (spendProfile == null) {
+      spendProfile = UserManagerService.fromContext().getDefaultSpendProfile(/*email=*/ null);
+    }
 
     Workspace workspace =
         Workspace.create(
@@ -49,7 +58,7 @@ public class Create extends WsmBaseCommand {
             workspaceNameAndDescription.name,
             workspaceNameAndDescription.description,
             workspaceProperties,
-            UserManagerService.fromContext().getDefaultSpendProfile(/*email=*/ null));
+            spendProfile);
     formatOption.printReturnValue(new UFWorkspace(workspace), this::printText);
   }
 

--- a/src/test/java/harness/utils/WorkspaceUtils.java
+++ b/src/test/java/harness/utils/WorkspaceUtils.java
@@ -31,7 +31,7 @@ public class WorkspaceUtils {
    *     the WSM workspaceDelete request.
    */
   public static UFWorkspace createWorkspace(
-      TestUser workspaceCreator, Optional<CloudPlatform> platform)
+      TestUser workspaceCreator, Optional<CloudPlatform> platform, Optional<String> spend)
       throws IOException, InterruptedException {
     // `terra workspace create --format=json`
     List<String> argsList =
@@ -41,6 +41,9 @@ public class WorkspaceUtils {
     // defaults to GCP otherwise
     platform.ifPresent(cloudPlatform -> argsList.add("--platform=" + cloudPlatform));
 
+    // defaults to user's default spend profile otherwise
+    spend.ifPresent(spendProfile -> argsList.add("--spend-profile=" + spendProfile));
+
     UFWorkspace workspace =
         TestCommand.runAndParseCommandExpectSuccess(
             UFWorkspace.class, argsList.toArray(new String[0]));
@@ -48,26 +51,18 @@ public class WorkspaceUtils {
     return workspace;
   }
 
-  /**
-   * Create a new workspace and register it with Janitor if this test is running in an environment
-   * where Janitor is enabled.
-   *
-   * @param workspaceCreator The user who owns the workspace. This user will be impersonated to in
-   *     the WSM workspaceDelete request.
-   */
+  public static UFWorkspace createWorkspace(
+      TestUser workspaceCreator, Optional<CloudPlatform> platform)
+      throws IOException, InterruptedException {
+    return createWorkspace(workspaceCreator, platform, Optional.empty());
+  }
+
   public static UFWorkspace createWorkspace(
       TestUser workspaceCreator, String name, String description, String properties)
       throws IOException, InterruptedException {
     return createWorkspace(workspaceCreator, name, description, properties, Optional.empty());
   }
 
-  /**
-   * Create a new workspace and register it with Janitor if this test is running in an environment
-   * where Janitor is enabled.
-   *
-   * @param workspaceCreator The user who owns the workspace. This user will be impersonated to in
-   *     the WSM workspaceDelete request.
-   */
   public static UFWorkspace createWorkspace(
       TestUser workspaceCreator,
       String name,

--- a/src/test/java/unit/Workspace.java
+++ b/src/test/java/unit/Workspace.java
@@ -311,7 +311,7 @@ public class Workspace extends ClearContextUnit {
     // select a test user and login
     TestUser testUser = TestUser.chooseTestUserWithoutSpendAccess();
     testUser.login();
-    final String workspaceName = "bad-profile-6789";
+    String workspaceName = "bad-profile-6789";
     // `terra workspace create --id=<user-facing-id>`
     String stdErr =
         TestCommand.runCommandExpectExitCode(
@@ -349,11 +349,14 @@ public class Workspace extends ClearContextUnit {
     assumeTrue(Context.getServer().getUserManagerUri() != null);
 
     // Use the spend owner account
-    TestUser spendProfileUser = TestUser.chooseTestUserWithSpendAccess();
-    spendProfileUser.login();
+    TestUser spendProfileOwner = TestUser.chooseTestUserWithOwnerAccess();
+    spendProfileOwner.login();
 
     // Create the workspace using the default spend profile, verify
-    WorkspaceUtils.createWorkspace(spendProfileUser, Optional.empty());
+    WorkspaceUtils.createWorkspace(
+        spendProfileOwner,
+        /* cloudPlatform= */ Optional.empty(),
+        /* spendProfile= */ Optional.empty());
     WorkspaceDescription workspaceDescription =
         WorkspaceManagerService.fromContext().getWorkspace(Context.requireWorkspace().getUuid());
     assertEquals(
@@ -361,7 +364,10 @@ public class Workspace extends ClearContextUnit {
         workspaceDescription.getSpendProfile());
 
     // Create the workspace using the alternate spend profile, verify
-    WorkspaceUtils.createWorkspace(spendProfileUser, Optional.empty());
+    WorkspaceUtils.createWorkspace(
+        spendProfileOwner,
+        /* cloudPlatform= */ Optional.empty(),
+        /* spendProfile= */ Optional.of(altSpendProfile));
     workspaceDescription =
         WorkspaceManagerService.fromContext().getWorkspace(Context.requireWorkspace().getUuid());
     assertEquals(altSpendProfile, workspaceDescription.getSpendProfile());


### PR DESCRIPTION
- Allow users to specific spend profile during workspace creation in CLI
- CLI cannot validate spend profile / user’s access to it, since only sam admins can query User manager for user profile with a specific email.
- WSM/ backend will validate spend profile. 
- Assuming that the spend profile is valid and the user has access to it. adding a param to CLI create workspace should let the user specific it as a string (optional).

test - 

```
terra-cli (dexamundsen/profile) >> terra server set --name=verily-devel 
Terra server is set to verily-devel (UNCHANGED).

# create with default spend profile (success)

terra-cli (dexamundsen/profile) >> terra workspace create --id=dex-test-1
Workspace successfully created.
ID:                dex-test-1
Name:              null
Description:       null
Cloud Platform:    GCP
Google project:    terra-vdevel-slick-turnip-4572
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-vdevel-slick-turnip-4572
Properties:
Created:           2023-07-27
Last updated:      2023-07-27
# Resources:       0

# specific spend valid spend profile (success)

terra-cli (dexamundsen/profile) >> terra workspace create --id=dex-test-2 --spend-profile=wm-alt-spend-profile
Workspace successfully created.
ID:                dex-test-2
Name:              null
Description:       null
Cloud Platform:    GCP
Google project:    terra-vdevel-beady-beet-9385
Cloud console:     https://console.cloud.google.com/home/dashboard?project=terra-vdevel-beady-beet-9385
Properties:
Created:           2023-07-27
Last updated:      2023-07-27
# Resources:       0

# specific invalid spend profile (failure) or something the user has no access to

terra-cli (dexamundsen/profile) >> terra workspace create --id=dex-test-3 --spend-profile=bad-spend-profile
Accessing the spend profile failed. Ask an administrator to grant you access.

2023-07-27 12:35:21.814 PDT [main] DEBUG bio.terra.cli.command.shared.BaseCommand - [COMMAND RUN] terra workspace create --id=dex-test-3 --spend-profile=bad-spend-profile
2023-07-27 12:35:21.818 PDT [main] DEBUG bio.terra.cli.service.utils.HttpUtils - Request attempt #1
2023-07-27 12:35:21.922 PDT [main] ERROR bio.terra.cli.service.WorkspaceManagerService - WSM exception status code: 403, response body: {"message":"User is unauthorized to link spend profile [bad-spend-profile]","statusCode":403,"causes":[]}, message: {"message":"User is unauthorized to link spend profile [bad-spend-profile]","statusCode":403,"causes":[]}
2023-07-27 12:35:21.925 PDT [main] ERROR bio.terra.cli.command.Main - Accessing the spend profile failed. Ask an administrator to grant you access.
```
```
workspace=> select workspace_id, spend_profile, user_facing_id from workspace where user_facing_id in ('dex-test-1','dex-test-2');
             workspace_id             |      spend_profile       | user_facing_id 
--------------------------------------+--------------------------+----------------
 ef499aad-239d-43cc-9942-9422e8df190c | wm-default-spend-profile | dex-test-1
 dffb029d-a451-42d6-8e04-84b9a62d8c1f | wm-alt-spend-profile     | dex-test-2
```