### PR TITLE
[draft] Remove PtestConfig

### DIFF
--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -69,9 +69,9 @@ jobs:
         echo "dryrun: $DRY_RUN"
         echo "terraserver: $TERRA_SERVER"
         if [ "$DRY_RUN" == "true" ]; then
-          ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PtestConfig=broad -PdryRun
+          ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PdryRun
         else
-          ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER -PtestConfig=broad
+          ./gradlew cleanupTestUserWorkspaces -Pserver=$TERRA_SERVER
         fi
       env:
         DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/cleanup-test-user-workspaces.yml
+++ b/.github/workflows/cleanup-test-user-workspaces.yml
@@ -42,17 +42,17 @@ jobs:
         # on local machines, the script fetches a SA from Vault.
         # in GH actions, the SA key is stored in a GH repo secret.
         # regardless of how it was fetched, tests and scripts expect these
-        # keys to be stored in rendered/broad/
-        mkdir -p rendered/broad/
-        echo "$TEST_USER_SA_KEY" > rendered/broad/test-user-account.json
-        echo "$EXT_PROJECT_SA_KEY" > rendered/broad/external-project-account.json
-        echo "$JANITOR_CLIENT_SA_KEY" > rendered/broad/janitor-client.json
-        echo "$BROOKLYN_THUNDERLORD" > rendered/broad/Brooklyn.Thunderlord@test.firecloud.org.json
-        echo "$ETHAN_BONECHEWER" > rendered/broad/Ethan.Bonechewer@test.firecloud.org.json
-        echo "$JOHN_WHITECLAW" > rendered/broad/John.Whiteclaw@test.firecloud.org.json
-        echo "$LILY_SHADOWMOON" > rendered/broad/Lily.Shadowmoon@test.firecloud.org.json
-        echo "$NOAH_FROSTWOLF" > rendered/broad/Noah.Frostwolf@test.firecloud.org.json
-        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/broad/Penelope.TwilightsHammer@test.firecloud.org.json
+        # keys to be stored in rendered/
+        mkdir -p rendered/
+        echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+        echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
+        echo "$JANITOR_CLIENT_SA_KEY" > rendered/janitor-client.json
+        echo "$BROOKLYN_THUNDERLORD" > rendered/Brooklyn.Thunderlord@test.firecloud.org.json
+        echo "$ETHAN_BONECHEWER" > rendered/Ethan.Bonechewer@test.firecloud.org.json
+        echo "$JOHN_WHITECLAW" > rendered/John.Whiteclaw@test.firecloud.org.json
+        echo "$LILY_SHADOWMOON" > rendered/Lily.Shadowmoon@test.firecloud.org.json
+        echo "$NOAH_FROSTWOLF" > rendered/Noah.Frostwolf@test.firecloud.org.json
+        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/Penelope.TwilightsHammer@test.firecloud.org.json
       env:
         TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
         EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}

--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -30,12 +30,12 @@ jobs:
         # on local machines, the script fetches a SA from Vault.
         # in GH actions, the SA key is stored in a GH repo secret.
         # regardless of how it was fetched, tests and scripts expect these
-        # keys to be stored in rendered/broad
-        mkdir -p rendered/broad
-        echo "$TEST_USER_SA_KEY" > rendered/broad/test-user-account.json
-        echo "$DEV_CI_SA_KEY" > rendered/broad/ci-account.json
-        echo "$EXT_PROJECT_SA_KEY" > rendered/broad/external-project-account.json
-        echo "$JANITOR_CLIENT_SA_KEY" > rendered/broad/janitor-client.json
+        # keys to be stored in rendered
+        mkdir -p rendered
+        echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+        echo "$DEV_CI_SA_KEY" > rendered/ci-account.json
+        echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
+        echo "$JANITOR_CLIENT_SA_KEY" > rendered/janitor-client.json
       env:
         TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
         DEV_CI_SA_KEY: ${{ secrets.DEV_CI_SA_KEY }}

--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -44,17 +44,17 @@ jobs:
         # on local machines, the script fetches a SA from Vault.
         # in GH actions, the SA key is stored in a GH repo secret.
         # regardless of how it was fetched, tests and scripts expect these
-        # keys to be stored in rendered/broad/
-        mkdir -p rendered/broad/
-        echo "$TEST_USER_SA_KEY" > rendered/broad/test-user-account.json
-        echo "$EXT_PROJECT_SA_KEY" > rendered/broad/external-project-account.json
-        echo "$JANITOR_CLIENT_SA_KEY" > rendered/broad/janitor-client.json
-        echo "$BROOKLYN_THUNDERLORD" > rendered/broad/Brooklyn.Thunderlord@test.firecloud.org.json
-        echo "$ETHAN_BONECHEWER" > rendered/broad/Ethan.Bonechewer@test.firecloud.org.json
-        echo "$JOHN_WHITECLAW" > rendered/broad/John.Whiteclaw@test.firecloud.org.json
-        echo "$LILY_SHADOWMOON" > rendered/broad/Lily.Shadowmoon@test.firecloud.org.json
-        echo "$NOAH_FROSTWOLF" > rendered/broad/Noah.Frostwolf@test.firecloud.org.json
-        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/broad/Penelope.TwilightsHammer@test.firecloud.org.json
+        # keys to be stored in rendered/
+        mkdir -p rendered/
+        echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+        echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
+        echo "$JANITOR_CLIENT_SA_KEY" > rendered/janitor-client.json
+        echo "$BROOKLYN_THUNDERLORD" > rendered/Brooklyn.Thunderlord@test.firecloud.org.json
+        echo "$ETHAN_BONECHEWER" > rendered/Ethan.Bonechewer@test.firecloud.org.json
+        echo "$JOHN_WHITECLAW" > rendered/John.Whiteclaw@test.firecloud.org.json
+        echo "$LILY_SHADOWMOON" > rendered/Lily.Shadowmoon@test.firecloud.org.json
+        echo "$NOAH_FROSTWOLF" > rendered/Noah.Frostwolf@test.firecloud.org.json
+        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/Penelope.TwilightsHammer@test.firecloud.org.json
       env:
         TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
         EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}

--- a/.github/workflows/tests-on-pr-push-and-merge.yml
+++ b/.github/workflows/tests-on-pr-push-and-merge.yml
@@ -71,17 +71,17 @@ jobs:
         # on local machines, the script fetches a SA from Vault.
         # in GH actions, the SA key is stored in a GH repo secret.
         # regardless of how it was fetched, tests and scripts expect these
-        # keys to be stored in rendered/broad/
-        mkdir -p rendered/broad/
-        echo "$TEST_USER_SA_KEY" > rendered/broad/test-user-account.json
-        echo "$EXT_PROJECT_SA_KEY" > rendered/broad/external-project-account.json
-        echo "$JANITOR_CLIENT_SA_KEY" > rendered/broad/janitor-client.json
-        echo "$BROOKLYN_THUNDERLORD" > rendered/broad/Brooklyn.Thunderlord@test.firecloud.org.json
-        echo "$ETHAN_BONECHEWER" > rendered/broad/Ethan.Bonechewer@test.firecloud.org.json
-        echo "$JOHN_WHITECLAW" > rendered/broad/John.Whiteclaw@test.firecloud.org.json
-        echo "$LILY_SHADOWMOON" > rendered/broad/Lily.Shadowmoon@test.firecloud.org.json
-        echo "$NOAH_FROSTWOLF" > rendered/broad/Noah.Frostwolf@test.firecloud.org.json
-        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/broad/Penelope.TwilightsHammer@test.firecloud.org.json
+        # keys to be stored in rendered/
+        mkdir -p rendered/
+        echo "$TEST_USER_SA_KEY" > rendered/test-user-account.json
+        echo "$EXT_PROJECT_SA_KEY" > rendered/external-project-account.json
+        echo "$JANITOR_CLIENT_SA_KEY" > rendered/janitor-client.json
+        echo "$BROOKLYN_THUNDERLORD" > rendered/Brooklyn.Thunderlord@test.firecloud.org.json
+        echo "$ETHAN_BONECHEWER" > rendered/Ethan.Bonechewer@test.firecloud.org.json
+        echo "$JOHN_WHITECLAW" > rendered/John.Whiteclaw@test.firecloud.org.json
+        echo "$LILY_SHADOWMOON" > rendered/Lily.Shadowmoon@test.firecloud.org.json
+        echo "$NOAH_FROSTWOLF" > rendered/Noah.Frostwolf@test.firecloud.org.json
+        echo "$PENELOPE_TWILIGHTSHAMMER" > rendered/Penelope.TwilightsHammer@test.firecloud.org.json
       env:
         TEST_USER_SA_KEY: ${{ secrets.TEST_USER_SA_KEY }}
         EXT_PROJECT_SA_KEY: ${{ secrets.EXT_PROJECT_SA_KEY }}

--- a/ADMIN.md
+++ b/ADMIN.md
@@ -146,7 +146,7 @@ the `broad-dev-cli-testing` deployment:
 ```shell
 ./tools/render-config.sh
 terra auth login # login as yourself, the break-glass granter
-terra workspace break-glass --email=breakglassrequester@gmail.com --big-query-project=terra-cli-dev --big-query-sa=rendered/broad/ci-account.json --user-project-admin-sa=rendered/broad/verilycli-wsm-sa.json --notes="Testing break-glass command."
+terra workspace break-glass --email=breakglassrequester@gmail.com --big-query-project=terra-cli-dev --big-query-sa=rendered/ci-account.json --user-project-admin-sa=rendered/broad/verilycli-wsm-sa.json --notes="Testing break-glass command."
 ```
 
 ### Requests catalog
@@ -155,7 +155,7 @@ The `terra workspace break-glass` command updates a central BigQuery dataset to
 track break-glass requests. This dataset was set up by a script:
 
 ```shell
-gcloud auth activate-service-account dev-ci-sa@broad-dsde-dev.iam.gserviceaccount.com --key-file=./rendered/broad/ci-account.json
+gcloud auth activate-service-account dev-ci-sa@broad-dsde-dev.iam.gserviceaccount.com --key-file=./rendered/ci-account.json
 ./tools/create-break-glass-bq.sh terra-cli-dev
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,10 +398,7 @@ deployment:
 * Create a new file
   under [Test config](https://github.com/DataBiosphere/terra-cli/tree/main/src/test/resources/testconfigs)
 * Create a new `render-config.sh` which renders config for your deployment. Put
-  the configs in a new directory under `rendered`, eg `rendered/<mydeployment>`.
-  The name of this directory must match the name of the testConfig in the next
-  step.
-* Run tests with `-PtestConfig=<testconfigfilenamewithout.json>`
+  the configs under `rendered`.
 
 For example, consider the project that external resources are created in. The
 Broad deployment uses a project in Broad GCP org; Verily deployment uses a

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -143,11 +143,18 @@ task runTestsWithTag(type: Test) {
     }
 
     // specify the server to run tests against (e.g. -Pserver=verily-devel). defaults to 'broad-dev'
-    String terraServer = project.hasProperty('server') ? project.findProperty('server') : 'broad-dev'
+    // testconfig is derived from the server
+    String terraServer = 'broad-dev'
+    String terraTestConfigName = 'broad'
+    if (project.hasProperty('server')) {
+        terraServer = project.findProperty('server')
+        if (terraServer == 'verily') {
+            terraTestConfigName = 'verily'
+        } else if (terraServer.startsWith('verily')) {
+            terraTestConfigName = 'verily-dev'
+        }
+    }
     environment 'TERRA_SERVER', terraServer
-
-    // set which file in src/test/resources/testconfigs to use
-    String terraTestConfigName = project.hasProperty('testConfig') ? project.findProperty('testConfig') : 'broad'
     systemProperty('TERRA_TEST_CONFIG_NAME', terraTestConfigName)
 
     // suppress console logging ('stdin' & 'stdout' display)

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -214,11 +214,19 @@ task cleanupTestUserWorkspaces(type: JavaExec) {
     environment 'TERRA_CONTEXT_PARENT_DIR', "${buildDir}/test-context/"
     mkdir "${project.buildDir}/test-context/"
 
-    // [required] specify the server to cleanup (e.g. -Pserver=broad-dev). no default value, force caller to specify this
-    systemProperty('TERRA_SERVER', project.findProperty('server'))
-
-    // set which file in src/test/resources/testconfigs to use
-    String terraTestConfigName = project.hasProperty('testConfig') ? project.findProperty('testConfig') : 'broad'
+    // specify the server to run tests against (e.g. -Pserver=verily-devel). defaults to 'broad-dev'
+    // testconfig is derived from the server
+    String terraServer = 'broad-dev'
+    String terraTestConfigName = 'broad'
+    if (project.hasProperty('server')) {
+        terraServer = project.findProperty('server')
+        if (terraServer == 'verily') {
+            terraTestConfigName = 'verily'
+        } else if (terraServer.startsWith('verily')) {
+            terraTestConfigName = 'verily-dev'
+        }
+    }
+    environment 'TERRA_SERVER', terraServer
     systemProperty('TERRA_TEST_CONFIG_NAME', terraTestConfigName)
 
     // suppress console logging ('stdin' & 'stdout' display)

--- a/src/main/java/bio/terra/cli/businessobject/User.java
+++ b/src/main/java/bio/terra/cli/businessobject/User.java
@@ -33,28 +33,36 @@ import org.slf4j.LoggerFactory;
     justification =
         "Known false positive for certain try-with-resources blocks, which are used in several methods in this class. https://github.com/spotbugs/spotbugs/issues/1338 (Other similar issues linked from there.)")
 public class User {
+  private static final Logger logger = LoggerFactory.getLogger(User.class);
+
   // these are the same scopes requested by Terra service swagger pages
   @VisibleForTesting
   public static final List<String> USER_SCOPES = ImmutableList.of("openid", "email", "profile");
 
-  private static final Logger logger = LoggerFactory.getLogger(User.class);
+  // these are the same scopes requested by Terra service swagger pages
+  @VisibleForTesting
+  public static final List<String> CLOUD_PLATFORM_SCOPES =
+      ImmutableList.of("https://www.googleapis.com/auth/cloud-platform");
+
   // these are the same scopes requested by Terra service swagger pages, plus the cloud platform
   // scope. pet SAs need the cloud platform scope to talk to GCP directly (e.g. to check the status
   // of a GCP notebook)
   @VisibleForTesting
   public static final List<String> PET_SA_SCOPES =
-      ImmutableList.of(
-          "openid", "email", "profile", "https://www.googleapis.com/auth/cloud-platform");
+      ImmutableList.<String>builder().addAll(USER_SCOPES).addAll(CLOUD_PLATFORM_SCOPES).build();
+
   // Number of milliseconds early to consider auth credentials as expired.
   private static final int CREDENTIAL_EXPIRATION_OFFSET_MS = 60 * 1000;
   // URL of the landing page shown in the browser after completing the OAuth part of login
   // ideally this should point to product documentation or perhaps the UI, but for now the CLI
   // README seems like the best option. in the future, if we want to make this server-specific, then
   // it should become a property of the Server
+
   private static final String LOGIN_LANDING_PAGE =
       "https://github.com/DataBiosphere/terra-cli/blob/main/README.md";
   // id that Terra uses to identify a user. the CLI queries SAM for a user's subject id to populate
   // this field.
+
   private String id;
   // name that Terra associates with this user. the CLI queries SAM for a user's email to populate
   // this field.

--- a/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
+++ b/src/main/java/bio/terra/cli/command/workspace/BreakGlass.java
@@ -1,5 +1,7 @@
 package bio.terra.cli.command.workspace;
 
+import static bio.terra.cli.businessobject.User.CLOUD_PLATFORM_SCOPES;
+
 import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.businessobject.WorkspaceUser;
@@ -18,7 +20,6 @@ import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.InsertAllRequest;
 import com.google.cloud.bigquery.InsertAllResponse;
 import com.google.cloud.bigquery.TableId;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
@@ -83,8 +84,7 @@ public class BreakGlass extends WsmBaseCommand {
     ServiceAccountCredentials userProjectsAdminCredentials;
     ServiceAccountCredentials bigQueryCredentials;
     try {
-      final List<String> SA_SCOPES =
-          ImmutableList.of("https://www.googleapis.com/auth/cloud-platform");
+      List<String> SA_SCOPES = CLOUD_PLATFORM_SCOPES;
       userProjectsAdminCredentials =
           Oauth.getServiceAccountCredential(Path.of(userProjectAdminSAKeyFile).toFile(), SA_SCOPES);
       bigQueryCredentials =

--- a/src/test/java/harness/TestConfig.java
+++ b/src/test/java/harness/TestConfig.java
@@ -36,8 +36,7 @@ public final class TestConfig {
 
   private TestConfig() {}
 
-  // Returns name of file under `testconfigs/` without `.json`, eg `broad`. This is also name of the
-  // directory under `rendered` where credentials are stored.
+  // Returns name of file under `testconfigs/` without `.json`, eg `broad`.
   public static String getTestConfigName() {
     return System.getProperty("TERRA_TEST_CONFIG_NAME");
   }

--- a/src/test/java/harness/TestConfig.java
+++ b/src/test/java/harness/TestConfig.java
@@ -36,19 +36,9 @@ public final class TestConfig {
 
   private TestConfig() {}
 
-  // Returns name of file under `testconfigs/` without `.json`, eg `broad`.
-  public static String getTestConfigName() {
-    return System.getProperty("TERRA_TEST_CONFIG_NAME");
-  }
-
   public static TestConfig get() {
     if (INSTANCE == null) {
-      String testConfigName = getTestConfigName();
-      if (testConfigName == null || testConfigName.isEmpty()) {
-        throw new SystemException("TERRA_TEST_CONFIG_NAME must be set");
-      }
-
-      String testConfigFileName = testConfigName + ".json";
+      String testConfigFileName = System.getProperty("TERRA_TEST_CONFIG_NAME") + ".json";
       TestConfig testConfig = fromJsonFile(testConfigFileName);
       validateTestConfig(testConfig, testConfigFileName);
 

--- a/src/test/java/harness/TestExternalResources.java
+++ b/src/test/java/harness/TestExternalResources.java
@@ -1,25 +1,19 @@
 package harness;
 
+import bio.terra.cli.businessobject.User;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.List;
 
 /** This class holds pointers to the SA that tests can use to create external resources. */
 public class TestExternalResources {
   // SA with permission to create/delete/query resources in the project
-  private static final String SA_KEY_FILE =
-      "./rendered/" + TestConfig.getTestConfigName() + "/external-project-account.json";
-
-  // default scope to request for the SA
-  private static final List<String> CLOUD_PLATFORM_SCOPE =
-      List.of("https://www.googleapis.com/auth/cloud-platform");
+  private static final String SA_KEY_FILE = "./rendered/external-project-account.json";
 
   /** Get credentials for the SA with permissions on the external project. */
   public static GoogleCredentials getSACredentials() throws IOException {
-    return ServiceAccountCredentials.fromStream(
-            new FileInputStream(TestExternalResources.SA_KEY_FILE))
-        .createScoped(TestExternalResources.CLOUD_PLATFORM_SCOPE);
+    return ServiceAccountCredentials.fromStream(new FileInputStream(SA_KEY_FILE))
+        .createScoped(User.CLOUD_PLATFORM_SCOPES);
   }
 }

--- a/src/test/java/harness/TestUser.java
+++ b/src/test/java/harness/TestUser.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/tools/publish-docker.sh
+++ b/tools/publish-docker.sh
@@ -31,7 +31,7 @@ if [[ -z "$localImageName" ]]; then
 fi
 
 echo "Logging in to docker using the CI service account key file"
-cat rendered/broad/ci-account.json | docker login -u _json_key --password-stdin https://gcr.io
+cat rendered/ci-account.json | docker login -u _json_key --password-stdin https://gcr.io
 
 echo "Tagging the local docker image with the name to use in GCR"
 dockerRepoPath=$(./gradlew --quiet getDockerRepoPath) # e.g. gcr.io/terra-cli-dev
@@ -42,7 +42,7 @@ docker tag $localImageNameAndTag $remoteImageNameAndTag
 echo "Logging into to gcloud and configuring docker with the CI service account"
 # reference: https://cloud.google.com/container-registry/docs/advanced-authentication#gcloud-helper
 currentGcloudUser=$(gcloud config get-value account)
-gcloud auth activate-service-account --key-file=rendered/broad/ci-account.json
+gcloud auth activate-service-account --key-file=rendered/ci-account.json
 gcloud auth configure-docker
 
 echo "Pushing the image to GCR"

--- a/tools/render-config.sh
+++ b/tools/render-config.sh
@@ -24,7 +24,7 @@ JANITOR_CLIENT_SA_VAULT_PATH=secret/dsde/terra/kernel/integration/tools/crl_jani
 VERILYCLI_WSM_SA_VAULT_PATH=secret/dsde/terra/kernel/integration/verilycli/workspace/app-sa
 CLIENT_CRED_VAULT_PATH=secret/dsde/terra/cli/oauth-client-credentials
 
-# Helper function to read a secret from Vault and write it to a local file in the rendered/broad/ directory.
+# Helper function to read a secret from Vault and write it to a local file in the rendered/ directory.
 # Inputs: vault path, file name, [optional] decode from base 64
 # Usage: readFromVault $CI_SA_VAULT_PATH ci-account.json
 #        readFromValue $JANITOR_CLIENT_SA_VAULT_PATH janitor-client.json base64
@@ -39,16 +39,16 @@ readFromVault () {
   if [[ -z "${decodeBase64}" ]]; then
     docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
               vault read -format json "${vaultPath}" \
-              | jq -r .data > "rendered/broad/${fileName}"
+              | jq -r .data > "rendered/${fileName}"
   else
     docker run --rm -e VAULT_TOKEN="${VAULT_TOKEN}" "${DSDE_TOOLBOX_DOCKER_IMAGE}" \
               vault read -format json "${vaultPath}" \
-              | jq -r .data.key | base64 -d > "rendered/broad/${fileName}"
+              | jq -r .data.key | base64 -d > "rendered/${fileName}"
   fi
   return 0
 }
 
-mkdir -p rendered/broad
+mkdir -p rendered
 
 # used for publishing Docker images to GCR in the terra-cli-dev project
 echo "Reading the CI service account key file from Vault"


### PR DESCRIPTION
Remove PtestConfig

uses test config file name 'broad' as default
for verily: verily-dev and verily

(includes minor cleanup) 