### PR TITLE
BENCH-968: Fix failing gcp notebook test

### DIFF
--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -261,7 +261,6 @@ public class GcpNotebookControlled extends SingleWorkspaceUnitGcp {
 
     // `terra notebook start --name=$name`
     TestCommand.runCommandExpectSuccessWithRetries("notebook", "start", "--name=" + name);
-    GcpNotebookUtils.assertNotebookState(name, "PROVISIONING");
     GcpNotebookUtils.pollDescribeForNotebookState(name, "ACTIVE");
   }
 }

--- a/src/test/java/unit/GcpNotebookControlled.java
+++ b/src/test/java/unit/GcpNotebookControlled.java
@@ -261,6 +261,7 @@ public class GcpNotebookControlled extends SingleWorkspaceUnitGcp {
 
     // `terra notebook start --name=$name`
     TestCommand.runCommandExpectSuccessWithRetries("notebook", "start", "--name=" + name);
-    GcpNotebookUtils.assertNotebookState(name, "ACTIVE");
+    GcpNotebookUtils.assertNotebookState(name, "PROVISIONING");
+    GcpNotebookUtils.pollDescribeForNotebookState(name, "ACTIVE");
   }
 }


### PR DESCRIPTION
it stays in the provision state for a while so pull till it becomes active

https://scans.gradle.com/s/wgq4l5xlscdlk/tests/task/:runTestsWithTag/details/unit.GcpNotebookControlled/startStop()?top-execution=1