### PR TITLE
[PF-2937] Validate group admin role before making Sam calls

### DIFF
--- a/src/test/java/unit/Group.java
+++ b/src/test/java/unit/Group.java
@@ -209,15 +209,15 @@ public class Group extends ClearContextUnit {
 
     // `terra group delete --name=$name` as member
     groupMember.login();
-    TestCommand.runCommandExpectExitCode(2, "group", "delete", "--name=" + name, "--quiet");
+    TestCommand.runCommandExpectExitCode(1, "group", "delete", "--name=" + name, "--quiet");
 
     // `terra group add-user --email=$email --policy=ADMIN` as member
     TestCommand.runCommandExpectExitCode(
-        2, "group", "add-user", "--name=" + name, "--email=" + groupMember.email, "--policy=ADMIN");
+        1, "group", "add-user", "--name=" + name, "--email=" + groupMember.email, "--policy=ADMIN");
 
     // `terra group remove-user --email=$email --policy=MEMBER` as member
     TestCommand.runCommandExpectExitCode(
-        2,
+        1,
         "group",
         "remove-user",
         "--name=" + name,


### PR DESCRIPTION
Currently, several CLI operations log confusing error messages from Sam when a group member tries to do admin-only actions (like listing or modifying a group's membership). We should validate that the user is an admin before making these Sam calls and surface a clearer user-facing exception instead.