### PR TITLE
[BENCH-780] Change resource creation time out to 60 min

### DIFF
--- a/src/test/java/harness/utils/ResourceUtils.java
+++ b/src/test/java/harness/utils/ResourceUtils.java
@@ -101,7 +101,7 @@ public class ResourceUtils {
                         "--workspace=" + workspaceUserFacingId),
             (result) -> fieldValue.equals(result.get(fieldName)),
             (ex) -> false, // no retries
-            30, // up to 30 minutes
+            60, // up to 60 minutes // TODO(BENCH-571): reduce this to 30 mins after this is fixed
             Duration.ofMinutes(1)); // every 1 minute
 
     assertNotNull(resource, "resource poll returned a resource");


### PR DESCRIPTION
Similar change was made in WSM - https://github.com/DataBiosphere/terra-workspace-manager/pull/1390

Without this change, AWS notebooks that take 30+ mins for creation will fail in CLI tests (creation + cleanup) and remain as stale resources 