### PR TITLE
[BENCH-547] Re-write AWS Config File on Resource Add

### DIFF
--- a/src/main/java/bio/terra/cli/app/CommandRunner.java
+++ b/src/main/java/bio/terra/cli/app/CommandRunner.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Sub-classes of CommandRunner define different ways to run app/tool commands (e.g. in a Docker
+ * Subclasses of CommandRunner define different ways to run app/tool commands (e.g. in a Docker
  * container, in a local child process). This class handles things that all of these options will
  * need, including building a map of environment variables to set before running the command. These
  * environment variables specify resolved workspace references and other context information.

--- a/src/main/java/bio/terra/cli/businessobject/Resource.java
+++ b/src/main/java/bio/terra/cli/businessobject/Resource.java
@@ -32,8 +32,8 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Internal representation of a workspace resource. This abstract class contains properties common
- * to all resource types. Sub-classes represent a specific resource type. Instances of the
- * sub-classes are part of the current context or state.
+ * to all resource types. Subclasses represent a specific resource type. Instances of the subclasses
+ * are part of the current context or state.
  */
 public abstract class Resource {
   // Copied from WSM: ResourceType specific validation performed in WSM

--- a/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
+++ b/src/main/java/bio/terra/cli/command/shared/BaseCommand.java
@@ -21,7 +21,7 @@ import picocli.CommandLine;
  *
  * <p>- executing the command
  *
- * <p>Sub-classes define how to execute the command (i.e. the implementation of {@link #execute}).
+ * <p>Subclasses define how to execute the command (i.e. the implementation of {@link #execute}).
  */
 @CommandLine.Command
 @SuppressFBWarnings(
@@ -69,7 +69,7 @@ public abstract class BaseCommand implements Callable<Integer> {
   /**
    * Required override for executing this command and printing any output.
    *
-   * <p>Sub-classes should throw exceptions for errors. The Main class handles turning these
+   * <p>Subclasses should throw exceptions for errors. The Main class handles turning these
    * exceptions into the appropriate exit code.
    */
   protected abstract void execute();
@@ -78,7 +78,7 @@ public abstract class BaseCommand implements Callable<Integer> {
    * This method returns true if login is required for the command. Default implementation is to
    * always require login.
    *
-   * <p>Sub-classes can use the current global and workspace context to decide whether to require
+   * <p>Subclasses can use the current global and workspace context to decide whether to require
    * login.
    *
    * @return true if login is required for this command

--- a/src/main/java/bio/terra/cli/command/workspace/ConfigureAws.java
+++ b/src/main/java/bio/terra/cli/command/workspace/ConfigureAws.java
@@ -1,18 +1,15 @@
 package bio.terra.cli.command.workspace;
 
+import static bio.terra.cli.utils.AwsConfiguration.AWS_CONFIG_FILE_ENVIRONMENT_VARIABLE;
+import static bio.terra.cli.utils.AwsConfiguration.DEFAULT_AWS_VAULT_PATH;
+import static bio.terra.cli.utils.AwsConfiguration.DEFAULT_CACHE_WITH_AWS_VAULT;
+import static bio.terra.cli.utils.AwsConfiguration.DEFAULT_TERRA_PATH;
+
 import bio.terra.cli.businessobject.Context;
-import bio.terra.cli.businessobject.Resource;
-import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.WorkspaceOverride;
-import bio.terra.cli.exception.SystemException;
-import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.utils.AwsConfiguration;
-import bio.terra.cli.utils.FileUtils;
-import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import picocli.CommandLine;
 
 /** This class corresponds to the third-level "terra workspace configure-aws" command. */
@@ -20,156 +17,48 @@ import picocli.CommandLine;
     name = "configure-aws",
     description = "Generate an AWS configuration file for a workspace.")
 public class ConfigureAws extends WsmBaseCommand {
-  private static final String AWS_CONTEXT_SUBDIRECTORY_NAME = "aws";
-  public static final String DEFAULT_TERRA_PATH = "/usr/local/bin/terra";
-  public static final String DEFAULT_AWS_VAULT_PATH = "/usr/local/bin/aws-vault";
-  public static final String AWS_CONFIG_FILE_ENVIRONMENT_VARIABLE = "AWS_CONFIG_FILE";
-
   @CommandLine.Mixin WorkspaceOverride workspaceOption;
 
   @CommandLine.Option(
       names = "--cache-with-aws-vault",
-      defaultValue = "false",
-      description = "Use aws-vault for caching")
-  private boolean cacheWithAwsVault;
+      description = "Use aws-vault for caching. Default - " + DEFAULT_CACHE_WITH_AWS_VAULT)
+  private Boolean cacheWithAwsVault;
 
   @CommandLine.Option(
       names = "--terra-path",
-      defaultValue = DEFAULT_TERRA_PATH,
-      description = "Location of terra executable.")
+      description = "Location of terra executable. Default - " + DEFAULT_TERRA_PATH)
   private String terraPath;
 
   @CommandLine.Option(
       names = "--aws-vault-path",
-      defaultValue = DEFAULT_AWS_VAULT_PATH,
-      description = "Location of aws-vault executable.")
+      description = "Location of aws-vault executable. Default - " + DEFAULT_AWS_VAULT_PATH)
   private String awsVaultPath;
 
   @CommandLine.Option(
       names = "--default-resource",
-      required = false,
       description = "Name of resource to treat as default")
   private String defaultResourceName;
-
-  private static Path getAwsContextDir() {
-    return Context.getContextDir().resolve(AWS_CONTEXT_SUBDIRECTORY_NAME);
-  }
-
-  private static Path getConfigFilePath(Workspace workspace) {
-    return getAwsContextDir().resolve(String.format("%s.conf", workspace.getUuid()));
-  }
 
   @Override
   protected void execute() {
     workspaceOption.overrideIfSpecified();
 
-    Workspace workspace = Context.requireWorkspace();
-
-    AwsConfiguration.Builder builder = AwsConfiguration.builder();
-    List<Resource> resourceList = Context.requireWorkspace().listResources();
-
-    for (Resource resource : resourceList) {
-      switch (resource.getResourceType()) {
-        case AWS_S3_STORAGE_FOLDER, AWS_SAGEMAKER_NOTEBOOK -> generateAwsResourceProfiles(
-            builder, resource);
-      }
+    AwsConfiguration.Builder builder =
+        AwsConfiguration.builder().setWorkspace(Context.requireWorkspace());
+    if (cacheWithAwsVault != null) {
+      builder.setCacheWithAwsVault(cacheWithAwsVault);
+    }
+    if (terraPath != null) {
+      builder.setTerraPath(terraPath);
+    }
+    if (awsVaultPath != null) {
+      builder.setAwsVaultPath(awsVaultPath);
+    }
+    if (defaultResourceName != null) {
+      builder.setDefaultResourceName(defaultResourceName);
     }
 
-    AwsConfiguration awsConfiguration = builder.build();
-
-    if (awsConfiguration.size() == 0) {
-      throw new UserActionableException(
-          "Workspace contains no AWS resources to configure profiles for.");
-    }
-
-    Path configFilePath = getConfigFilePath(workspace);
-
-    try {
-      FileUtils.writeStringToFile(configFilePath.toFile(), awsConfiguration.toString());
-    } catch (IOException e) {
-      throw new SystemException("Error writing configuration file to disk.", e);
-    }
-
-    OUT.printf("export %s=%s%n", AWS_CONFIG_FILE_ENVIRONMENT_VARIABLE, configFilePath);
-  }
-
-  private void generateAwsResourceProfiles(AwsConfiguration.Builder builder, Resource resource) {
-
-    String resourceName = resource.getName();
-    boolean isDefault = resourceName.equals(defaultResourceName);
-
-    String region = resource.getRegion();
-    String profileName = String.format("%s", resourceName);
-    String readOnlyProfileName = String.format("%s-ro", profileName);
-
-    if (cacheWithAwsVault) {
-      // Add Caching Profiles
-
-      // Caching profile names should track resource names.  We append an underscore to "real"
-      // profile names, which now serve as targets for the caching profiles.  Note that this side
-      // effect is intentionally applied to all subsequent statements, including those outside this
-      // block.
-      String cachingProfileName = profileName;
-      String cachingReadOnlyProfileName = readOnlyProfileName;
-      profileName += "_";
-      readOnlyProfileName += "_";
-
-      addCachingProfile(builder, region, cachingProfileName, isDefault, profileName);
-      addCachingProfile(builder, region, cachingReadOnlyProfileName, false, readOnlyProfileName);
-
-      // clear isDefault flag
-      isDefault = false;
-    }
-
-    addAwsResourceProfile(builder, region, profileName, isDefault, resourceName, "WRITE_READ");
-    addAwsResourceProfile(builder, region, readOnlyProfileName, false, resourceName, "READ_ONLY");
-  }
-
-  @VisibleForTesting
-  public static List<String> buildResourceCommandLine(
-      String terraPath, String resourceName, String access) {
-    return List.of(
-        terraPath,
-        "resource",
-        "credentials",
-        "--name",
-        resourceName,
-        "--scope",
-        access,
-        "--format",
-        "JSON");
-  }
-
-  private void addAwsResourceProfile(
-      AwsConfiguration.Builder builder,
-      String region,
-      String profileName,
-      boolean isDefault,
-      String resourceName,
-      String access) {
-    builder.addProfile(
-        profileName,
-        AwsConfiguration.createProfile(
-            region, buildResourceCommandLine(terraPath, resourceName, access)),
-        isDefault);
-  }
-
-  @VisibleForTesting
-  public static List<String> buildCachingCommandLine(
-      String awsVaultPath, String targetProfileName) {
-    return List.of(awsVaultPath, "export", "--no-session", "--format", "json", targetProfileName);
-  }
-
-  private void addCachingProfile(
-      AwsConfiguration.Builder builder,
-      String region,
-      String profileName,
-      boolean isDefault,
-      String targetProfileName) {
-    builder.addProfile(
-        profileName,
-        AwsConfiguration.createProfile(
-            region, buildCachingCommandLine(awsVaultPath, targetProfileName)),
-        isDefault);
+    Path filePath = builder.build().storeToDisk();
+    OUT.printf("export %s=%s%n", AWS_CONFIG_FILE_ENVIRONMENT_VARIABLE, filePath);
   }
 }

--- a/src/main/java/bio/terra/cli/utils/AwsConfiguration.java
+++ b/src/main/java/bio/terra/cli/utils/AwsConfiguration.java
@@ -1,37 +1,263 @@
 package bio.terra.cli.utils;
 
+import static bio.terra.cli.utils.AwsConfiguration.Builder.OPT_AWS_VAULT_PATH;
+import static bio.terra.cli.utils.AwsConfiguration.Builder.OPT_CACHE_WITH_AWS_VAULT;
+import static bio.terra.cli.utils.AwsConfiguration.Builder.OPT_DEFAULT_RESOURCE_NAME;
+import static bio.terra.cli.utils.AwsConfiguration.Builder.OPT_TERRA_PATH;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Resource;
+import bio.terra.cli.businessobject.Resource.CredentialsAccessScope;
+import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.exception.SystemException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import org.ini4j.Ini;
+import org.ini4j.Profile.Section;
 
 /**
- * Class to represent an AWS CLI/SDK profile for all of the AWS resources in a workspace, and write
- * it in <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html">the
+ * Class to represent an AWS CLI/SDK profile for all the AWS resources in a workspace, and write it
+ * in <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html">the
  * expected format</a>.
  *
  * <p>This makes use of class {@link Ini}, which writes files in the ini format used by AWS config
  * files.
  */
 public class AwsConfiguration {
+  public static final String AWS_CONTEXT_SUBDIRECTORY_NAME = "aws";
+  public static final String AWS_CONFIG_FILE_ENVIRONMENT_VARIABLE = "AWS_CONFIG_FILE";
+  public static final boolean DEFAULT_CACHE_WITH_AWS_VAULT = false;
+  public static final String DEFAULT_TERRA_PATH = "/usr/local/bin/terra";
+  public static final String DEFAULT_AWS_VAULT_PATH = "/usr/local/bin/aws-vault";
+  private static final String defaultProfileSectionName = "default";
+  private static final Set<Resource.Type> supportedResourceTypes =
+      Set.of(Resource.Type.AWS_S3_STORAGE_FOLDER, Resource.Type.AWS_SAGEMAKER_NOTEBOOK);
+  private final Path filePath;
+  private final Map<String, String> optionsMap;
+  private final Ini ini;
 
-  private final Map<String, Profile> profileMap;
-  private final Optional<Profile> defaultProfile;
-
-  private AwsConfiguration(Builder builder) {
-    profileMap = new TreeMap<>(builder.profileMap);
-    defaultProfile = builder.defaultProfile;
-  }
-
-  /** Gets a builder for the AwsConfiguration class. */
   public static Builder builder() {
     return new Builder();
   }
+
+  private AwsConfiguration(Builder builder) {
+    Workspace workspace = builder.workspace;
+    filePath = getConfigFilePath(workspace.getUuid());
+    ini = new Ini();
+
+    optionsMap = builderToOptionsMap(builder);
+    ini.setComment(optionsMapToString());
+
+    workspace.listResources().stream()
+        .filter(resource -> supportedResourceTypes.contains(resource.getResourceType()))
+        .forEach(
+            resource ->
+                addAwsResourceProfiles(
+                    resource.getName(),
+                    resource.getRegion(),
+                    builder.cacheWithAwsVault,
+                    builder.terraPath,
+                    builder.awsVaultPath,
+                    resource.getName().equals(builder.defaultResourceName)));
+  }
+
+  private AwsConfiguration(Path filePath) throws IOException {
+    this.filePath = filePath;
+    this.ini = new Ini(filePath.toFile());
+    this.optionsMap = stringToOptionsMap(ini.getComment());
+  }
+
+  @Override
+  public String toString() {
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    try {
+      ini.store(stream);
+    } catch (IOException e) {
+      throw new SystemException("Writing configuration to file failed.", e);
+    }
+    return stream.toString();
+  }
+
+  private Map<String, String> builderToOptionsMap(Builder builder) {
+    Map<String, String> map = new HashMap<>();
+    map.put(Builder.OPT_CACHE_WITH_AWS_VAULT, String.valueOf(builder.cacheWithAwsVault));
+    map.put(Builder.OPT_TERRA_PATH, builder.terraPath);
+    map.put(Builder.OPT_AWS_VAULT_PATH, builder.awsVaultPath);
+
+    if (builder.defaultResourceName != null) {
+      map.put(Builder.OPT_DEFAULT_RESOURCE_NAME, builder.defaultResourceName);
+    }
+    return map;
+  }
+
+  private String optionsMapToString() {
+    return optionsMap.entrySet().stream()
+        .map(entry -> entry.getKey() + "=" + entry.getValue())
+        .collect(Collectors.joining(", "));
+  }
+
+  private static Map<String, String> stringToOptionsMap(String options) {
+    return Arrays.stream(options.split(", "))
+        .map(entry -> entry.split("="))
+        .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1]));
+  }
+
+  private void addAwsResourceProfiles(
+      // Resource resource,
+      String resourceName,
+      String region,
+      boolean cacheWithAwsVault,
+      String terraPath,
+      String awsVaultPath,
+      boolean isDefault) {
+    String profileName = getProfileName(resourceName);
+    String readOnlyProfileName = getReadOnlyProfileName(profileName);
+
+    Optional<Profile> defaultProfile = Optional.empty();
+
+    if (cacheWithAwsVault) {
+      // Add Caching Profiles: Caching profile names should track resource names.
+      // We append an underscore to "real" profile names, which now serve as targets for the
+      // caching profiles. Note that this side effect is intentionally applied to all subsequent
+      // statements, including those outside this block.
+      String cachingProfileName = profileName;
+      String cachingReadOnlyProfileName = readOnlyProfileName;
+      profileName += "_";
+      readOnlyProfileName += "_";
+
+      Section section = ini.add(getNamedProfileSectionName(cachingProfileName));
+      Profile profile = buildCachingProfile(region, awsVaultPath, profileName);
+      addProfileToSection(section, profile);
+      if (isDefault) {
+        defaultProfile = Optional.of(profile);
+        isDefault = false;
+      }
+
+      section = ini.add(getNamedProfileSectionName(cachingReadOnlyProfileName));
+      profile = buildCachingProfile(region, awsVaultPath, readOnlyProfileName);
+      addProfileToSection(section, profile);
+    }
+
+    Section section = ini.add(getNamedProfileSectionName(profileName));
+    Profile profile =
+        buildResourceProfile(
+            region, terraPath, resourceName, CredentialsAccessScope.WRITE_READ.toString());
+    addProfileToSection(section, profile);
+    if (isDefault) {
+      defaultProfile = Optional.of(profile);
+    }
+
+    section = ini.add(getNamedProfileSectionName(readOnlyProfileName));
+    profile =
+        buildResourceProfile(
+            region, terraPath, resourceName, CredentialsAccessScope.READ_ONLY.toString());
+    addProfileToSection(section, profile);
+
+    defaultProfile.ifPresent(p -> addProfileToSection(ini.add(defaultProfileSectionName), p));
+  }
+
+  public void addResource(String resourceName, String region, Resource.Type resourceType) {
+    if (supportedResourceTypes.contains(resourceType)) {
+      addAwsResourceProfiles(
+          resourceName,
+          region,
+          Boolean.parseBoolean(optionsMap.get(Builder.OPT_CACHE_WITH_AWS_VAULT)),
+          optionsMap.get(Builder.OPT_TERRA_PATH),
+          optionsMap.get(Builder.OPT_AWS_VAULT_PATH),
+          false);
+    }
+  }
+
+  public void removeResource(String resourceName) {
+    String profileName = getProfileName(resourceName);
+    String readOnlyProfileName = getReadOnlyProfileName(profileName);
+
+    Optional.ofNullable(ini.get(getNamedProfileSectionName(profileName))).ifPresent(ini::remove);
+    Optional.ofNullable(ini.get(getNamedProfileSectionName(readOnlyProfileName)))
+        .ifPresent(ini::remove);
+
+    Optional.ofNullable(ini.get(getNamedProfileSectionName(profileName + "_")))
+        .ifPresent(ini::remove);
+    Optional.ofNullable(ini.get(getNamedProfileSectionName(readOnlyProfileName + "_")))
+        .ifPresent(ini::remove);
+
+    if (resourceName.equals(optionsMap.getOrDefault(Builder.OPT_DEFAULT_RESOURCE_NAME, null))) {
+      Optional.ofNullable(ini.get(defaultProfileSectionName)).ifPresent(ini::remove);
+      optionsMap.remove(Builder.OPT_DEFAULT_RESOURCE_NAME);
+      ini.setComment(optionsMapToString());
+    }
+  }
+
+  public Path getFilePath() {
+    return filePath;
+  }
+
+  public String getTerraPath() {
+    return optionsMap.get(OPT_TERRA_PATH);
+  }
+
+  public String getAwsVaultPath() {
+    return optionsMap.get(OPT_AWS_VAULT_PATH);
+  }
+
+  public boolean getCacheWithAwsVault() {
+    return Boolean.parseBoolean(optionsMap.get(OPT_CACHE_WITH_AWS_VAULT));
+  }
+
+  public Optional<String> getDefaultResourceName() {
+    return optionsMap.containsKey(OPT_DEFAULT_RESOURCE_NAME)
+        ? Optional.of(optionsMap.get(OPT_DEFAULT_RESOURCE_NAME))
+        : Optional.empty();
+  }
+
+  public int getResourceCount() {
+    return ini.size();
+  }
+
+  // Disk operations
+
+  public static Path getConfigFilePath(UUID workspaceUuid) {
+    return Context.getContextDir()
+        .resolve(AWS_CONTEXT_SUBDIRECTORY_NAME)
+        .resolve(String.format("%s.conf", workspaceUuid.toString()));
+  }
+
+  public Path storeToDisk() {
+    try {
+      FileUtils.writeStringToFile(filePath.toFile(), this.toString());
+      return filePath;
+    } catch (IOException e) {
+      throw new SystemException("Error writing configuration file to disk.", e);
+    }
+  }
+
+  public static void deleteFromDisk(UUID workspaceUuid) {
+    try {
+      FileUtils.delete(getConfigFilePath(workspaceUuid));
+    } catch (IOException e) {
+      throw new SystemException("Error deleting configuration file from disk.", e);
+    }
+  }
+
+  public static AwsConfiguration loadFromDisk(UUID workspaceUuid) {
+    try {
+      Path filePath = AwsConfiguration.getConfigFilePath(workspaceUuid);
+      return new AwsConfiguration(filePath);
+    } catch (IOException e) {
+      throw new SystemException("Error reading configuration file from disk.", e);
+    }
+  }
+
+  // Profile
 
   /**
    * Record type for specifying the 'region' and 'credential_process' configuration parameters for a
@@ -44,7 +270,7 @@ public class AwsConfiguration {
   public record Profile(String region, List<String> credentialProcess) {}
 
   /**
-   * Factory method for creating {@link Profile} instances to pass to {@link Builder#addProfile}.
+   * Factory method for creating {@link Profile} instances.
    *
    * @param region region of an AWS resource
    * @param credentialProcess command to call to obtain a credential for the resource
@@ -54,78 +280,104 @@ public class AwsConfiguration {
     return new Profile(region, credentialProcess);
   }
 
-  /**
-   * Get the number of profiles in the configuration.
-   *
-   * @return the number of profiles in the configuration file
-   */
-  public int size() {
-    return profileMap.size();
-  }
-
-  private void addProfileToSection(org.ini4j.Profile.Section section, Profile profile) {
+  private static void addProfileToSection(Section section, Profile profile) {
     section.add("region", profile.region());
     section.add("credential_process", String.join(" ", profile.credentialProcess));
   }
 
-  private void addDefaultProfile(Ini ini, Profile profile) {
-    addProfileToSection(ini.add("default"), profile);
+  public static String getProfileName(String resourceName) {
+    return String.format("%s", resourceName);
   }
 
-  private void addNamedProfile(Ini ini, String name, Profile profile) {
-    addProfileToSection(ini.add(String.format("profile %s", name)), profile);
+  public static String getReadOnlyProfileName(String profileName) {
+    return String.format("%s-ro", profileName);
   }
 
-  @Override
-  public String toString() {
-    Ini ini = new Ini();
+  private static String getNamedProfileSectionName(String name) {
+    return String.format("profile %s", name);
+  }
 
-    defaultProfile.ifPresent(profile -> addDefaultProfile(ini, profile));
+  public static List<String> buildCachingCommandLine(
+      String awsVaultPath, String targetProfileName) {
+    return List.of(awsVaultPath, "export", "--no-session", "--format", "json", targetProfileName);
+  }
 
-    for (Map.Entry<String, Profile> entry : profileMap.entrySet()) {
-      addNamedProfile(ini, entry.getKey(), entry.getValue());
-    }
+  private static Profile buildCachingProfile(
+      String region, String awsVaultPath, String targetProfileName) {
+    return AwsConfiguration.createProfile(
+        region, buildCachingCommandLine(awsVaultPath, targetProfileName));
+  }
 
-    ByteArrayOutputStream stream = new ByteArrayOutputStream();
-    try {
-      ini.store(stream);
-    } catch (IOException e) {
-      throw new SystemException("Writing configuration to file failed.", e);
-    }
-    return stream.toString();
+  public static List<String> buildResourceCommandLine(
+      String terraPath, String resourceName, String access) {
+    return List.of(
+        terraPath,
+        "resource",
+        "credentials",
+        "--name",
+        resourceName,
+        "--scope",
+        access,
+        "--format",
+        "JSON");
+  }
+
+  private static Profile buildResourceProfile(
+      String region, String terraPath, String resourceName, String access) {
+    return AwsConfiguration.createProfile(
+        region, buildResourceCommandLine(terraPath, resourceName, access));
   }
 
   public static class Builder {
+    public static final String OPT_CACHE_WITH_AWS_VAULT = "cacheWithAwsVault";
+    public static final String OPT_TERRA_PATH = "terraPath";
+    public static final String OPT_AWS_VAULT_PATH = "awsVaultPath";
+    public static final String OPT_DEFAULT_RESOURCE_NAME = "defaultResourceName";
+
+    private boolean cacheWithAwsVault;
+    private String terraPath;
+    private String awsVaultPath;
+    private String defaultResourceName;
+    private Workspace workspace;
 
     private Builder() {
-      profileMap = new HashMap<>();
-      defaultProfile = Optional.empty();
+      cacheWithAwsVault = false;
+      terraPath = DEFAULT_TERRA_PATH;
+      awsVaultPath = DEFAULT_AWS_VAULT_PATH;
+      defaultResourceName = null; // no default
+      workspace = null; // no default
     }
 
-    private final Map<String, Profile> profileMap;
-    private Optional<Profile> defaultProfile;
+    public Builder setCacheWithAwsVault(boolean cacheWithAwsVault) {
+      this.cacheWithAwsVault = cacheWithAwsVault;
+      return this;
+    }
 
-    /**
-     * Adds a profile to the configuration being built. Expects a {@link Profile} created with the
-     * {@link #createProfile(String, List)} method.
-     *
-     * @param name name of the profile to create
-     * @param profile {@link Profile} class describing profile settings
-     * @param isDefault indicate whether this profile should be considered default
-     * @return a reference to the Builder
-     */
-    public Builder addProfile(String name, Profile profile, boolean isDefault) {
-      profileMap.put(name, profile);
+    public Builder setTerraPath(String terraPath) {
+      this.terraPath = terraPath;
+      return this;
+    }
 
-      if (isDefault) {
-        defaultProfile = Optional.of(profile);
-      }
+    public Builder setAwsVaultPath(String awsVaultPath) {
+      this.awsVaultPath = awsVaultPath;
+      return this;
+    }
 
+    public Builder setDefaultResourceName(String defaultResourceName) {
+      this.defaultResourceName = defaultResourceName;
+      return this;
+    }
+
+    public Builder setWorkspace(Workspace workspace) {
+      this.workspace = workspace;
       return this;
     }
 
     /** Build the configuration */
     public AwsConfiguration build() {
+      if (workspace == null) {
+        throw new SystemException("Workspace not set for AWS configuration");
+      }
       return new AwsConfiguration(this);
     }
   }

--- a/src/main/java/bio/terra/cli/utils/FileUtils.java
+++ b/src/main/java/bio/terra/cli/utils/FileUtils.java
@@ -25,6 +25,7 @@ public class FileUtils {
   /**
    * Build a stream handle to a resource file.
    *
+   * @param resourceFilePath the file to read from
    * @return the new file handle
    * @throws FileNotFoundException if the resource file doesn't exist
    */
@@ -71,15 +72,20 @@ public class FileUtils {
     return Files.writeString(outputFile.toPath(), fileContents == null ? "" : fileContents);
   }
 
+  /** Delete the file or directory (recursively) if it exists. */
+  public static void delete(Path root) throws IOException {
+    walkUpFileTree(root, childPath -> childPath.toFile().delete(), false);
+  }
+
   /**
-   * Walks a file tree from the bottom up, excluding the root. This means that all children of a
-   * directory are walked before their parent.
+   * Walks a file tree from the bottom up. This means that all children of a directory are walked
+   * before their parent.
    *
    * <p>Outline of algorithm:
    *
    * <p>- Walk the file tree and build a list of child paths
    *
-   * <p>- Sort the list from longest paths to shortest
+   * <p>- Sort the list from the longest paths to shortest
    *
    * <p>- Process the paths in this order, skipping the root path
    *
@@ -134,13 +140,12 @@ public class FileUtils {
   }
 
   /**
-   * Recursively deletes empty subdirectories in the given root directory, excluding the root
-   * itself.
+   * Recursively deletes empty subdirectories in the given root directory, including the root.
    *
    * @param root the root directory to delete empty subdirectories from.
    * @throws SystemException if an error occurs while deleting the empty directories.
    */
-  public static void deleteEmptyDirectories(Path root) {
+  public static void deleteEmptyDirectories(Path root, boolean skipRoot) {
     try {
       FileUtils.walkUpFileTree(
           root,
@@ -152,7 +157,7 @@ public class FileUtils {
                   String.format("Directory is not empty: %s", childPath));
             }
           },
-          false);
+          skipRoot);
     } catch (Exception ex) {
       throw new SystemException(String.format("Error deleting empty directory %s", root), ex);
     }

--- a/src/main/java/bio/terra/cli/utils/mount/MountController.java
+++ b/src/main/java/bio/terra/cli/utils/mount/MountController.java
@@ -153,7 +153,7 @@ public abstract class MountController {
         .filter(Objects::nonNull)
         .forEach(mountEntry -> BaseMountHandler.unmount(Path.of(mountEntry.mountPath)));
     // Delete empty directories in WORKSPACE_DIR, throw an error there are any nonempty directories
-    FileUtils.deleteEmptyDirectories(getWorkspaceDir());
+    FileUtils.deleteEmptyDirectories(getWorkspaceDir(), /*skipRoot= */ false);
   }
 
   /**

--- a/src/test/java/harness/baseclasses/ClearContextUnit.java
+++ b/src/test/java/harness/baseclasses/ClearContextUnit.java
@@ -3,13 +3,13 @@ package harness.baseclasses;
 import bio.terra.cli.app.CommandRunner;
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.User;
+import bio.terra.cli.utils.CommandUtils;
 import bio.terra.cli.utils.Logger;
 import bio.terra.workspace.model.CloudPlatform;
 import harness.TestCommand;
 import harness.TestContext;
 import harness.TestUser;
 import java.io.IOException;
-import java.util.Set;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,19 +83,14 @@ public class ClearContextUnit {
     TestContext.clearGlobalContextDir();
     resetContext();
 
-    Set<CloudPlatform> supportedPlatforms = Context.getServer().getSupportedCloudPlatforms();
+    workspaceCreator.login();
+
+    // isPlatformEnabled() requires user to be logged in
     Assumptions.assumeTrue(
-        supportedPlatforms != null && supportedPlatforms.contains(cloudPlatform),
+        CommandUtils.isPlatformEnabled(cloudPlatform),
         String.format(
             "Cloud platform %s not supported on server %s",
             cloudPlatform.toString(), Context.getServer().getName()));
-
-    // retain default platform if supported, otherwise replace
-    if (!supportedPlatforms.contains(getCloudPlatform())) {
-      setCloudPlatform(supportedPlatforms.iterator().next());
-    }
-
-    workspaceCreator.login();
   }
 
   /**


### PR DESCRIPTION
STATUS

- [done] implementation changes, manual testing
- [done] unit test updates
- Note: changes to flieUtils function needed for config file deletion. 

-----
CHANGES - 

manual configure:
- no change in command and user facing bahavior
- Move implementation from command.execute to AwsConfiguration file 
- Store the config details (such as path, cache etc) as comments in the config file

workspace create:
- Create a empty config file (no resources) with default config values

workspace delete:
- Delete the config file

resource create:
- Load the config from disk, add resource and write back the config file
- No changes to default resource config, since this is automatically added and default must be manually set

resource delete:
- Load the config from disk, delete resource and write back the config file
- If resource was default, remove the default resource config

-----

MANUAL TESTING - 
```
// create workspace id: 0026e5db-f44e-40c6-898f-43869842d766 / userFacingId: dex-ws-0828-1q
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
#terraPath=/usr/local/bin/terra, awsVaultPath=/usr/local/bin/aws-vault, cacheWithAwsVault=false

// create resource
>> terra resource create s3-storage-folder --name=dex-s3-0828-2
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
#terraPath=/usr/local/bin/terra, awsVaultPath=/usr/local/bin/aws-vault, cacheWithAwsVault=false
[profile dex-s3-0828-2] ..
[profile dex-s3-0828-2-ro] ..


// manual configure
>> terra workspace configure-aws --default-resource=dex-s3-0828-2 --cache-with-aws-vault=true
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
#terraPath=/usr/local/bin/terra, awsVaultPath=/usr/local/bin/aws-vault, cacheWithAwsVault=true, defaultResourceName=dex-s3-0828-2
[profile dex-s3-0828-2] ..
[profile dex-s3-0828-2-ro] ..
[profile dex-s3-0828-2_] ..
[profile dex-s3-0828-2-ro_] ..
[default]
region = us-east-1
credential_process = /usr/local/bin/aws-vault export --no-session --format json dex-s3-0828-2-ro_

// create another resource
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
.. contains config for new resource as expected (including caching profiles)
.. default is unchanged as expected

// delete default resource
>> terra resource delete --name=dex-s3-0828-2 
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
#terraPath=/usr/local/bin/terra, awsVaultPath=/usr/local/bin/aws-vault, cacheWithAwsVault=true
.. entries for resource removed
.. config does not contain default resource as expected

// delete all resources
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf 
#terraPath=/usr/local/bin/terra, awsVaultPath=/usr/local/bin/aws-vault, cacheWithAwsVault=true

// delete workspace
>> terra workspace delete
>> cat /Users/dexamundsen/.terra/aws/0026e5db-f44e-40c6-898f-43869842d766.conf
.. file not found as expected
```

![image](https://github.com/DataBiosphere/terra-cli/assets/2914285/97a35c9d-35c6-480c-9071-2ceee4ec9776)
