### PR TITLE
Remove nightly test schedule

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,8 +1,8 @@
 name: Run tests nightly
 on:
   workflow_dispatch: { }
-  schedule:
-  - cron: '0 5 * * *' # 5AM UTC = 12AM EST
+#  schedule:
+#  - cron: '0 5 * * *' # 5AM UTC = 12AM EST
 
 jobs:
   test-source-and-install:


### PR DESCRIPTION
Comment out the nightly test schedule. Verily is no longer maintaining the code in this repository.