### PR TITLE
[BENCH-1036], [BENCH-1037] Use Flagsmith feature flags for supported platforms

### DIFF
--- a/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
+++ b/src/main/java/bio/terra/cli/cloud/auth/Oauth.java
@@ -6,6 +6,7 @@ import bio.terra.cli.command.auth.Login.LogInMode;
 import bio.terra.cli.exception.SystemException;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.service.FeatureService;
+import bio.terra.cli.service.FeatureService.Features;
 import bio.terra.cli.service.utils.HttpUtils;
 import bio.terra.cli.service.utils.TerraCredentials;
 import bio.terra.cli.utils.UserIO;
@@ -318,9 +319,7 @@ public final class Oauth {
    * @return false by default.
    */
   private static boolean isAuth0RefreshTokenEnabled() {
-    return FeatureService.fromContext()
-        .isFeatureEnabled("vwb__cli_token_refresh_enabled")
-        .orElse(false);
+    return FeatureService.fromContext().isFeatureEnabled(Features.CLI_AUTH0_TOKEN_REFRESH_ENABLED);
   }
 
   private static AccessToken useAuth0RefreshToken(TerraCredentials credential)

--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -45,7 +45,7 @@ public class Create extends WsmBaseCommand {
   /** Create a new workspace. */
   @Override
   protected void execute() {
-    CommandUtils.checkServerSupport(cloudPlatform);
+    CommandUtils.checkPlatformEnabled(cloudPlatform);
 
     if (spendProfile == null) {
       spendProfile = UserManagerService.fromContext().getDefaultSpendProfile(/*email=*/ null);

--- a/src/main/java/bio/terra/cli/service/FeatureService.java
+++ b/src/main/java/bio/terra/cli/service/FeatureService.java
@@ -15,9 +15,28 @@ import org.apache.http.util.TextUtils;
 import org.slf4j.Logger;
 
 public class FeatureService {
-
   private static final Logger LOGGER = getLogger(FeatureService.class);
   private final FlagsmithClient flagsmith;
+
+  // list of features
+  public enum Features {
+    AWS_ENABLED("vwb__aws_enabled"),
+    GCP_ENABLED("vwb__gcp_enabled"),
+
+    // CLI specific
+    CLI_AUTH0_TOKEN_REFRESH_ENABLED("vwb__cli_token_refresh_enabled"),
+    CLI_DATAPROC_ENABLED("vwb__cli_dataproc_enabled");
+
+    private final String featureName;
+
+    Features(String featureName) {
+      this.featureName = featureName;
+    }
+
+    public String toString() {
+      return featureName;
+    }
+  }
 
   private FeatureService(Server server) {
     if (!TextUtils.isEmpty(server.getFlagsmithApiUrl())) {
@@ -35,8 +54,12 @@ public class FeatureService {
     return new FeatureService(Context.getServer());
   }
 
-  public Optional<Boolean> isFeatureEnabled(String feature) {
-    return isFeatureEnabled(feature, /*userEmail=*/ null);
+  public boolean isFeatureEnabled(Features feature) {
+    return isFeatureEnabled(feature.featureName, /*userEmail=*/ null).orElse(false);
+  }
+
+  public boolean isFeatureEnabled(Features feature, @Nullable String userEmail) {
+    return isFeatureEnabled(feature.featureName, userEmail).orElse(false);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/utils/CommandUtils.java
+++ b/src/main/java/bio/terra/cli/utils/CommandUtils.java
@@ -2,13 +2,15 @@ package bio.terra.cli.utils;
 
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.exception.UserActionableException;
+import bio.terra.cli.service.FeatureService;
+import bio.terra.cli.service.FeatureService.Features;
 import bio.terra.workspace.model.CloudPlatform;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class CommandUtils {
   // Checks if current server supports cloud platform
-  public static void checkServerSupport(CloudPlatform cloudPlatform)
+  private static void checkServerSupport(CloudPlatform cloudPlatform)
       throws UserActionableException {
     if (!Context.getServer().getSupportedCloudPlatforms().contains(cloudPlatform)) {
       throw new UserActionableException(
@@ -17,6 +19,18 @@ public class CommandUtils {
               + " not supported for server "
               + Context.getServer().getName());
     }
+  }
+
+  public static void checkPlatformEnabled(CloudPlatform cloudPlatform)
+      throws UserActionableException {
+    if (switch (cloudPlatform) {
+      case AWS -> FeatureService.fromContext().isFeatureEnabled(Features.AWS_ENABLED);
+      case GCP -> FeatureService.fromContext().isFeatureEnabled(Features.GCP_ENABLED);
+      default -> false;
+    }) return;
+
+    // fallback: if feature service is not enabled check server config
+    checkServerSupport(cloudPlatform);
   }
 
   // Checks if workspace cloud platform is one of the cloud platforms

--- a/src/main/resources/servers/verily-autopush.json
+++ b/src/main/resources/servers/verily-autopush.json
@@ -13,6 +13,5 @@
   "auth0Enabled": true,
   "auth0Domain": "verily-terra-dev.us.auth0.com",
   "flagsmithClientSideKey": "8gVQW74MiaTJudZ4xRrczi",
-  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/",
-  "supportedCloudPlatforms": ["GCP", "AWS"]
+  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/"
 }

--- a/src/main/resources/servers/verily-devel.json
+++ b/src/main/resources/servers/verily-devel.json
@@ -13,6 +13,5 @@
   "auth0Enabled": true,
   "auth0Domain": "verily-terra-dev.us.auth0.com",
   "flagsmithClientSideKey": "FYzNYx4DrHrfg64pxSwEjP",
-  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/",
-  "supportedCloudPlatforms": ["GCP", "AWS"]
+  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/"
 }

--- a/src/main/resources/servers/verily-preprod.json
+++ b/src/main/resources/servers/verily-preprod.json
@@ -13,6 +13,5 @@
   "auth0Enabled": true,
   "auth0Domain": "verily-terra-prod.us.auth0.com",
   "flagsmithClientSideKey": "VKr2E33BSw6rY7HbcmhwXd",
-  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/",
-  "supportedCloudPlatforms": ["GCP", "AWS"]
+  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/"
 }

--- a/src/main/resources/servers/verily-staging.json
+++ b/src/main/resources/servers/verily-staging.json
@@ -13,6 +13,5 @@
   "auth0Enabled": true,
   "auth0Domain": "verily-terra-dev.us.auth0.com",
   "flagsmithClientSideKey": "4w63mhUZZKzisZgNJ8okUC",
-  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/",
-  "supportedCloudPlatforms": ["GCP"]
+  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/"
 }

--- a/src/main/resources/servers/verily.json
+++ b/src/main/resources/servers/verily.json
@@ -13,6 +13,5 @@
   "auth0Enabled": true,
   "auth0Domain": "verily-terra-prod.us.auth0.com",
   "flagsmithClientSideKey": "PvCmfnTvoDniqAWrZVww62",
-  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/",
-  "supportedCloudPlatforms": ["GCP"]
+  "flagsmithApiUrl": "https://terra-flagsmith.api.verily.com/api/v1/"
 }


### PR DESCRIPTION
- Create Enums for feature names, defined in FeatureService. This consolidates feature names to a single location
- Util function to use the above feature name enum instead of feature name as string
- Use vwb__aws/gcp_enabled flags instead of reading supported values from server config
- As a fallback for broad server which dont use flagsmith - if feature service returns false, check server config
- Remove supported platforms from server config of verily servers. This enables controlling platform visibility w/o requiring user to re-install newer version of CLI


verily servers (from Flagsmith)
```
>> terra server status
Current server: verily-devel (Verily devel environment)
Server status: OKAY

>> terra workspace create --id=dummy-1
2023-08-30 15:18:47.998 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** GCP_ENABLED from flagsmith - true

// Flag disabled on flsgsmith
>> terra workspace create --id=dummy-1 --platform=AWS
2023-08-30 15:20:13.112 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** AWS_ENABLED from flagsmith - false
2023-08-30 15:20:13.112 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** Fallback: check from server config
2023-08-30 15:20:13.113 PDT [main] ERROR bio.terra.cli.command.Main - Cloud platform AWS not supported for server verily-devel

// enable on flagsmith
>> terra workspace create --id=dummy-1 --platform=AWS
2023-08-30 15:23:11.213 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** AWS_ENABLED from flagsmith - true

// other non-prod - both GCP and AWS enabled 

// on prod- GCP enabled, AWS disabled (expected)
>> terra server status
Current server: verily (Verily production environment)
Server status: OKAY

>> terra workspace create --id=dummy-1
2023-08-30 15:24:20.132 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** GCP_ENABLED from flagsmith - true

>> terra workspace create --id=dummy-1 --platform=AWS
2023-08-30 15:26:26.983 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** AWS_ENABLED from flagsmith - false
2023-08-30 15:26:26.984 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** Fallback: check from server config
2023-08-30 15:26:26.985 PDT [main] ERROR bio.terra.cli.command.Main - Cloud platform AWS not supported for server verily
```

Broad servers (from server config)
```
>> terra server status
Current server: broad-dev (Broad main development environment)
Server status: OKAY
>> terra workspace create --id=dummy-1
2023-08-30 15:30:19.443 PDT [main] INFO  bio.terra.cli.service.FeatureService - Flagsmith is not enabled, use default value
2023-08-30 15:30:19.444 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** GCP_ENABLED from flagsmith - false
2023-08-30 15:30:19.444 PDT [main] DEBUG bio.terra.cli.utils.CommandUtils - ****** Fallback: check from server config
```