### PR TITLE
[BENCH-1086]: Add terra resource update dataproc-cluster command

### DIFF
--- a/src/main/java/bio/terra/cli/businessobject/resource/GcpDataprocCluster.java
+++ b/src/main/java/bio/terra/cli/businessobject/resource/GcpDataprocCluster.java
@@ -7,6 +7,7 @@ import bio.terra.cli.businessobject.Resource;
 import bio.terra.cli.exception.UserActionableException;
 import bio.terra.cli.serialization.persisted.resource.PDGcpDataprocCluster;
 import bio.terra.cli.serialization.userfacing.input.CreateGcpDataprocClusterParams;
+import bio.terra.cli.serialization.userfacing.input.UpdateControlledGcpDataprocClusterParams;
 import bio.terra.cli.serialization.userfacing.resource.UFGcpDataprocCluster;
 import bio.terra.cli.service.AxonServerService;
 import bio.terra.cli.service.WorkspaceManagerServiceGcp;
@@ -76,6 +77,15 @@ public class GcpDataprocCluster extends Resource {
     logger.info("Created GCP dataproc cluster: {}", createdResource);
 
     return new GcpDataprocCluster(createdResource);
+  }
+
+  public void updateControlled(UpdateControlledGcpDataprocClusterParams updateParams) {
+    if (updateParams.resourceFields.name != null) {
+      validateResourceName(updateParams.resourceFields.name);
+    }
+    WorkspaceManagerServiceGcp.fromContext()
+        .updateControlledDataprocCluster(Context.requireWorkspace().getUuid(), id, updateParams);
+    super.updatePropertiesAndSync(updateParams.resourceFields);
   }
 
   /**

--- a/src/main/java/bio/terra/cli/command/resource/Update.java
+++ b/src/main/java/bio/terra/cli/command/resource/Update.java
@@ -2,6 +2,7 @@ package bio.terra.cli.command.resource;
 
 import bio.terra.cli.command.resource.update.BqDataset;
 import bio.terra.cli.command.resource.update.BqTable;
+import bio.terra.cli.command.resource.update.GcpDataprocCluster;
 import bio.terra.cli.command.resource.update.GcpNotebook;
 import bio.terra.cli.command.resource.update.GcsBucket;
 import bio.terra.cli.command.resource.update.GcsObject;
@@ -19,6 +20,7 @@ import picocli.CommandLine;
       BqDataset.class,
       BqTable.class,
       GcpNotebook.class,
+      GcpDataprocCluster.class,
       GcsBucket.class,
       GcsObject.class,
       GitRepo.class

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpDataprocCluster.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpDataprocCluster.java
@@ -146,7 +146,7 @@ public class GcpDataprocCluster extends WsmBaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     CommandUtils.checkWorkspaceSupport(CloudPlatform.GCP);
-    CommandUtils.checkDataprocSupport();
+    // CommandUtils.checkDataprocSupport();
 
     // Retrieve the staging and temp bucket resource UUIDs and throw if they don't exist
     UUID configBucketId = Context.requireWorkspace().getResource(configBucket).getId();

--- a/src/main/java/bio/terra/cli/command/resource/create/GcpDataprocCluster.java
+++ b/src/main/java/bio/terra/cli/command/resource/create/GcpDataprocCluster.java
@@ -146,7 +146,7 @@ public class GcpDataprocCluster extends WsmBaseCommand {
   protected void execute() {
     workspaceOption.overrideIfSpecified();
     CommandUtils.checkWorkspaceSupport(CloudPlatform.GCP);
-    // CommandUtils.checkDataprocSupport();
+    CommandUtils.checkDataprocSupport();
 
     // Retrieve the staging and temp bucket resource UUIDs and throw if they don't exist
     UUID configBucketId = Context.requireWorkspace().getResource(configBucket).getId();

--- a/src/main/java/bio/terra/cli/command/resource/update/GcpDataprocCluster.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcpDataprocCluster.java
@@ -1,0 +1,100 @@
+package bio.terra.cli.command.resource.update;
+
+import bio.terra.cli.businessobject.Context;
+import bio.terra.cli.businessobject.Resource.Type;
+import bio.terra.cli.command.shared.WsmBaseCommand;
+import bio.terra.cli.command.shared.options.Format;
+import bio.terra.cli.command.shared.options.ResourceUpdate;
+import bio.terra.cli.command.shared.options.WorkspaceOverride;
+import bio.terra.cli.exception.UserActionableException;
+import bio.terra.cli.serialization.userfacing.input.UpdateControlledGcpDataprocClusterParams;
+import bio.terra.cli.serialization.userfacing.resource.UFGcpDataprocCluster;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "dataproc-cluster",
+    description = "Update a GCP Dataproc cluster.",
+    showDefaultValues = true)
+public class GcpDataprocCluster extends WsmBaseCommand {
+  @CommandLine.Mixin ResourceUpdate resourceUpdateOptions;
+  @CommandLine.Mixin WorkspaceOverride workspaceOption;
+  @CommandLine.Mixin Format formatOption;
+
+  @CommandLine.Option(names = "--num-workers", description = "The number of worker nodes.")
+  private Integer numWorkers;
+
+  @CommandLine.Option(
+      names = "--num-secondary-workers",
+      description = "The number of secondary worker nodes.")
+  private Integer numSecondaryWorkers;
+
+  @CommandLine.Option(
+      names = "--autoscaling-policy",
+      description =
+          "Autoscaling policy url to attach to the cluster. Format: projects/[projectId]/locations/[dataproc_region]/autoscalingPolicies/[policy_id]")
+  private String autoscalingPolicy;
+
+  @CommandLine.Option(
+      names = "--graceful-decommission-timeout",
+      description = "The duration to wait for graceful decommissioning to finish.")
+  private String gracefulDecommissionTimeout;
+
+  @CommandLine.Option(
+      names = "--idle-delete-ttl",
+      description = "Time-to-live after which the resource becomes idle and is deleted.")
+  public String idleDeleteTtl;
+
+  /** Print this command's output in text format. */
+  private static void printText(UFGcpDataprocCluster returnValue) {
+    OUT.println("Successfully updated GCP Dataproc cluster.");
+    returnValue.print();
+  }
+
+  /** Update a GCP Dataproc cluster in the workspace. */
+  @Override
+  protected void execute() {
+    workspaceOption.overrideIfSpecified();
+
+    // all update parameters are optional, but make sure at least one is specified
+    if (!resourceUpdateOptions.isDefined()
+        && numWorkers == null
+        && numSecondaryWorkers == null
+        && autoscalingPolicy == null
+        && gracefulDecommissionTimeout == null
+        && idleDeleteTtl == null) {
+      throw new UserActionableException("Specify at least one property to update.");
+    }
+
+    // get the resource and make sure it's the right type
+    bio.terra.cli.businessobject.resource.GcpDataprocCluster resource =
+        Context.requireWorkspace()
+            .getResource(resourceUpdateOptions.resourceNameOption.name)
+            .castToType(Type.DATAPROC_CLUSTER);
+
+    UpdateControlledGcpDataprocClusterParams.Builder builder =
+        new UpdateControlledGcpDataprocClusterParams.Builder()
+            .resourceFields(resourceUpdateOptions.populateMetadataFields().build())
+            .numWorkers(numWorkers)
+            .numSecondaryWorkers(numSecondaryWorkers)
+            .autoscalingPolicyUri(autoscalingPolicy)
+            .gracefulDecommissionTimeout(gracefulDecommissionTimeout)
+            .idleDeleteTtl(idleDeleteTtl);
+
+    // Optional.ofNullable(numWorkers).ifPresent(builder::numWorkers);
+    // Optional.ofNullable(numSecondaryWorkers).ifPresent(builder::numSecondaryWorkers);
+    // Optional.ofNullable(autoscalingPolicy).ifPresent(builder::autoscalingPolicyUri);
+    // Optional.ofNullable(gracefulDecommissionTimeout)
+    //     .ifPresent(builder::gracefulDecommissionTimeout);
+    //
+    // builder.idleDeleteTtl(idleDeleteTtl);
+    resource.updateControlled(builder.build());
+
+    // re-load the resource so we display all properties with up-to-date values
+    resource =
+        Context.requireWorkspace()
+            .getResource(resource.getName())
+            .castToType(Type.DATAPROC_CLUSTER);
+    formatOption.printReturnValue(
+        new UFGcpDataprocCluster(resource), GcpDataprocCluster::printText);
+  }
+}

--- a/src/main/java/bio/terra/cli/command/resource/update/GcpDataprocCluster.java
+++ b/src/main/java/bio/terra/cli/command/resource/update/GcpDataprocCluster.java
@@ -71,23 +71,15 @@ public class GcpDataprocCluster extends WsmBaseCommand {
             .getResource(resourceUpdateOptions.resourceNameOption.name)
             .castToType(Type.DATAPROC_CLUSTER);
 
-    UpdateControlledGcpDataprocClusterParams.Builder builder =
+    resource.updateControlled(
         new UpdateControlledGcpDataprocClusterParams.Builder()
             .resourceFields(resourceUpdateOptions.populateMetadataFields().build())
             .numWorkers(numWorkers)
             .numSecondaryWorkers(numSecondaryWorkers)
             .autoscalingPolicyUri(autoscalingPolicy)
             .gracefulDecommissionTimeout(gracefulDecommissionTimeout)
-            .idleDeleteTtl(idleDeleteTtl);
-
-    // Optional.ofNullable(numWorkers).ifPresent(builder::numWorkers);
-    // Optional.ofNullable(numSecondaryWorkers).ifPresent(builder::numSecondaryWorkers);
-    // Optional.ofNullable(autoscalingPolicy).ifPresent(builder::autoscalingPolicyUri);
-    // Optional.ofNullable(gracefulDecommissionTimeout)
-    //     .ifPresent(builder::gracefulDecommissionTimeout);
-    //
-    // builder.idleDeleteTtl(idleDeleteTtl);
-    resource.updateControlled(builder.build());
+            .idleDeleteTtl(idleDeleteTtl)
+            .build());
 
     // re-load the resource so we display all properties with up-to-date values
     resource =

--- a/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateControlledGcpDataprocClusterParams.java
+++ b/src/main/java/bio/terra/cli/serialization/userfacing/input/UpdateControlledGcpDataprocClusterParams.java
@@ -1,0 +1,84 @@
+package bio.terra.cli.serialization.userfacing.input;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+
+/**
+ * Parameters for updating a GCP Dataproc cluster workspace controlled resource. This class is not
+ * currently user-facing, but could be exposed as a command input format in the future.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@class")
+@JsonDeserialize(builder = UpdateResourceParams.Builder.class)
+public class UpdateControlledGcpDataprocClusterParams {
+  /** When null, the name of the resource should not be updated. */
+  public final UpdateResourceParams resourceFields;
+
+  public final Integer numWorkers;
+  public final Integer numSecondaryWorkers;
+  public final String autoscalingPolicyUri;
+  public final String gracefulDecommissionTimeout;
+  public final String idleDeleteTtl;
+
+  protected UpdateControlledGcpDataprocClusterParams(Builder builder) {
+    this.resourceFields = builder.resourceFields;
+    this.numWorkers = builder.numWorkers;
+    this.numSecondaryWorkers = builder.numSecondaryWorkers;
+    this.autoscalingPolicyUri = builder.autoscalingPolicyUri;
+    this.gracefulDecommissionTimeout = builder.gracefulDecommissionTimeout;
+    this.idleDeleteTtl = builder.idleDeleteTtl;
+  }
+
+  @JsonPOJOBuilder(buildMethodName = "build", withPrefix = "")
+  public static class Builder {
+    private UpdateResourceParams resourceFields;
+
+    private Integer numWorkers;
+    private Integer numSecondaryWorkers;
+    private String autoscalingPolicyUri;
+    private String gracefulDecommissionTimeout;
+    private String idleDeleteTtl;
+
+    /** Default constructor for Jackson. */
+    public Builder() {}
+
+    public UpdateControlledGcpDataprocClusterParams.Builder resourceFields(
+        UpdateResourceParams resourceFields) {
+      this.resourceFields = resourceFields;
+      return this;
+    }
+
+    public UpdateControlledGcpDataprocClusterParams.Builder numWorkers(Integer numWorkers) {
+      this.numWorkers = numWorkers;
+      return this;
+    }
+
+    public UpdateControlledGcpDataprocClusterParams.Builder numSecondaryWorkers(
+        Integer numSecondaryWorkers) {
+      this.numSecondaryWorkers = numSecondaryWorkers;
+      return this;
+    }
+
+    public UpdateControlledGcpDataprocClusterParams.Builder autoscalingPolicyUri(
+        String autoscalingPolicyUri) {
+      this.autoscalingPolicyUri = autoscalingPolicyUri;
+      return this;
+    }
+
+    public UpdateControlledGcpDataprocClusterParams.Builder gracefulDecommissionTimeout(
+        String gracefulDecommissionTimeout) {
+      this.gracefulDecommissionTimeout = gracefulDecommissionTimeout;
+      return this;
+    }
+
+    public UpdateControlledGcpDataprocClusterParams.Builder idleDeleteTtl(String idleDeleteTtl) {
+      this.idleDeleteTtl = idleDeleteTtl;
+      return this;
+    }
+
+    /** Call the private constructor. */
+    public UpdateControlledGcpDataprocClusterParams build() {
+      return new UpdateControlledGcpDataprocClusterParams(this);
+    }
+  }
+}

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceGcp.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceGcp.java
@@ -575,9 +575,10 @@ public class WorkspaceManagerServiceGcp extends WorkspaceManagerService {
       UUID workspaceId, UUID resourceId, UpdateControlledGcpDataprocClusterParams updateParams) {
 
     ControlledGcpResourceApi gcpResourceApi = new ControlledGcpResourceApi(apiClient);
-    String updateErrMsg =  "Error updating controlled GCP Dataproc cluster in the workspace";
+    String updateErrMsg = "Error updating controlled GCP Dataproc cluster in the workspace";
 
-    // Update WSM metadata fields and primary, secondary worker counts, and graceful decommission timeout.
+    // Update WSM metadata fields and primary, secondary worker counts, and graceful decommission
+    // timeout.
     UpdateControlledGcpDataprocClusterRequestBody updateRequest =
         new UpdateControlledGcpDataprocClusterRequestBody()
             .name(updateParams.resourceFields.name)
@@ -588,7 +589,6 @@ public class WorkspaceManagerServiceGcp extends WorkspaceManagerService {
             .numPrimaryWorkers(updateParams.numWorkers)
             .numSecondaryWorkers(updateParams.numSecondaryWorkers)
             .gracefulDecommissionTimeout(updateParams.gracefulDecommissionTimeout));
-
     callWithRetries(
         () -> gcpResourceApi.updateDataprocCluster(updateRequest, workspaceId, resourceId),
         updateErrMsg);

--- a/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceGcp.java
+++ b/src/main/java/bio/terra/cli/service/WorkspaceManagerServiceGcp.java
@@ -594,7 +594,7 @@ public class WorkspaceManagerServiceGcp extends WorkspaceManagerService {
         updateErrMsg);
 
     // Update autoscaling policy independently. Dataproc api does not allow autoscaling policy and
-    // other attributes in tandem.
+    // other attributes together.
     if (updateParams.autoscalingPolicyUri != null) {
       UpdateControlledGcpDataprocClusterRequestBody autoscalingPolicyUpdateRequest =
           new UpdateControlledGcpDataprocClusterRequestBody()
@@ -609,7 +609,7 @@ public class WorkspaceManagerServiceGcp extends WorkspaceManagerService {
     }
 
     // Update scheduled deletion independently. Dataproc api does not allow autoscaling policy and
-    // other attributes in tandem.
+    // other attributes together.
     if (updateParams.idleDeleteTtl != null) {
       UpdateControlledGcpDataprocClusterRequestBody autoscalingPolicyUpdateRequest =
           new UpdateControlledGcpDataprocClusterRequestBody()

--- a/src/test/java/unit/GcpDataprocClusterControlled.java
+++ b/src/test/java/unit/GcpDataprocClusterControlled.java
@@ -214,7 +214,7 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
 
   @Test
   @DisplayName("update cluster worker count and idle deletion time")
-  void overrideLocationAndInstanceId() throws IOException, InterruptedException {
+  void update() throws IOException, InterruptedException {
     workspaceCreator.login();
 
     // `terra workspace set --id=$id`
@@ -228,7 +228,7 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
         UFGcpDataprocCluster.class,
         "resource",
         "update",
-        "gcp-cluster",
+        "dataproc-cluster",
         "--name=" + clusterName,
         "--new-description=" + newDescription,
         "--num-workers=" + newPrimaryWorkerCount,
@@ -243,7 +243,7 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
             UFGcpDataprocCluster.class,
             "resource",
             "update",
-            "gcp-cluster",
+            "dataproc-cluster",
             "--name=" + clusterName,
             "--idle-delete-ttl=" + newIdleDeleteTtl);
     ResourceUtils.pollDescribeForResourceField(clusterName, "status", "RUNNING");

--- a/src/test/java/unit/GcpDataprocClusterControlled.java
+++ b/src/test/java/unit/GcpDataprocClusterControlled.java
@@ -239,7 +239,12 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
     // additional updates throw a user facing exception
     String stdErr =
         TestCommand.runCommandExpectExitCode(
-            1, "resource", "update", "dataproc-cluster", "--num-secondary-workers=5");
+            1,
+            "resource",
+            "update",
+            "dataproc-cluster",
+            "--name=" + clusterName,
+            "--num-secondary-workers=5");
     assertThat(
         "error message includes expected and current status",
         stdErr,

--- a/src/test/java/unit/GcpDataprocClusterControlled.java
+++ b/src/test/java/unit/GcpDataprocClusterControlled.java
@@ -213,6 +213,64 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
   }
 
   @Test
+  @DisplayName("update cluster worker count and idle deletion time")
+  void overrideLocationAndInstanceId() throws IOException, InterruptedException {
+    workspaceCreator.login();
+
+    // `terra workspace set --id=$id`
+    TestCommand.runCommandExpectSuccess("workspace", "set", "--id=" + getUserFacingId());
+
+    // Update wsm metadata and worker counts
+    String newDescription = "\"new cluster description\"";
+    int newPrimaryWorkerCount = 3;
+    int newSecondaryWorkerCount = 3;
+    TestCommand.runAndParseCommandExpectSuccess(
+        UFGcpDataprocCluster.class,
+        "resource",
+        "update",
+        "gcp-cluster",
+        "--name=" + clusterName,
+        "--new-description=" + newDescription,
+        "--num-workers=" + newPrimaryWorkerCount,
+        "--num-secondary-workers=" + newSecondaryWorkerCount);
+    UFGcpDataprocCluster updatedCluster;
+    ResourceUtils.pollDescribeForResourceField(clusterName, "status", "RUNNING");
+
+    // Update idle deletion time
+    String newIdleDeleteTtl = "2000s";
+    updatedCluster =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGcpDataprocCluster.class,
+            "resource",
+            "update",
+            "gcp-cluster",
+            "--name=" + clusterName,
+            "--idle-delete-ttl=" + newIdleDeleteTtl);
+    ResourceUtils.pollDescribeForResourceField(clusterName, "status", "RUNNING");
+
+    // check that the fields are correctly updated
+    assertEquals(
+        newDescription, updatedCluster.description, "cluster description matches expected");
+
+    UFGcpDataprocCluster describeResource =
+        TestCommand.runAndParseCommandExpectSuccess(
+            UFGcpDataprocCluster.class, "resource", "describe", "--name=" + clusterName);
+
+    assertEquals(
+        newPrimaryWorkerCount,
+        describeResource.numWorkers,
+        "cluster num primary workers matches expected");
+    assertEquals(
+        newSecondaryWorkerCount,
+        describeResource.numSecondaryWorkers,
+        "cluster num secondary workers matches expected");
+    assertEquals(
+        newIdleDeleteTtl,
+        describeResource.idleDeleteTtl,
+        "cluster idle delete ttl matches expected");
+  }
+
+  @Test
   @DisplayName("list and describe reflect a deleting cluster")
   void listDescribeReflectDelete() throws IOException {
     workspaceCreator.login();

--- a/src/test/java/unit/GcpDataprocClusterControlled.java
+++ b/src/test/java/unit/GcpDataprocClusterControlled.java
@@ -234,6 +234,18 @@ public class GcpDataprocClusterControlled extends SingleWorkspaceUnitGcp {
         "--num-workers=" + newPrimaryWorkerCount,
         "--num-secondary-workers=" + newSecondaryWorkerCount);
     UFGcpDataprocCluster updatedCluster;
+
+    // While the cluster is scaling down secondary workers (takes ~30 seconds), ensure that
+    // additional updates throw a user facing exception
+    String stdErr =
+        TestCommand.runCommandExpectExitCode(
+            1, "resource", "update", "dataproc-cluster", "--num-secondary-workers=5");
+    assertThat(
+        "error message includes expected and current status",
+        stdErr,
+        CoreMatchers.containsString("Expected cluster status is"));
+
+    // Poll until the cluster is running again
     ResourceUtils.pollDescribeForResourceField(clusterName, "status", "RUNNING");
 
     // Update idle deletion time


### PR DESCRIPTION
Adds resource update command for dataproc clusters.

```
❯ terras resource update dataproc-cluster --help
Missing required option: '--name=<name>'
Usage: terra resource update dataproc-cluster
       [--autoscaling-policy=<autoscalingPolicy>] [--format=<format>]
       [--graceful-decommission-timeout=<gracefulDecommissionTimeout>]
       [--idle-delete-ttl=<idleDeleteTtl>] --name=<name>
       [--new-description=<newDescription>] [--new-name=<newName>]
       [--num-secondary-workers=<numSecondaryWorkers>]
       [--num-workers=<numWorkers>] [--workspace=<id>]
Update a GCP Dataproc cluster.
      --autoscaling-policy=<autoscalingPolicy>
                             Autoscaling policy url to attach to the cluster.
                               Format: projects/[projectId]/locations/
                               [dataproc_region]/autoscalingPolicies/[policy_id]
      --format=<format>      Set the format for printing command output: JSON,
                               TEXT. Defaults to the config format property.
                               Default: null
      --graceful-decommission-timeout=<gracefulDecommissionTimeout>
                             The duration to wait for graceful decommissioning
                               to finish.
      --idle-delete-ttl=<idleDeleteTtl>
                             Time-to-live after which the resource becomes idle
                               and is deleted.
      --name=<name>          Name of the resource, scoped to the workspace.
                               Only use letters, numbers, dashes, and
                               underscores.
      --new-description=<newDescription>
                             New description of the resource.
      --new-name=<newName>   New name of the resource. Only alphanumeric and
                               underscore characters are permitted.
      --num-secondary-workers=<numSecondaryWorkers>
                             The number of secondary worker nodes.
      --num-workers=<numWorkers>
                             The number of worker nodes.
      --workspace=<id>       Workspace id to use for this command only.
```