### PR TITLE
[BENCH-1067]: Add email address to dataproc flag check

### DIFF
--- a/src/main/java/bio/terra/cli/command/workspace/Create.java
+++ b/src/main/java/bio/terra/cli/command/workspace/Create.java
@@ -1,6 +1,5 @@
 package bio.terra.cli.command.workspace;
 
-import bio.terra.cli.businessobject.Context;
 import bio.terra.cli.businessobject.Workspace;
 import bio.terra.cli.command.shared.WsmBaseCommand;
 import bio.terra.cli.command.shared.options.Format;
@@ -45,7 +44,7 @@ public class Create extends WsmBaseCommand {
   /** Create a new workspace. */
   @Override
   protected void execute() {
-    CommandUtils.checkPlatformEnabled(cloudPlatform, Context.requireUser().getEmail());
+    CommandUtils.checkPlatformEnabled(cloudPlatform);
 
     if (spendProfile == null) {
       spendProfile = UserManagerService.fromContext().getDefaultSpendProfile(/*email=*/ null);

--- a/src/main/java/bio/terra/cli/utils/CommandUtils.java
+++ b/src/main/java/bio/terra/cli/utils/CommandUtils.java
@@ -6,7 +6,6 @@ import bio.terra.cli.service.FeatureService;
 import bio.terra.workspace.model.CloudPlatform;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 public class CommandUtils {
   // Checks if current server supports cloud platform
@@ -21,11 +20,11 @@ public class CommandUtils {
     }
   }
 
-  public static void checkPlatformEnabled(CloudPlatform cloudPlatform, @Nullable String userEmail)
+  public static void checkPlatformEnabled(CloudPlatform cloudPlatform)
       throws UserActionableException {
     if (switch (cloudPlatform) {
       case AWS -> FeatureService.fromContext()
-          .isFeatureEnabled(FeatureService.AWS_ENABLED, userEmail);
+          .isFeatureEnabled(FeatureService.AWS_ENABLED, Context.requireUser().getEmail());
       case GCP -> true;
       default -> false;
     }) return;
@@ -48,7 +47,8 @@ public class CommandUtils {
 
   // Checks if the dataproc is supported
   public static void checkDataprocSupport() throws UserActionableException {
-    if (!FeatureService.fromContext().isFeatureEnabled(FeatureService.CLI_DATAPROC_ENABLED)) {
+    if (!FeatureService.fromContext()
+        .isFeatureEnabled(FeatureService.CLI_DATAPROC_ENABLED, Context.requireUser().getEmail())) {
       throw new UserActionableException("Dataproc is not enabled for the current server or user.");
     }
   }


### PR DESCRIPTION
Also pass email at flag check in `CommandUtils` instead at the caller level. We should always provide email address for feature flag checks.