### PR TITLE
BENCH-966: Revert change to USER_SCOPES to not break tests

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -35,12 +35,7 @@ import org.slf4j.LoggerFactory;
 public class User {
   // these are the same scopes requested by Terra service swagger pages
   @VisibleForTesting
-  public static final List<String> USER_SCOPES =
-      Context.getServer().getAuth0Enabled()
-          ?
-          // offline_access scope is required for getting refresh token from Auth0
-          ImmutableList.of("openid", "email", "profile", "offline_access")
-          : ImmutableList.of("openid", "email", "profile");
+  public static final List<String> USER_SCOPES = ImmutableList.of("openid", "email", "profile");
 
   private static final Logger logger = LoggerFactory.getLogger(User.class);
   // these are the same scopes requested by Terra service swagger pages, plus the cloud platform

--- a/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
+++ b/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
@@ -61,7 +61,6 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.http.HttpStatus;
-import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -312,8 +311,13 @@ public final class Oauth {
     return credential.getGoogleCredentials().getAccessToken();
   }
 
-  @NotNull
-  private static Boolean isAuth0RefreshTokenEnabled() {
+  /**
+   * whether auth0 response contains a refresh token which we use to get a newer access token. scope
+   * needs to include "offline_access" to receive a refresh token from Auth0.
+   *
+   * @return false by default.
+   */
+  private static boolean isAuth0RefreshTokenEnabled() {
     return FeatureService.fromContext()
         .isFeatureEnabled("vwb__cli_token_refresh_enabled")
         .orElse(false);

--- a/src/test/java/harness/TestUser.java
+++ b/src/test/java/harness/TestUser.java
@@ -23,7 +23,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -224,9 +223,8 @@ public class TestUser {
    * or another Terra service.
    */
   public GoogleCredentials getCredentialsWithCloudPlatformScope() throws IOException {
-    List<String> scopesWithCloudPlatform = new ArrayList<>(User.USER_SCOPES);
-    scopesWithCloudPlatform.add(CLOUD_PLATFORM_SCOPE);
-    return getCredentials(scopesWithCloudPlatform);
+    // USER_SCOPE + "https://www.googleapis.com/auth/cloud-platform"
+    return getCredentials(User.PET_SA_SCOPES);
   }
 
   /** Get domain-wide delegated Google credentials for this user. */


### PR DESCRIPTION
the test_user_account json uses google oauth login which is not expecting the offline_access scope. 

put offline_access into the scope at TerraAuthenticationHelper to be closest to when user login to auth0 happens to be most precise. 